### PR TITLE
Excetions and console.logs now have event callbacks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -133,7 +133,7 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events).
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events) and `'js-error'`.
 
 #### .screenshot(path[, clip])
 Saves a screenshot of the current page to the specified `path`. Useful for debugging. The output is always a `png`. You can optionally provide a clip rect as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback).

--- a/Readme.md
+++ b/Readme.md
@@ -133,12 +133,12 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events). Additional to the electron-events we provide nightmare-events `'js-error'` and `'js-log'`.
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events). Additional to the electron-events we provide nightmare-events `'page-error'` and `'page-log'`.
 
-##### .on('js-error', errorMessage, errorStack)
+##### .on('page-error', errorMessage, errorStack)
 This event is triggered if any javscript exception is thrown on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is throwing an exception.
 
-##### .on('js-log', errorMessage, errorStack)
+##### .on('page-log', errorMessage, errorStack)
 This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
 
 #### .screenshot(path[, clip])

--- a/Readme.md
+++ b/Readme.md
@@ -133,7 +133,13 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events) and `'js-error'`.
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events). Additional to the electron-events we provide nightmare-events `'js-error'` and `'js-log'`.
+
+##### .on('js-error', errorMessage, errorStack)
+This event is triggered if any javscript exception is thrown on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is throwing an exception.
+
+##### .on('js-log', errorMessage, errorStack)
+This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
 
 #### .screenshot(path[, clip])
 Saves a screenshot of the current page to the specified `path`. Useful for debugging. The output is always a `png`. You can optionally provide a clip rect as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback).

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -78,8 +78,8 @@ function Nightmare(options) {
     log.apply(log, arguments);
   });
 
