### PR TITLE
console.warn and console.error events

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,13 +154,18 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents). Additional to the electron-events we provide nightmare-events `'page-error'` and `'page-log'`.
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents). Additional to the electron-events we provide nightmare-events:
 
 ##### .on('page-error', errorMessage, errorStack)
 This event is triggered if any javscript exception is thrown on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is throwing an exception.
 
-##### .on('page-log', errorMessage, errorStack)
-This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
+##### .on('page-console-log', errorMessage, errorStack)
+##### .on('page-console-warn', errorMessage, errorStack)
+##### .on('page-console-error', errorMessage, errorStack)
+These events are triggered if `console.log`, `console.warn` or `console.error` functions are used on the page. But these events are not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.*`.
+
+##### .on('page-log', errorMessage, errorStack) *deprecated*
+This is an alias for `page-console-log`.
 
 #### .screenshot(path[, clip])
 Saves a screenshot of the current page to the specified `path`. Useful for debugging. The output is always a `png`. You can optionally provide a clip rect as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback).

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -10,7 +10,6 @@ window.addEventListener('error', function(e) {
 
   var defaultLog = console.log;
   console.log = function() {
-    __nightmare.ipc.send('page-log', arguments);
     __nightmare.ipc.send('page-console-log', arguments);
     return defaultLog.apply(this, arguments);
   };

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -7,9 +7,23 @@ window.addEventListener('error', function(e) {
 });
 
 (function(){
+
   var defaultLog = console.log;
   console.log = function() {
     __nightmare.ipc.send('page-log', arguments);
+    __nightmare.ipc.send('page-console-log', arguments);
     return defaultLog.apply(this, arguments);
+  };
+
+  var defaultWarn = console.warn;
+  console.warn = function() {
+    __nightmare.ipc.send('page-console-warn', arguments);
+    return defaultWarn.apply(this, arguments);
+  };
+
+  var defaultError = console.error;
+  console.error = function() {
+    __nightmare.ipc.send('page-console-error', arguments);
+    return defaultError.apply(this, arguments);
   };
 })()

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -59,8 +59,15 @@ app.on('ready', function() {
     renderer.on('page-error', function(event, errorMessage, errorStack) {
       parent.emit('page-error', errorMessage, errorStack);
     });
-    renderer.on('page-log', function(event, args) {
+    renderer.on('page-console-log', function(event, args) {
       parent.emit('page-log', args);
+      parent.emit('page-console-log', args);
+    });
+    renderer.on('page-console-warn', function(event, args) {
+      parent.emit('page-console-warn', args);
+    });
+    renderer.on('page-console-error', function(event, args) {
+      parent.emit('page-error', args);
     });
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -67,7 +67,7 @@ app.on('ready', function() {
       parent.emit('page-console-warn', args);
     });
     renderer.on('page-console-error', function(event, args) {
-      parent.emit('page-error', args);
+      parent.emit('page-console-error', args);
     });
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));


### PR DESCRIPTION
I've named the events `page-console-error` and `page-console-warn` because otherwise the error event has a naming conflict with the existing event.

I've suggested deprecating page-log and making it page-console-log to bring it inline with the other new events. Any thoughts?