### PR TITLE
Add cookies getter function

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -350,6 +350,19 @@ exports.useragent = function(useragent, done) {
 };
 
 /**
+ * Get session cookies.
+ *
+ * @param {Function} done
+ */
+exports.cookies = function(done) {
+  debug('.cookies() getting it');
+  this.child.once('cookies', function (err, cookies) {
+    done(err, cookies);
+  });
+  this.child.emit('cookies');
+};
+
+/**
  * Set the scroll position.
  *
  * @param {Number} x

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -142,6 +142,16 @@ app.on('ready', function() {
   });
 
   /**
+   * cookies
+   */
+
+  parent.on('cookies', function() {
+    win.webContents.session.cookies.get({}, function(err, cookies) {
+      parent.emit('cookies', err, cookies);
+    });
+  });
+
+  /**
    * screenshot
    */
 


### PR DESCRIPTION
This is useful for retrieving HttpOnly cookies which are not available from `document.cookie`.