### PR TITLE
add options for ssl

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,7 @@ var SUPPORTED_ARGS = [
   'proxy',
   'proxyType',
   'proxyAuth',
-  'cookiesFile',
-  'webSecurity'
+  'cookiesFile'
 ];
 
 /**
@@ -49,8 +48,7 @@ var DEFAULTS = {
   proxy: null,
   proxyType: null,
   proxyAuth: null,
-  cookiesFile: null,
-  webSecurity: true
+  cookiesFile: null
 };
 
 /**


### PR DESCRIPTION
Allows to pass phantomjs arguments via new Nightmare() second argument
Example:

``` javascript
var nightmare = new Nightmare({
    'ignoreSslErrors': true,
    'sslProtocol': 'tlsv1'
});
```

The phantomjs will be called with this arguments
