### PR TITLE
Fix menu sub-section URL in documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Many thanks to [@matthewmueller](https://github.com/matthewmueller) for his help
 
 * [Examples](#examples)
 * [API](#api)
-  - [Set up an instance](#new-nightmareoptions)
+  - [Set up an instance](#nightmareoptions)
   - [Interact with the page](#interact-with-the-page)
   - [Extract from the page](#extract-from-the-page)
 * [Usage](#usage)


### PR DESCRIPTION
In the README documentation menu, the URL for **Set up a new instance** was [wrong](https://github.com/segmentio/nightmare#new-nightmareoptions).
This pull request changes it to a [correct](https://github.com/segmentio/nightmare#nightmareoptions) one.

It started from the commit https://github.com/segmentio/nightmare/commit/562e7e42d98d8e844883ae7f7c79e8722ca287e6,  when it removed the **new** keyword but missed the respective URL hash.

I hope I didn't mess anything.