### PR TITLE
improves resourceRequestStarted event

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -458,7 +458,7 @@ exports.on = function (type, callback, done) {
     var args = [].slice.call(arguments);
     args = args.slice(1, args.length-1); // callback OR callback with args
     this.page.onResourceRequested.apply(this.page, args);
-    done();
+    arguments[arguments.length-1]();
   }
   // All other events handled natively in phantomjs
   else {

--- a/test/index.js
+++ b/test/index.js
@@ -402,6 +402,22 @@ describe('Nightmare', function () {
         });
     });
 
+    it('should also execute a resourceRequested callback on resourceRequestStarted', function (done) {
+      var fired = false;
+      new Nightmare()
+          .on('resourceRequestStarted',
+          function () {
+
+          }, function() {
+            fired = true;
+          })
+          .goto(fixture('events'))
+          .run(function () {
+            fired.should.be.true;
+            done();
+          });
+    });
+
     it('should fire an event when a resource is received', function (done) {
       var fired = false;
       new Nightmare()


### PR DESCRIPTION
Before this change resourceRequestStarted would clobber any listeners set for resourceRequested. This change allows two callbacks to be passed to resourceRequestStarted. The first callback runs in the scope of phantom and the second runs in the scope of node. Wraps [onResourceRequested of the underlying phantom library](https://github.com/sgentle/phantomjs-node#functionality-details).