### PR TITLE
remove keypress from .type action

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -222,13 +222,10 @@ exports.mouseover = function(selector, done) {
 
 exports.type = function(selector, text, done) {
   debug('.type() %s into %s', text, selector);
-  var self = this;
-  this.page.evaluate(function(selector, text){
-    document.querySelector(selector).focus();
-  }, function(){
-    self.page.sendEvent('keypress', text, null, null, 0);
-    done();
-  }, selector, text);
+  this.page.evaluate(function(selector, text) {
+    var element = document.querySelector(selector);
+    element.value = text;
+  }, done, selector, text);
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -260,25 +260,6 @@ describe('Nightmare', function () {
         .run(done);
     });
 
-    it('should fire a keypress when typing', function(done) {
-      new Nightmare()
-        .goto(fixture('manipulation'))
-        .evaluate(function () {
-          window.keypressed = false;
-          var element = document.querySelector('input[type=search]');
-          element.onkeypress = function () {
-            window.keypressed = true;
-          };
-        })
-        .type('input[type=search]', 'nightmare')
-        .evaluate(function () {
-          return window.keypressed;
-        }, function (keypressed) {
-          keypressed.should.be.true;
-        })
-        .run(done);
-    });
-
     it('should scroll to specified position', function(done) {
       new Nightmare()
           .viewport(320, 320)


### PR DESCRIPTION
This PR addresses https://github.com/segmentio/nightmare/issues/120 when the `keypress` event was added it broke functionality for certain forms. 

I ran tests locally and the following tests are not passing:
```js
it('should upload a file', function (done) {
  new Nightmare()
    .goto(fixture('upload'))
    .upload('input[type=file]', 'test/files/test.css')
    .click('button[type=submit]')
    .wait(1000)
    .evaluate(function () {
      return JSON.parse(document.body.querySelector('pre').innerHTML)
    }, function (files) {
      files.file.originalname.should.equal('test.css');
    })
    .run(done);
});

// results in err => Uncaught TypeError: Cannot read property 'originalname' of undefined
```

```js
it('should set authentication', function (done) {
  new Nightmare()
    .authentication('my', 'auth')
    .goto(fixture('auth'))
    .evaluate(function () {
      return JSON.parse(document.querySelector('pre').innerHTML);
    }, function (data) {
      data.should.eql({ name: 'my', pass: 'auth' });
    })
    .run(done);
});
//results in err => Error: timeout of 40000ms exceeded
```

but this seems unrelated to the PR and I'm wondering if these tests are somehow "flaky"?. 