### PR TITLE
Allow passing arguments to wait(fn), just like evaluate()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -147,7 +147,7 @@ Scrolls the page to desired position. `top` and `left` are always relative to th
 #### .inject(type, file)
 Inject a local `file` onto the current page. The file `type` must be either `js` or `css`.
 
-#### .evaluate(fn, arg1, arg2,...)
+#### .evaluate(fn[, arg1, arg2,...])
 Invokes `fn` on the page with `arg1, arg2,...`. All the `args` are optional. On completion it returns the return value of `fn`. Useful for extracting information from the page. Here's an example:
 
 ```js
@@ -165,8 +165,8 @@ Wait for `ms` milliseconds e.g. `.wait(5000)`
 #### .wait(selector)
 Wait until the element `selector` is present e.g. `.wait('#pay-button')`
 
-#### .wait(fn)
-Wait until the `fn` evaluated on the page returns `true`.
+#### .wait(fn[, arg1, arg2,...])
+Wait until the `fn` evaluated on the page with `arg1, arg2,...` returns `true`. All the `args` are optional. See `.evaluate()` for usage.
 
 
 ### Extract from the Page

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -236,7 +236,8 @@ exports.wait = function () {
   }
   else if (typeof arg === 'function') {
     debug('.wait() for fn');
-    waitfn(this, arg, done);
+    args.unshift(this);
+    waitfn.apply(this, args);
   }
   else {
     done();
@@ -275,20 +276,25 @@ function waitelem (self, selector, done) {
  *
  * @param {Nightmare} self
  * @param {Function} fn
+ * @param {...} args
  * @param {Function} done
  */
 
-function waitfn (self, fn, done) {
-  self._evaluate(fn, function (err, result) {
+function waitfn (self, fn/**, arg1, arg2..., done**/) {
+  var args = sliced(arguments);
+  var done = args[args.length-1];
+  var waitDone = function (err, result) {
     if (result) {
       return done();
     }
     else {
       setTimeout(function () {
-        waitfn(self, fn, done);
+        waitfn.apply(self, args);
       }, 250);
     }
-  });
+  };
+  var newArgs = [fn, waitDone].concat(args.slice(2,-1));
+  self._evaluate.apply(self, newArgs);
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -117,6 +117,16 @@ describe('Nightmare', function () {
           return (text === 'A');
         });
     });
+
+    it('should wait until the evaluate fn with arguments returns true', function*() {
+      yield nightmare
+        .goto(fixture('navigation'))
+        .wait(function (expectedA, expectedB) {
+          var textA = document.querySelector('a.a').textContent;
+          var textB = document.querySelector('a.b').textContent;
+          return (expectedA === textA && expectedB === textB);
+        }, 'A', 'B');
+    });
   });
 
   describe('evaluation', function () {


### PR DESCRIPTION
This fulfills #356.