### PR TITLE
swapping defaults for defaults-deep

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,7 +8,7 @@ var sliced = require('sliced');
 var renderer = require('ipc');
 var app = require('app');
 var fs = require('fs');
-var defaults = require('defaults');
+var defaults = require('defaults-deep');
 var join = require('path').join;
 
 /**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "description": "A high-level browser automation library.",
   "dependencies": {
     "debug": "^2.2.0",
-    "defaults": "^1.0.2",
+    "defaults-deep": "^0.2.3",
     "electron-prebuilt": "^0.33.0",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",


### PR DESCRIPTION
This allows all of the `web-preferences` to merge deeply without overwriting the defaults for `preload` and `node-integration`.  Should fix #345.