### PR TITLE
Handling Phantom crashes more gracefully

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -195,6 +195,7 @@ Capture page events with the callback. You have to call `.on()` before calling `
 * `prompt` - callback(msg, defaultValue)
 * `error` - callback(msg, trace)
 * `timeout` - callback(msg) fired when a .wait() times out before condition becomes true
+* `exit` - callback(code, signal) fired when the underlying phantom process dies unexpectedly (if not handled, this will become an uncaught exception)
 
 For a more in-depth description, see [the full callbacks list for phantomjs](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#callbacks-list).
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -447,6 +447,11 @@ exports.on = function (type, callback, done) {
     this.onTimeout = callback;
     done();
   }
+  // The onExit callback is special-cased here too
+  else if (type === 'exit') {
+    this.onExit = callback;
+    done();
+  }
   // resourceRequestStarted has a special function...
   else if (type === 'resourceRequestStarted') {
     var args = [].slice.call(arguments);

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,7 +155,8 @@ Nightmare.prototype.createInstance = function(done) {
   args.push({
     port: this.options.port || getPort(),
     dnodeOpts: dnodeOpts,
-    path: this.options.phantomPath
+    path: this.options.phantomPath,
+    onExit: this.handleCrash.bind(this)
   });
   var self = this;
   args.push(function(instance) {
@@ -257,6 +258,31 @@ Nightmare.prototype.afterNextPageLoad = function(callback) {
       callback();
     });
   });
+};
+
+/**
+ * Handles the phantom process ending/crashing unexpectedly.
+ *
+ * If an `onExit` handler has been bound (via `Nightmare#on('exit', ...)`)
+ * then that will be called. Otherwise, the error will be re-thrown.
+ *
+ * @param {Number} code
+ * @param {String} [signal]
+ */
+
+Nightmare.prototype.handleCrash = function (code, signal) {
+  // if a handler is defined, call it
+  if (this.onExit) {
+    this.onExit(code, signal);
+
+  // otherwise, if we have a non-zero code we'll throw a better error message
+  // than the `phantom` lib would.
+  } else if (code !== 0) {
+    var err = new Error('the phantomjs process ended unexpectedly');
+    err.code = code;
+    err.signal = signal;
+    throw err;
+  }
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -502,7 +502,6 @@ describe('Nightmare', function () {
     it('should fire the exit handler once the process exits', function (done) {
       new Nightmare()
         .on('exit', function (code, signal) {
-          code.should.equal(1);
           done();
         })
         .goto('http://example.com')
@@ -535,8 +534,7 @@ describe('Nightmare', function () {
         });
 
       function checkError(err) {
-        err.message.should.equal('the phantomjs process ended unexpectedly')
-        err.code.should.equal(1);
+        err.message.should.equal('the phantomjs process ended unexpectedly');
         done();
       }
     });


### PR DESCRIPTION
We have a service that is running nightmare as part of it's API. If the PhantomJS process dies unexpectedly, the `phantom` lib will throw an **[uncaught exception](https://github.com/sgentle/phantomjs-node/blob/2645246eb987b163b233cc042715bd0a6a4d181f/phantom.coffee#L91-L92)**. As is the case with uncaught exceptions, this crashes the entire server. Thankfully, `phantom` does expose an [`onExit` option/hook](https://github.com/sgentle/phantomjs-node/blob/2645246eb987b163b233cc042715bd0a6a4d181f/phantom.coffee#L88-L89) that allows you to handle such cases.

As far as nightmare is concerned, this adds a new custom event. (ie: `Nightmare#on('exit', ...);`) When this handler is attached, it will be called upon with the given exit `code` and `signal`. (the signal is not always present, but in our case we saw a lot of `SIGSEGV`) If the handler is _not_ bound, then we are still forced to `throw` (so the failure isn't just lost in the abyss) but we format a pretty clear error message. (and provide the `code` and `signal` as properties on the `Error` object for later inspection.

In short, this makes no API changes, only the custom event is added. (since "exit" is not a phantom event, I have adopted it for this purpose)