### PR TITLE
add local test server

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "devDependencies": {
     "should": "~2.1.1",
-    "mocha": "~1.17.0"
+    "mocha": "~1.17.0",
+    "body-parser": "^1.9.0",
+    "express": "^4.9.8"
   },
   "main": "lib/index"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,27 @@
 var Nightmare = require('../lib');
 var should = require('should');
+var express = require('express');
+var path = require('path');
 
 describe('Nightmare', function(){
   this.timeout(20000);
+
+  var app, server, serverUrl;
+
+  before(function(done){
+    app = express();
+    var port = process.env.PORT || 4567;
+    app.use(express.static(path.join(__dirname, 'files')));
+    server = app.listen(port, function() {
+      serverUrl = 'http://localhost:' + port + '/';
+      console.log('test server listening on port %s', port);
+      done();
+    });
+  });
+
+  after(function(done){
+    server.close(done);
+  });
 
   it('should be constructable', function(){
     var nightmare = new Nightmare();


### PR DESCRIPTION
Add local test server - use `express` as a `devDependencies`, so tests will be maintainability && run fast.

Signed-off-by: TZ atian25@qq.com
