### PR TITLE
Initialize mocha-generators so tests run

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,8 @@
  * Module dependencies.
  */
 
+require('mocha-generators').install();
+
 var Nightmare = require('..');
 var should = require('chai').should();
 var url = require('url');


### PR DESCRIPTION
Hey Nightmare Team - it looks like mocha test suite isn't automatically initializing `mocha-generators` so the tests only appear to run and succeed, instead of running.

**Branch**: Master
**Commit**: 748a2b2b14163d34e89108250e34553d991e7913

### Use-Case
Modify any test to have a `console.log` - never logs to console.

### Solution
Setup needs `require('mocha-generators').install()`
