### PR TITLE
'js-error' event added

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -133,7 +133,7 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events).
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events) and `'js-error'`.
 
 #### .screenshot(path[, clip])
 Saves a screenshot of the current page to the specified `path`. Useful for debugging. The output is always a `png`. You can optionally provide a clip rect as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback).

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -74,8 +74,8 @@ function Nightmare(options) {
   });
 
   // propagate console.log(...) through
-  this.child.on('log', function() {
-    log.apply(log, arguments);
+  this.child.on('js-error', function(errorMsg, error) {
+    log('js-error', errorMsg);
   });
 
   // proporate events through to debugging

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -74,6 +74,10 @@ function Nightmare(options) {
   });
 
   // propagate console.log(...) through
+  this.child.on('log', function() {
+    log.apply(log, arguments);
+  });
+
   this.child.on('js-error', function(errorMsg, error) {
     log('js-error', errorMsg);
   });

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -2,6 +2,6 @@ window.__nightmare = {};
 __nightmare.ipc = require('ipc');
 __nightmare.sliced = require('sliced');
 
-window.onerror = function (errorMsg, url, lineNumber, columnNumber, error) {
-  __nightmare.ipc.send('js-error', 'Error: ' + errorMsg + ' Script: ' + url + ' Line: ' + lineNumber+':'+columnNumber, error);
-};
+window.addEventListener('error', function(errorMsg, url, lineNumber, columnNumber, error) {
+  __nightmare.ipc.send('js-error', ('Error: ' + errorMsg + ' Script: ' + url + ' Line: ' + lineNumber+':'+ columnNumber), error);
+});

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,3 +1,7 @@
 window.__nightmare = {};
 __nightmare.ipc = require('ipc');
 __nightmare.sliced = require('sliced');
+
+window.onerror = function (errorMsg, url, lineNumber, columnNumber, error) {
+  __nightmare.ipc.send('js-error', 'Error: ' + errorMsg + ' Script: ' + url + ' Line: ' + lineNumber+':'+columnNumber, error);
+};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -56,6 +56,9 @@ app.on('ready', function() {
     /**
      * Pass along web content events
      */
+    renderer.on('js-error', function(event, errorMsg, error) {
+      parent.emit('js-error', errorMsg, error);
+    });
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));
     win.webContents.on('did-fail-load', forward('did-fail-load'));

--- a/test/fixtures/events/index.html
+++ b/test/fixtures/events/index.html
@@ -6,4 +6,7 @@
   <body>
     <h1>Hello World!</h1>
   </body>
+  <script>
+    thisIsAnError(foobar);
+  </script>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -419,6 +419,17 @@ describe('Nightmare', function () {
       fired.should.be.true;
     });
 
+    it('should fire an event on javascript error', function*() {
+      var fired = false;
+      nightmare
+        .on('error', function (errorMessage) {
+          fired = true;
+        });
+      yield nightmare
+        .goto(fixture('events'));
+      fired.should.be.true;
+    });
+
     it('should fire an event on page load failure', function*() {
       var fired = false;
       nightmare

--- a/test/index.js
+++ b/test/index.js
@@ -422,7 +422,7 @@ describe('Nightmare', function () {
     it('should fire an event on javascript error', function*() {
       var fired = false;
       nightmare
-        .on('error', function (errorMessage) {
+        .on('js-error', function (a, b) {
           fired = true;
         });
       yield nightmare


### PR DESCRIPTION
Now it's possible to trace js exceptions. It solves this https://github.com/segmentio/nightmare/issues/248 issue and makes Nightmare viable for TTD again.