### PR TITLE
Allow overriding Electron app paths

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,17 @@ package for Mocha, which enables the support for generators.
 ## API
 
 #### Nightmare(options)
-Create a new instance that can navigate around the web. The available options are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions).
+Create a new instance that can navigate around the web. The available options are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions), along with additional nightmare-specific options:
+
+##### paths
+Object (name -> path) of [Electron app paths](https://github.com/atom/electron/blob/master/docs/api/app.md#appsetpathname-path) to override.
+
+E.g.
+```
+{
+  userData: 'foo/bar'
+}
+```
 
 #### .useragent(useragent)
 Set the `useragent` used by electron.

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -49,7 +49,14 @@ function Nightmare(options) {
   options = options || {};
   var self = this;
 
-  this.proc = proc.spawn(electron_path, [runner], {
+  var electronArgs = [runner];
+
+  if(options.paths) {
+
+  	electronArgs.push( JSON.stringify(options.paths) );
+  }
+
+  this.proc = proc.spawn(electron_path, electronArgs, {
     stdio: [null, null, null, 'ipc']
   });
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -53,7 +53,7 @@ function Nightmare(options) {
 
   if(options.paths) {
 
-  	electronArgs.push( JSON.stringify(options.paths) );
+  	electronArgs.push(JSON.stringify(options.paths));
   }
 
   this.proc = proc.spawn(electron_path, electronArgs, {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -11,6 +11,17 @@ var fs = require('fs');
 var defaults = require('defaults');
 var join = require('path').join;
 
+
+if( process.argv.length > 2 ) {
+
+  var paths = JSON.parse(process.argv[2]);
+
+  for(var i in paths) {
+
+    app.setPath( i, paths[i] );
+  }
+}
+
 /**
  * Hide the dock
  */

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,13 +12,13 @@ var defaults = require('defaults');
 var join = require('path').join;
 
 
-if( process.argv.length > 2 ) {
+if (process.argv.length > 2) {
 
   var paths = JSON.parse(process.argv[2]);
 
-  for(var i in paths) {
+  for (var i in paths) {
 
-    app.setPath( i, paths[i] );
+    app.setPath(i, paths[i]);
   }
 }
 


### PR DESCRIPTION
This is useful for example to change the userData directory so you don't reuse cookies and such from other instances.