### PR TITLE
Allow for user-specified web-preferences options.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -24,19 +24,22 @@ var join = require('path').join;
 app.on('ready', function() {
 
   var win;
-  
+
   /**
    * create a browser window
    */
-  
+
   parent.on('browser-initialize', function(options) {
+    var webPreferences = defaults(options['web-preferences'] || {}, {
+      'preload': join(__dirname, 'preload.js'),
+      'node-integration': false
+    });
+
     options = defaults(options, {
-      'web-preferences': {
-        'preload': join(__dirname, 'preload.js'),
-        'node-integration': false
-      },
+      'web-preferences': webPreferences,
       show: false
     });
+
     win = new BrowserWindow(options);
 
     /**
@@ -75,7 +78,7 @@ app.on('ready', function() {
   /**
    * Parent actions
    */
-  
+
   /**
    * goto
    */
@@ -201,4 +204,3 @@ function forward(event) {
     parent.emit.apply(parent, [event].concat(sliced(arguments)));
   };
 }
-

--- a/test/fixtures/options/index.html
+++ b/test/fixtures/options/index.html
@@ -5,5 +5,6 @@
   </head>
   <body>
     <h1>Hello World!</h1>
+    <iframe id='example-iframe' src='http://example.com'></iframe>
   </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -482,6 +481,17 @@ describe('Nightmare', function () {
       headers['x-nightmare-header'].should.equal('hello world');
     });
     */
+
+    it('should allow web-preferece settings', function*() {
+      nightmare = Nightmare({'web-preferences': {'web-security': false}});
+      var result = yield nightmare
+        .goto(fixture('options'))
+        .evaluate(function () {
+          return document.getElementById('example-iframe').contentDocument;
+        });
+
+      result.should.be.ok;
+    });
   });
 });
 


### PR DESCRIPTION
In trying to turn off cross origin policy using  `web-preferences: {web-security: false}` as specified in [Electrons options](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions), I realized it hoses nightmare's use of the `web-preferences` setting. 

This PR fixes it.   Tests included.   It also provides a v2-compatible solution for https://github.com/segmentio/nightmare/issues/203. 