### PR TITLE
add nightmare.cookies.get(...) and nightmare.cookies.set(...) support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -174,6 +174,58 @@ Returns the title of the current page.
 #### .url()
 Returns the url of the current page.
 
+### Cookies
+
+#### .cookies.get(name)
+
+Get a cookie by it's `name`. The url will be the current url.
+
+#### .cookies.get(query)
+
+Query multiple cookies with the `query` object. If a `query.name` is set, it will return the first cookie it finds with that name, otherwise it will query for an array of cookies. If no `query.url` is set, it will use the current url. Here's an example:
+
+```js
+// get all google cookies that are secure
+// and have the path `/query`
+var cookies = yield nightmare
+  .goto('http://google.com')
+  .cookies.get({
+    path: '/query',
+    secure: true
+  })
+```
+
+Available properties are documented here: https://github.com/atom/electron/blob/master/docs/api/session.md#sescookiesgetdetails-callback
+
+#### .cookies.get()
+
+Get all the cookies for the current url. If you'd like get all cookies for all urls, use: `.get({ url: null })`.
+
+#### .cookies.set(name, value)
+
+Set a cookie's `name` and `value`. Most basic form, the url will be the current url.
+
+#### .cookies.set(cookie)
+
+Set a `cookie`. If `cookie.url` is not set, it will set the cookie on the current url. Here's an example:
+
+```js
+yield nightmare
+  .goto('http://google.com')
+  .cookies.set({
+    name: 'token',
+    value: 'some token',
+    path: '/query',
+    secure: true
+  })
+```
+
+Available properties are documented here:  https://github.com/atom/electron/blob/master/docs/api/session.md#sescookiessetdetails-callback
+
+#### .cookies.set(cookies)
+
+Set multiple cookies at once. `cookies` is an array of `cookie` objects. Take a look at the `.cookies.set(cookie)` documentation above for a better idea of what `cookie` should look like.
+
 ## Usage
 #### Installation
 Nightmare is a Node.js module, so you'll need to [have Node.js installed](http://nodejs.org/). Then you just need to `npm install` the module:

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -5,8 +5,10 @@
 var debug = require('debug')('nightmare:actions');
 var sliced = require('sliced');
 var jsesc = require('jsesc');
+var isArray = Array.isArray;
 var once = require('once');
 var fs = require('fs');
+var keys = Object.keys;
 
 /**
  * Get the title of the page.
@@ -405,4 +407,65 @@ exports.pdf = function (path, options, done) {
     done();
   });
   this.child.emit('pdf', path, options);
+};
+
+/**
+ * Get and set cookies
+ *
+ * @param {String} name
+ * @param {Mixed} value (optional)
+ * @param {Function} done
+ */
+
+exports.cookies = {};
+
+/**
+ * Get a cookie
+ */
+
+exports.cookies.get = function (name, done) {
+  debug('cookies.get()')
+  var query = {}
+
+  switch (arguments.length) {
+    case 2:
+      query = typeof name === 'string'
+        ? { name: name }
+        : name
+      break;
+    case 1:
+      done = name
+      break;
+  }
+
+  this.child.once('cookie.get', done)
+  this.child.emit('cookie.get', query);
+};
+
+/**
+ * Set a cookie
+ */
+
+exports.cookies.set = function (name, value, done) {
+  debug('cookies.set()')
+  var cookies = []
+
+  switch (arguments.length) {
+    case 3:
+      cookies.push({
+        name: name,
+        value: value
+      })
+      break;
+    case 2:
+      cookies = [].concat(name)
+      done = value
+      break;
+    case 1:
+      done = name
+      break;
+  }
+
+  this.child.once('cookie.set', done);
+  this.child.emit('cookie.set', cookies);
 };

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -19,6 +19,7 @@ var sliced = require('sliced');
 var child = require('./ipc');
 var once = require('once');
 var noop = function() {};
