### PR TITLE
Split run into setup -> execQueue -> teardown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,8 @@ function Nightmare (options) {
 }
 
 /**
- * Run all the queued methods.
+ * Setup new PhantomJS instance, execute all queued methods
+ * shutdown PhantomJS and finally execute a callback.
  *
  * @param {Function} callback
  */
@@ -59,27 +60,43 @@ function Nightmare (options) {
 Nightmare.prototype.run = function(callback) {
   var self = this;
   debug('run');
-  this.setup(function () {
-    setTimeout(next, 0);
-    function next(err) {
-      var item = self.queue.shift();
-      if (!item) {
-        self.teardownInstance();
-        return (callback || noop)(err, self);
-      }
-      var method = item[0];
-      var args = item[1];
-      args.push(once(next));
-      method.apply(self, args);
-    }
+  self.setup(function () {
+    self.exec(function(err) {
+      self.teardownInstance();
+      return (callback || noop)(err, self);
+    });
   });
+};
+
+/**
+ * Execute all the queued methods.
+ * PhantomJS instance must be initialized with `setup`
+ * prior to executing methods.
+ *
+ * @param {Function} callback
+ */
+Nightmare.prototype.exec = function(callback) {
+  var self = this;
+  if (!self.page)
+    throw new Error('PhantomJS page must be initialized via `setup`.')
+  setTimeout(next, 0);
+  function next(err) {
+    var item = self.queue.shift();
+    if (!item) {
+      return (callback || noop)(err, self);
+    }
+    var method = item[0];
+    var args = item[1];
+    args.push(once(next));
+    method.apply(self, args);
+  }
+  return this;
 };
 
 /**
  * Set up a fresh phantomjs page.
  *
  * @param {Function} done
- * @api private
  */
 
 Nightmare.prototype.setup = function(done) {
@@ -171,8 +188,6 @@ Nightmare.prototype.createInstance = function(done) {
 
 /**
  * Tear down a phantomjs instance.
- *
- * @api private
  */
 
 Nightmare.prototype.teardownInstance = function() {

--- a/test/index.js
+++ b/test/index.js
@@ -739,6 +739,40 @@ describe('Nightmare', function () {
         });
     });
   });
+
+  describe('instance reuse', function (done) {
+
+    var nightmare = new Nightmare();
+
+    before(function(done) {
+      nightmare
+        .goto(fixture('simple'))
+        .setup(done);
+    });
+
+    after(function() {
+      nightmare.teardownInstance();
+    });
+
+    it('should support instance reuse', function (done) {
+      nightmare.evaluate(function() {
+        localStorage.setItem('hello', 'world');
+        return localStorage.getItem('hello');
+      }, function(world) {
+        world.should.eql('world');
+      }).exec(done);
+    });
+
+    it('should access localStorage from previous test case', function (done) {
+      nightmare.evaluate(function() {
+        return localStorage.getItem('hello');
+      }, function(world) {
+        world.should.eql('world');
+      }).exec(done);
+    });
+
+  });
+
 });
 
 /**


### PR DESCRIPTION
As explained in #175, I extracted the `exec` method which runs the queue on already initialized Nightmare instance. I also took the liberty of removing `@api private` from `setup` and `teardownInstance`, since these methods should now be exposed for this style of working with Nightmare.

I'd also rename `teardownInstance` into `teardown`, but I decided to leave this one up to the core team.

I'd also be happy if someone could reflect this in docs (I'm not so confident about my English).

Thanks again for an awesome tool!