### PR TITLE
Add sendInputEvent, update to latest Electron

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -111,6 +111,9 @@ Clicks the `selector` element once.
 #### .type(selector, text)
 Enters the `text` provided into the `selector` element.
 
+#### .sendInputEvent(event)
+Send the input event to the page. See [Electron Docs](https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssendinputeventevent).
+
 #### .check(selector)
 Toggles the `selector` checkbox element.
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -406,3 +406,17 @@ exports.pdf = function (path, options, done) {
   });
   this.child.emit('pdf', path, options);
 };
+
+/**
+ * Send an inputEvent.
+ *
+ * @param {Object} event
+ */
+
+exports.sendInputEvent = function (event, done) {
+  debug('.sendInputEvent()');
+  this.child.emit('sendInputEvent', event);
+  done();
+  return this;
+
+};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -194,6 +194,12 @@ app.on('ready', function() {
     }
   });
 
+  parent.on('sendInputEvent', function(event) {
+
+    parent.emit('log', 'sendInputEvent: ' + JSON.stringify(event));
+    win.webContents.sendInputEvent(event);
+  });
+
   /**
    * Send "ready" event to the parent process
    */

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "defaults": "^1.0.2",
-    "electron-prebuilt": "^0.33.0",
+    "electron-prebuilt": "^0.35.0",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",


### PR DESCRIPTION
sendInputEvent wasn't implemented in Electron 0.33 so I bumped the dependency, tests seem ok. Happy to add a test for sendInputEvent if needed.