### PR TITLE
Remove unused variables

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -5,7 +5,6 @@
 var debug = require('debug')('nightmare:actions');
 var sliced = require('sliced');
 var jsesc = require('jsesc');
-var once = require('once');
 var fs = require('fs');
 
 /**

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -10,15 +10,12 @@ var debug = require('debug')('nightmare');
  */
 
 var electron_path = require('electron-prebuilt');
-var source = require('function-source');
 var proc = require('child_process');
 var actions = require('./actions');
-var enqueue = require('enqueue');
 var join = require('path').join;
 var sliced = require('sliced');
 var child = require('./ipc');
 var once = require('once');
-var noop = function() {};
 
 /**
  * Export `Nightmare`

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "debug": "^2.2.0",
     "defaults": "^1.0.2",
     "electron-prebuilt": "^0.33.0",
-    "enqueue": "^1.0.2",
-    "function-source": "^0.1.0",
     "jsesc": "^0.5.0",
     "minstache": "^1.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
`source` and `enqueue` and `noop` are not used in lib/nightmare.js.
`once` is not used in lib/actions.js.