### PR TITLE
Added license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nightmare",
   "version": "2.0.7",
+  "license": "MIT",
   "main": "lib/nightmare.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added a license field to package.json to get rid of this error.

    >:nightmare$ npm install
    npm WARN package.json nightmare@2.0.7 No license field.