-  this.child.on('js-error', function(errorMsg, error) {
-    log('js-error', errorMsg);
+  this.child.on('js-error', function(errorMessage, errorStack) {
+    log('js-error', errorMessage, errorStack);
   });
 
   // proporate events through to debugging

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -78,8 +78,8 @@ function Nightmare(options) {
     log.apply(log, arguments);
   });
 
-  this.child.on('js-error', function(errorMessage, errorStack) {
-    log('js-error', errorMessage, errorStack);
+  this.child.on('page-error', function(errorMessage, errorStack) {
+    log('page-error', errorMessage, errorStack);
   });
 
   // proporate events through to debugging

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -74,8 +74,8 @@ function Nightmare(options) {
   });
 
   // propagate console.log(...) through
-  this.child.on('log', function() {
-    log.apply(log, arguments);
+  this.child.on('js-error', function(errorMsg, error) {
+    log('js-error', errorMsg);
   });
 
   // proporate events through to debugging

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -74,6 +74,10 @@ function Nightmare(options) {
   });
 
   // propagate console.log(...) through
+  this.child.on('log', function() {
+    log.apply(log, arguments);
+  });
+
   this.child.on('js-error', function(errorMsg, error) {
     log('js-error', errorMsg);
   });

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -2,6 +2,6 @@ window.__nightmare = {};
 __nightmare.ipc = require('ipc');
 __nightmare.sliced = require('sliced');
 
-window.onerror = function (errorMsg, url, lineNumber, columnNumber, error) {
-  __nightmare.ipc.send('js-error', 'Error: ' + errorMsg + ' Script: ' + url + ' Line: ' + lineNumber+':'+columnNumber, error);
-};
+window.addEventListener('error', function(errorMsg, url, lineNumber, columnNumber, error) {
+  __nightmare.ipc.send('js-error', ('Error: ' + errorMsg + ' Script: ' + url + ' Line: ' + lineNumber+':'+ columnNumber), error);
+});

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -3,11 +3,13 @@ __nightmare.ipc = require('ipc');
 __nightmare.sliced = require('sliced');
 
 window.addEventListener('error', function(e) {
-  __nightmare.ipc.send('js-error', e.message, e.error.stack);
+  __nightmare.ipc.send('page-error', e.message, e.error.stack);
 });
 
-defautlLog = console.log;
-console.log = function() {
-  __nightmare.ipc.send('js-log', arguments);
-  return defautlLog.apply(this, arguments);
-};
+(function(){
+  var defaultLog = console.log;
+  console.log = function() {
+    __nightmare.ipc.send('page-log', arguments);
+    return defaultLog.apply(this, arguments);
+  };
+})()

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -2,6 +2,12 @@ window.__nightmare = {};
 __nightmare.ipc = require('ipc');
 __nightmare.sliced = require('sliced');
 
-window.addEventListener('error', function(errorMsg, url, lineNumber, columnNumber, error) {
-  __nightmare.ipc.send('js-error', ('Error: ' + errorMsg + ' Script: ' + url + ' Line: ' + lineNumber+':'+ columnNumber), error);
+window.addEventListener('error', function(e) {
+  __nightmare.ipc.send('js-error', e.message, e.error.stack);
 });
+
+defautlLog = console.log;
+console.log = function() {
+  __nightmare.ipc.send('js-log', arguments);
+  return defautlLog.apply(this, arguments);
+};

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,3 +1,7 @@
 window.__nightmare = {};
 __nightmare.ipc = require('ipc');
 __nightmare.sliced = require('sliced');
+
+window.onerror = function (errorMsg, url, lineNumber, columnNumber, error) {
+  __nightmare.ipc.send('js-error', 'Error: ' + errorMsg + ' Script: ' + url + ' Line: ' + lineNumber+':'+columnNumber, error);
+};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -56,8 +56,11 @@ app.on('ready', function() {
     /**
      * Pass along web content events
      */
-    renderer.on('js-error', function(event, errorMsg, error) {
-      parent.emit('js-error', errorMsg, error);
+    renderer.on('js-error', function(event, errorMessage, errorStack) {
+      parent.emit('js-error', errorMessage, errorStack);
+    });
+    renderer.on('js-log', function(event, args) {
+      parent.emit('js-log', args);
     });
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -56,11 +56,11 @@ app.on('ready', function() {
     /**
      * Pass along web content events
      */
-    renderer.on('js-error', function(event, errorMessage, errorStack) {
-      parent.emit('js-error', errorMessage, errorStack);
+    renderer.on('page-error', function(event, errorMessage, errorStack) {
+      parent.emit('page-error', errorMessage, errorStack);
     });
-    renderer.on('js-log', function(event, args) {
-      parent.emit('js-log', args);
+    renderer.on('page-log', function(event, args) {
+      parent.emit('page-log', args);
     });
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -56,6 +56,9 @@ app.on('ready', function() {
     /**
      * Pass along web content events
      */
+    renderer.on('js-error', function(event, errorMsg, error) {
+      parent.emit('js-error', errorMsg, error);
+    });
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));
     win.webContents.on('did-fail-load', forward('did-fail-load'));

--- a/test/fixtures/events/index.html
+++ b/test/fixtures/events/index.html
@@ -7,6 +7,7 @@
     <h1>Hello World!</h1>
   </body>
   <script>
+    console.log('my log');
     thisIsAnError(foobar);
   </script>
 </html>

--- a/test/fixtures/events/index.html
+++ b/test/fixtures/events/index.html
@@ -6,4 +6,7 @@
   <body>
     <h1>Hello World!</h1>
   </body>
+  <script>
+    thisIsAnError(foobar);
+  </script>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -430,7 +430,7 @@ describe('Nightmare', function () {
       fired.should.be.true;
     });
 
-    it('should fire an event on javascript console.log', function*(done) {
+    it('should fire an event on javascript console.log', function*() {
       var log = '';
       nightmare
         .on('js-log', function (logs) {

--- a/test/index.js
+++ b/test/index.js
@@ -419,6 +419,17 @@ describe('Nightmare', function () {
       fired.should.be.true;
     });
 
+    it('should fire an event on javascript error', function*() {
+      var fired = false;
+      nightmare
+        .on('error', function (errorMessage) {
+          fired = true;
+        });
+      yield nightmare
+        .goto(fixture('events'));
+      fired.should.be.true;
+    });
+
     it('should fire an event on page load failure', function*() {
       var fired = false;
       nightmare

--- a/test/index.js
+++ b/test/index.js
@@ -422,7 +422,7 @@ describe('Nightmare', function () {
     it('should fire an event on javascript error', function*() {
       var fired = false;
       nightmare
-        .on('js-error', function (errorMessage, errorStack) {
+        .on('page-error', function (errorMessage, errorStack) {
           fired = true;
         });
       yield nightmare
@@ -433,7 +433,7 @@ describe('Nightmare', function () {
     it('should fire an event on javascript console.log', function*() {
       var log = '';
       nightmare
-        .on('js-log', function (logs) {
+        .on('page-log', function (logs) {
           log = logs[0];
         });
       yield nightmare

--- a/test/index.js
+++ b/test/index.js
@@ -422,7 +422,7 @@ describe('Nightmare', function () {
     it('should fire an event on javascript error', function*() {
       var fired = false;
       nightmare
-        .on('error', function (errorMessage) {
+        .on('js-error', function (a, b) {
           fired = true;
         });
       yield nightmare

--- a/test/index.js
+++ b/test/index.js
@@ -422,12 +422,23 @@ describe('Nightmare', function () {
     it('should fire an event on javascript error', function*() {
       var fired = false;
       nightmare
-        .on('js-error', function (a, b) {
+        .on('js-error', function (errorMessage, errorStack) {
           fired = true;
         });
       yield nightmare
         .goto(fixture('events'));
       fired.should.be.true;
+    });
+
+    it('should fire an event on javascript console.log', function*(done) {
+      var log = '';
+      nightmare
+        .on('js-log', function (logs) {
+          log = logs[0];
+        });
+      yield nightmare
+        .goto(fixture('events'))
+      log.should.equal('my log');
     });
 
     it('should fire an event on page load failure', function*() {


### PR DESCRIPTION
There are two ways of getting an exception in Nightmare, one is to inject some "bad" code via .evaluate(), this will stop nightmare and even call done() in mocha. But there is also the issue with already existing code, that has errors, now there is an option to listen for this.
Same with console log, before only console logs from evaluate() where shown.