### PR TITLE
Return a buffered screenshot if no path is provided

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -162,8 +162,8 @@ This event is triggered if any javscript exception is thrown on the page. But th
 ##### .on('page-log', errorMessage, errorStack)
 This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
 
-#### .screenshot(path[, clip])
-Saves a screenshot of the current page to the specified `path`. Useful for debugging. The output is always a `png`. You can optionally provide a clip rect as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback).
+#### .screenshot([path, clip])
+Takes a screenshot of the current page. If a path is provided, it saves it to the specified `path`. Otherwise it returns a `Buffer` of the image data. Useful for debugging. The output is always a `png`. You can optionally provide a clip rect as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback).
 
 #### .pdf(path, options)
 Saves a PDF with A4 size pages of the current page to the specified `path`. Options are [here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#webcontents-printtopdf-options-callback).

--- a/Readme.md
+++ b/Readme.md
@@ -162,8 +162,8 @@ This event is triggered if any javscript exception is thrown on the page. But th
 ##### .on('page-log', errorMessage, errorStack)
 This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
 
-#### .screenshot([path, clip])
-Takes a screenshot of the current page. If a path is provided, it saves it to the specified `path`. Otherwise it returns a `Buffer` of the image data. Useful for debugging. The output is always a `png`. You can optionally provide a clip rect as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback).
+#### .screenshot([path][, clip])
+Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
 #### .pdf(path, options)
 Saves a PDF with A4 size pages of the current page to the specified `path`. Options are [here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#webcontents-printtopdf-options-callback).

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -371,6 +371,7 @@ exports.scrollTo = function (y, x, done) {
  * @param {Object} clip
  * @param {Function} done
  */
+
 exports.screenshot = function (path, clip, done) {
   debug('.screenshot()');
   if (typeof path === 'function') {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -371,18 +371,22 @@ exports.scrollTo = function (y, x, done) {
  * @param {Object} clip
  * @param {Function} done
  */
-
+``
 exports.screenshot = function (path, clip, done) {
   debug('.screenshot()');
-  // clip is optional
-  if (!done) {
-    done = clip;
+  if (typeof path === 'function') {
+    done = path;
     clip = undefined;
+    path = undefined;
+  } else if (typeof clip === 'function') {
+    done = clip;
+    clip = (typeof path === 'string') ? undefined : path;
+    path = (typeof path === 'string') ? path : undefined;
   }
   this.child.once('screenshot', function (img) {
     var buf = new Buffer(img.data);
     debug('.screenshot() captured with length %s', buf.length);
-    fs.writeFile(path, buf, done);
+    path ? fs.writeFile(path, buf, done) : done(null, buf);
   });
   this.child.emit('screenshot', path, clip);
 };

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -371,7 +371,6 @@ exports.scrollTo = function (y, x, done) {
  * @param {Object} clip
  * @param {Function} done
  */
-``
 exports.screenshot = function (path, clip, done) {
   debug('.screenshot()');
   if (typeof path === 'function') {

--- a/test/index.js
+++ b/test/index.js
@@ -365,7 +365,7 @@ describe('Nightmare', function () {
       stats.size.should.be.at.least(10*statsClipped.size);
     });
 
-    it.only('should buffer a clipped screenshot', function*() {
+    it('should buffer a clipped screenshot', function*() {
       var image = yield nightmare
         .goto('https://github.com')
         .screenshot({

--- a/test/index.js
+++ b/test/index.js
@@ -341,6 +341,14 @@ describe('Nightmare', function () {
       stats.size.should.be.at.least(1000);
     });
 
+    it('should buffer a screenshot', function*() {
+      var image = yield nightmare
+        .goto('https://github.com')
+        .screenshot();
+      Buffer.isBuffer(image).should.be.true;
+      image.length.should.be.at.least(1000);
+    });
+
     it('should take a clipped screenshot', function*() {
       yield mkdirp('/tmp/nightmare');
       yield nightmare
@@ -355,6 +363,19 @@ describe('Nightmare', function () {
       var statsClipped = fs.statSync('/tmp/nightmare/test-clipped.png');
       statsClipped.size.should.be.at.least(300);
       stats.size.should.be.at.least(10*statsClipped.size);
+    });
+
+    it.only('should buffer a clipped screenshot', function*() {
+      var image = yield nightmare
+        .goto('https://github.com')
+        .screenshot({
+          x: 200,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      Buffer.isBuffer(image).should.be.true;
+      image.length.should.be.at.least(300);
     });
 
     it('should load jquery correctly', function*() {


### PR DESCRIPTION
I've got a use case for the screenshot function that doesn't require it to be written to disk. Electron itself returns the image in memory, so I thought it'd be useful if writing it to the disk were optional. This pull request maintains backwards compatibility and adds the necessary tests. These tests actually pass (https://github.com/segmentio/nightmare/pull/290), but I didn't include the line from that PR to avoid a conflict.