+var keys = Object.keys;
 
 /**
  * Export `Nightmare`
@@ -59,11 +60,15 @@ function Nightmare(options) {
     self.proc.kill();
   });
 
+  // initial state
   this.state = 'initial';
   this.running = false;
   this.ending = false;
   this.ended = false;
   this._queue = [];
+
+  // initialize subproperties
+  this.cookies = this.cookies()
 
   this.child = child(this.proc);
   this.child.once('ready', function() {
@@ -77,6 +82,13 @@ function Nightmare(options) {
   this.child.on('log', function() {
     log.apply(log, arguments);
   });
+
+  this.child.on('uncaughtException', function(stack) {
+    console.error('Nightmare runner error:\n\n%s\n', '\t' + stack.replace(/\n/g, '\n\t'))
+    self.proc.disconnect()
+    self.proc.kill()
+    process.exit(1)
+  })
 
   this.child.on('page-error', function(errorMessage, errorStack) {
     log('page-error', errorMessage, errorStack);
@@ -261,10 +273,29 @@ Nightmare.prototype.then = function(fulfill, reject) {
 
 Object.keys(actions).forEach(function (name) {
   var fn = actions[name];
-  Nightmare.prototype[name] = function() {
-    debug('queueing action "' + name + '"');
-    var args = [].slice.call(arguments);
-    this._queue.push([fn, args]);
-    return this;
-  };
+
+  // support functions and objects
+  // if it's an object, wrap it's
+  // properties in the queue function
+  if (typeof fn === 'function') {
+    Nightmare.prototype[name] = queued(name, fn)
+  } else {
+    Nightmare.prototype[name] = function() {
+      var self = this;
+      return keys(fn).reduce(function (obj, key) {
+        obj[key] = queued(name, fn[key]).bind(self)
+        return obj;
+      }, {});
+    }
+  }
+
+  // wrap all the functions in the queueing function
+  function queued (name, fn) {
+    return function action () {
+      debug('queueing action "' + name + '"');
+      var args = [].slice.call(arguments);
+      this._queue.push([fn, args]);
+      return this;
+    }
+  }
 });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,12 +4,21 @@
 
 var parent = require('./ipc')(process);
 var BrowserWindow = require('browser-window');
+var assign = require('object-assign');
+var defaults = require('defaults');
+var join = require('path').join;
 var sliced = require('sliced');
 var renderer = require('ipc');
 var app = require('app');
 var fs = require('fs');
-var defaults = require('defaults');
-var join = require('path').join;
+
+/**
+ * Handle uncaught exceptions in the main electron process
+ */
+
+process.on('uncaughtException', function(e) {
+  parent.emit('uncaughtException', e.stack)
+})
 
 /**
  * Hide the dock
@@ -22,7 +31,6 @@ var join = require('path').join;
  */
 
 app.on('ready', function() {
-
   var win;
 
   /**
@@ -173,6 +181,42 @@ app.on('ready', function() {
       });
     });
   });
+
+  /**
+   * Get cookies
+   */
+
+  parent.on('cookie.get', function (query) {
+    var details = assign({}, {
+      url: win.webContents.getUrl(),
+    }, query)
+
+    parent.emit('log', 'getting cookie: ' + JSON.stringify(details))
+    win.webContents.session.cookies.get(details, function (err, cookies) {
+      if (err) return parent.emit('cookie.get', err);
+      parent.emit('cookie.get', null, details.name ? cookies[0] : cookies)
+    })
+  })
+
+  /**
+   * Set cookies
+   */
+
+  parent.on('cookie.set', function (cookies) {
+    var pending = cookies.length
+
+    for (var i = 0, cookie; cookie = cookies[i]; i++) {
+      var details = assign({}, {
+        url: win.webContents.getUrl()
+      }, cookie)
+
+      parent.emit('log', 'setting cookie: ' + JSON.stringify(details))
+      win.webContents.session.cookies.set(details, function (err) {
+        if (err) parent.emit('cookie.set', err);
+        else if (!--pending) parent.emit('cookie.set')
+      })
+    }
+  })
 
   /**
    * Continue

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "minstache": "^1.2.0",
     "mkdirp": "^0.5.1",
     "mocha-generators": "^1.1.1",
+    "object-assign": "^4.0.1",
     "once": "^1.3.2",
     "sliced": "0.0.5",
     "thunkify": "^2.1.2"

--- a/test/fixtures/cookies/index.html
+++ b/test/fixtures/cookies/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Cookies</title>
+  </head>
+  <body>
+    <h1 class="title">Hello World!</h1>
+    <span class="subtitle">Welcome to the Cookies Test!</span>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -322,6 +322,108 @@ describe('Nightmare', function () {
     });
   });
 
+  describe('cookies', function() {
+    var nightmare;
+
+    beforeEach(function() {
+      nightmare = Nightmare().goto(fixture('cookie'));
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('.set(name, value) & .get(name)', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set('hi', 'hello')
+      var cookie = yield cookies.get('hi')
+
+      cookie.name.should.equal('hi')
+      cookie.value.should.equal('hello')
+      cookie.path.should.equal('/')
+      cookie.secure.should.equal(false)
+    })
+
+    it('.set(obj) & .get(name)', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set({
+        name: 'nightmare',
+        value: 'rocks',
+        path: '/cookie'
+      })
+      var cookie = yield cookies.get('nightmare')
+
+      cookie.name.should.equal('nightmare')
+      cookie.value.should.equal('rocks')
+      cookie.path.should.equal('/cookie')
+      cookie.secure.should.equal(false)
+    })
+
+    it('.set([cookie1, cookie2]) & .get()', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ])
+
+      var cookies = yield cookies.get()
+      cookies.length.should.equal(2)
+
+      // sort in case they come in a different order
+      cookies = cookies.sort(function (a, b) {
+        if (a.name > b.name) return 1
+        if (a.name < b.name) return -1
+        return 0
+      })
+
+      cookies[0].name.should.equal('hi')
+      cookies[0].value.should.equal('hello')
+      cookies[0].path.should.equal('/')
+      cookies[0].secure.should.equal(false)
+
+      cookies[1].name.should.equal('nightmare')
+      cookies[1].value.should.equal('rocks')
+      cookies[1].path.should.equal('/cookie')
+      cookies[1].secure.should.equal(false)
+    })
+
+    it('.set([cookie1, cookie2]) & .get(query)', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ])
+
+      var cookies = yield cookies.get({ path: '/cookie'})
+      cookies.length.should.equal(1)
+
+      cookies[0].name.should.equal('nightmare')
+      cookies[0].value.should.equal('rocks')
+      cookies[0].path.should.equal('/cookie')
+      cookies[0].secure.should.equal(false)
+    })
+  })
+
 
   describe('rendering', function () {
     var nightmare;


### PR DESCRIPTION
Adds support for getting and setting cookies. Originally, I wanted to just export `.cookie(...)` (as discussed in #241), but electron has a lot of power to query all the cookies or query for certain cookies on urls. I didn't want to intentionally limit their API. 

I decided to use sub-properties because it's going to get messy if we have a ton of top-level methods, so instead of:

```js
nightmare.setCookie(...)
nightmare.getCookie(...)
```

It looks like:

```js
nightmare.cookies.get(...)
nightmare.cookies.set(...)
```

This should allow for more powerful namespacing for things like `sessions`, `cache`, `proxy`, etc.

---

Additionally, while putting this together, I improved error handling. If the main electron process encounters an uncaughtException, it will propagate to the node process instead of popping up an electron window and not cleaning up after itself. It's not full-proof (doesn't work for syntax errors), but those should only happen while hacking on nightmare.

/cc @reinpk 