### PR TITLE
adding docs and support for ssl, proxy and other cli args

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,8 @@ The available options are:
 * `weak`: set dnode weak option to `false` to fix cpp compilation for windows users, default `true`.
 * `loadImages`: load all inlined images, default `true`.
 * `ignoreSslErrors`: ignores SSL errors, such as expired or self-signed certificate errors, default `true`.
-* `sslProtocol`: sets the SSL protocol for secure connections `[sslv3|sslv2|tlsv1|any]`, default `sslv3`.
+* `sslProtocol`: sets the SSL protocol for secure connections `[sslv3|sslv2|tlsv1|any]`, default `any`.
+* `webSecurity`: enables web security and forbids cross-domain XHR, default `true`.
 * `proxy`: specify the proxy server to use `address:port`, default not set.
 * `proxyType`: specify the proxy server type `[http|socks5|none]`, default not set.
 * `proxyAuth`: specify the auth information for the proxy `user:pass`, default not set.

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,8 @@ var PHANTOMJS_INSTANCE = null;
 
 /**
  * Default options.
+ *
+ * http://phantomjs.org/api/command-line.html
  */
 
 var DEFAULTS = {
@@ -30,11 +32,12 @@ var DEFAULTS = {
   weak: true,
   loadImages: true,
   ignoreSslErrors: true,
-  sslProtocol: 'sslv3',
+  sslProtocol: 'any',
   proxy: null,
   proxyType: null,
   proxyAuth: null,
-  cookiesFile: null
+  cookiesFile: null,
+  webSecurity: true
 };
 
 /**
@@ -128,6 +131,7 @@ Nightmare.prototype.createInstance = function(done) {
   flags.push('--load-images='+this.options.loadImages);
   flags.push('--ignore-ssl-errors='+this.options.ignoreSslErrors);
   flags.push('--ssl-protocol='+this.options.sslProtocol);
+  flags.push('--web-security='+this.options.webSecurity);
   if (this.options.proxy !== null) {
     flags.push('--proxy='+this.options.proxy);
   }


### PR DESCRIPTION
@execmd @fbm-static does this take on the same idea solve the use case as #62? i think it will be easier to abstract engines down the road #60, and hides the specifics of phantomjs for people who find nightmare before they ever try to use phantom :)
