### PR TITLE
change path property to binary to match options property in node-phantom

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@ Nightmare.prototype.createInstance = function(done) {
   args.push({
     port: this.options.port,
     dnodeOpts: dnodeOpts,
-    path: this.options.phantomPath
+    binary: this.options.phantomPath
   });
   args.push(function(instance) {
     PHANTOMJS_INSTANCE = instance;


### PR DESCRIPTION
This PR addresses issue https://github.com/segmentio/nightmare/issues/92 and PR https://github.com/segmentio/nightmare/pull/94.

@kevva @reinpk 

I agree that it would be nice to specify the phantom binary path rather than globally installing Phantom via Homebrew or some other method.  @kevva I tested out your solution and believe I found a problem in that the `path` property in the `options` should actually be `binary`, which corresponds to the same property in the node-phantom module.  

Therefore, you would

`var phantomPath = require('phantomjs').path;`

and instantiate nightmare the same way

`new Nightmare({phantomPath: phantomPath})`

@kevva if I use your solution I will continuously get the "phantomjs-node: You don't have 'phantomjs' installed" error message from node-phantom.
