### PR TITLE
Fix screenshot() for paths with 2+ periods (#179)

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -359,7 +359,7 @@ exports.wait = function(/* args */) {
 
 exports.screenshot = function (path, done) {
   var formats = ['png', 'gif', 'jpeg', 'jpg', 'pdf'];
-  var ext = path.substring(path.indexOf('.') + 1);
+  var ext = path.match(/[^.]+$/);
   if (!~formats.join(',').indexOf(ext)) {
     done(new Error('Must include file extension in `path`.'));
   }


### PR DESCRIPTION
@t-suwa proposed this fix in #179, just creating a PR for easy merging.

I'm running into this problem on CircleCI. Their artifacts directories have extra periods in them, and this currently breaks any use of `screenshot()` when trying to save to them.