### PR TITLE
Add option for setting PhantomJS port

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,7 @@ Create a new instance that can navigate around the web.
 The available options are:
 * `timeout`: how long to wait for page loads, default `5000ms`
 * `interval`: how frequently to poll for page load state, default `50ms`
+* `port`: port to mount the phantomjs instance to, default `12301`
 
 #### .goto(url)
 Load the page at `url`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,8 @@ var PHANTOMJS_INSTANCE = null;
 function Nightmare (options) {
   this.options = defaults(clone(options) || {}, {
     timeout: 5000,
-    interval: 50
+    interval: 50,
+    port: 12301
   });
   this._queue = [];
   this._executing = false;
@@ -307,7 +308,7 @@ Nightmare.prototype.setupInstance = function(cb) {
   }
   else {
     PHANTOMJS_INITING = true;
-    phantom.create(function(instance) {
+    phantom.create({port: self.options.port}, function(instance) {
       PHANTOMJS_INSTANCE = instance;
       cb(instance);
     });


### PR DESCRIPTION
Hey guys!

First off thanks for the awesome PhantomJS wrapper. I really enjoy the approach you took to queuing actions upfront, and the plugin architecture.

---

I ran into a scenario where multiple Nightmare instances would be spun up at the same time, but in separate node processes, and found that the ports were colliding between the two processes.

In order to work around this, I added an option to the constructor for specifying port, so that I could eventually randomize the port when the node processes were being created to minimize collision.

I thought I'd post back the contribution, to get your guys feedback on it. I didn't see any specific tests around constructor options, but I'm happy to add some, if you guys want.

Thanks!
