### PR TITLE
Fix electron errors casued by process not connected

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -29,7 +29,9 @@ function IPC(process) {
   });
 
   emitter.emit = function() {
-    process.send(sliced(arguments));
+    if(process.connected){
+      process.send(sliced(arguments));
+    }
   }
 
   return emitter;


### PR DESCRIPTION
A non connected node process in the IPC emitter would cause electron to
break.