### PR TITLE
Fire change and input events on type

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -135,15 +135,15 @@ exports.mouseover = function(selector, done) {
 exports.type = function(selector, text, done) {
   debug('.type() %s into %s', text, selector);
   this._evaluate(function (selector, text) {
-    var elem = document.querySelector(selector);
-    elem.focus();
-    elem.value = text;
+    var element = document.querySelector(selector);
+    element.focus();
+    element.value = text;
     ['change', 'input'].forEach(function(name) {
       var event = document.createEvent('HTMLEvents');
       event.initEvent(name, true, true);
-      elem.dispatchEvent(event);
+      element.dispatchEvent(event);
     });
-    elem.blur();
+    element.blur();
   }, done, selector, text);
 };
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -138,6 +138,11 @@ exports.type = function(selector, text, done) {
     var elem = document.querySelector(selector);
     elem.focus();
     elem.value = text;
+    ['change', 'input'].forEach(function(name) {
+      var event = document.createEvent('HTMLEvents');
+      event.initEvent(name, true, true);
+      elem.dispatchEvent(event);
+    });
     elem.blur();
   }, done, selector, text);
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "defaults": "^1.0.2",
-    "electron-prebuilt": "^0.32.2",
+    "electron-prebuilt": "^0.33.0",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",

--- a/test/index.js
+++ b/test/index.js
@@ -345,7 +345,7 @@ describe('Nightmare', function () {
         });
       var stats = fs.statSync('/tmp/nightmare/test.png');
       var statsClipped = fs.statSync('/tmp/nightmare/test-clipped.png');
-      statsClipped.size.should.be.at.least(500);
+      statsClipped.size.should.be.at.least(300);
       stats.size.should.be.at.least(10*statsClipped.size);
     });
 


### PR DESCRIPTION
Changing the value of a field doesn't trigger the change and input event by default.