### PR TITLE
Adding Nightmare..drainQueue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ function Nightmare (options) {
 }
 
 /**
- * Run all the queued methods.
+ * Run all the queued methods and when done, terminate the page.
  *
  * @param {Function} callback
  */
@@ -60,19 +60,34 @@ Nightmare.prototype.run = function(callback) {
   var self = this;
   debug('run');
   this.setup(function () {
-    setTimeout(next, 0);
-    function next(err) {
-      var item = self.queue.shift();
-      if (!item) {
-        self.teardownInstance();
-        return (callback || noop)(err, self);
-      }
-      var method = item[0];
-      var args = item[1];
-      args.push(once(next));
-      method.apply(self, args);
-    }
+    self.drainQueue(function (err) {
+      self.teardownInstance();
+      (callback || noop)(err, self);
+    });
   });
+};
+
+/**
+ * Run all the queued methods.
+ *
+ * @param {Function} callback
+ * @api private
+ */
+Nightmare.prototype.drainQueue = function(callback) {
+  var self = this;
+  debug('draining queue');
+  setImmediate(next);
+  function next(err) {
+    var item = self.queue.shift();
+    if (!item) {
+      debug('queue drained');
+      return (callback || noop)(err, self);
+    }
+    var method = item[0];
+    var args = item[1];
+    args.push(once(next));
+    method.apply(self, args);
+  }
 };
 
 /**


### PR DESCRIPTION
It can be used when one doesn't want to kill the page once all queued actions are done.

I've already used it a few times like so:

```js
nightmare
    .stuff()
    .moreStuff()
    .setup(function () {
        nightmare.drainQueue(console.log.bind(console, 'drained'))
    });
```

It also allows queueing up more actions after the run loop, for instance from user input.

Useful enough to merge into main?