### PR TITLE
implement screenshots

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -388,9 +388,9 @@ exports.scrollTo = function (y, x, done) {
 
 exports.screenshot = function (path, done) {
   debug('.screenshot()');
-  this.child.once('screenshot', function (err) {
-    if (err) debug(err);
-    done();
+  this.child.once('screenshot', function (img) {
+    var buf = new Buffer(img.data)
+    fs.writeFile(path, buf, done)
   });
   this.child.emit('screenshot', path);
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -114,9 +114,7 @@ app.on('ready', function() {
   parent.on('screenshot', function(path) {
     // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
     win.capturePage(function handleCapture (img) {
-      fs.writeFile(path, img, function (err) {
-        parent.emit('screenshot', arguments);
-      });
+      parent.emit('screenshot', img.toPng())
     });
   });
 


### PR DESCRIPTION
fixed up the `nightmare.screenshot(path)` implementation. Basically passes the image buffer back from the electron process to the node process to write the file.

Here's an example:

```js
var Nightmare = require('./')

Nightmare()
  .goto('https://google.com')
  .screenshot('screenshot.png')
  .end(function(err) {
    if (err) throw err
  })
```