### PR TITLE
Fix escaping of selectors in .wait(selector)

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,5 +1,6 @@
 var debug = require('debug')('nightmare');
 var fs = require('fs');
+var jsesc = require('jsesc');
 
 /**
  * Use a `plugin` function.
@@ -318,7 +319,7 @@ exports.wait = function(/* args */) {
       // we lose the clojure when it goes to phantom, so we have to
       // force it with string concatenation and eval
       eval("var elementPresent = function() {"+
-      "  var element = document.querySelector('"+selector+"');"+
+      "  var element = document.querySelector('"+jsesc(selector)+"');"+
       "  return (element ? true : false);" +
       "};");
       this.untilOnPage(elementPresent, true, function (present) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "debug": "^0.7.4",
     "defaults": "~1.0.0",
     "once": "1.3.0",
-    "phantom": "^0.7.0"
+    "phantom": "^0.7.0",
+    "jsesc": "^0.5.0"
   },
   "devDependencies": {
     "after": "~0.8.1",

--- a/test/fixtures/navigation/index.html
+++ b/test/fixtures/navigation/index.html
@@ -6,6 +6,6 @@
   <body>
     <a href="a.html">A</a>
     <a href="b.html">B</a>
-    <a href="c.html">C</a>
+    <a href="c.html" id="escaping:test">C</a>
   </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -57,6 +57,13 @@ describe('Nightmare', function () {
         .run(done);
     });
 
+    it('should escape the css selector correctly when waiting for an element', function (done) {
+      new Nightmare()
+        .goto(fixture('navigation'))
+        .wait('#escaping\\:test')
+        .run(done);
+    });
+
     it('should wait until evaluate returns the right value', function (done) {
       new Nightmare()
         .goto(fixture('navigation'))


### PR DESCRIPTION
Fixes this error: 

```
phantom stdout: SyntaxError: DOM Exception 12: An invalid or illegal string was specified.
```

when trying to use escaped selectors (e.g. `.wait("#escaping\\:test")`)