### PR TITLE
Allow the user to disable Chromium's HTTP cache

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -67,6 +67,7 @@ function Nightmare(options) {
 
   this.child = child(this.proc);
   this.child.once('ready', function() {
+    self.child.emit('browser-configure', options);
     self.child.once('browser-initialize', function() {
       self.state = 'ready';
     });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -17,6 +17,15 @@ var join = require('path').join;
 
 // app.dock.hide();
 
+parent.on('browser-configure', function(options) {
+  options = defaults(options, {
+    'disable-http-cache': false
+  });
+  if (options['disable-http-cache']) {
+    app.commandLine.appendSwitch('disable-http-cache');
+  }
+});
+
 /**
  * Listen for the app being "ready"
  */


### PR DESCRIPTION
This introduces a new `browser-configure` event that happens before `browser-initialize`, which allows the user to configure the Chromium instance itself. Might be useful to provide other flags, but I only needed `disable-http-cache`. (Apologies for the lack of tests.)