### PR TITLE
fix end() if no done passed as argument

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -185,7 +185,7 @@ Nightmare.prototype._inject = function(js, done) {
 
 Nightmare.prototype.end = function(done) {
   this.ending = true;
-  if (!this.running) {
+  if (done && !this.running) {
     return this.run(done)
   }
   return this;


### PR DESCRIPTION
![capture d ecran 2015-09-08 a 00 11 21](https://cloud.githubusercontent.com/assets/1368129/9723274/2f321e58-55be-11e5-9789-3b66693e8323.png)

When I run `make test`, it threw `Cannot read property 'apply' of undefined`.
Now it checks if done is passed as an argument.

Another fix for the if could be:

~~~js
if (done) {
  return this.run(done)
}
~~~

Because as I understand, `done` is only passed if nightmare is not running ?