### PR TITLE
Custom events with bind and unbind

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -178,13 +178,16 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents). Additional to the electron-events we provide nightmare-events `'page-error'` and `'page-log'`.
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents). Additional to the electron-events we provide nightmare-events `'page-error'` and `'page-log'`.  Custom events can be added with `.customevent()`.
 
 ##### .on('page-error', errorMessage, errorStack)
 This event is triggered if any javscript exception is thrown on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is throwing an exception.
 
 ##### .on('page-log', errorMessage, errorStack)
 This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
+
+##### .customevent(name)
+Adds an event that can be captured with `.on()` triggerable in `.evaluate()` or `.inject()` with `ipc.send([name], ...)`.
 
 #### .screenshot([path][, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.

--- a/Readme.md
+++ b/Readme.md
@@ -199,11 +199,11 @@ This event is triggered if `console.log` is used on the page. But this event is 
 ##### .on('page-alert', message)
 This event is triggered if `alert` is used on the page.
 
-##### .bind(name)
-Adds a custom event that can be captured with `.on()` triggerable in `.evaluate()` or `.inject()` with `ipc.send([name], ...)`.
+##### .bind(name [, handler])
+Adds a custom event that can be captured with `.on()` triggerable in `.evaluate()` or `.inject()` with `ipc.send([name], ...)`.  The optional `handler` will consume the named event.
 
-##### .unbind(name)
-Removes a custom event added with `.bind()`.
+##### .unbind(name [, handler])
+Removes a custom event added with `.bind()`.  If handler is specified, the handler is removed.  If no handler is specified or the handler was the last handler for the emitter, the custom event is removed and will no longer be emittable until it is bound again.
 
 #### .screenshot([path][, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.

--- a/Readme.md
+++ b/Readme.md
@@ -187,7 +187,7 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents). Additional to the electron-events we provide nightmare-events `'page-error'`, `'page-alert'`, and `'page-log'`.  Custom events can be added with `'.customevent()`.
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents). Additional to the electron-events we provide nightmare-events `'page-error'`, `'page-alert'`, and `'page-log'`.  Custom events can be added with `'.bind()`.
 
 ##### .on('page-error', errorMessage, errorStack)
 This event is triggered if any javscript exception is thrown on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is throwing an exception.
@@ -198,8 +198,11 @@ This event is triggered if `console.log` is used on the page. But this event is 
 ##### .on('page-alert', message)
 This event is triggered if `alert` is used on the page.
 
-##### .customevent(name)
-Adds an event that can be captured with `.on()` triggerable in `.evaluate()` or `.inject()` with `ipc.send([name], ...)`.
+##### .bind(name)
+Adds a custom event that can be captured with `.on()` triggerable in `.evaluate()` or `.inject()` with `ipc.send([name], ...)`.
+
+##### .unbind(name)
+Removes a custom event added with `.bind()`.
 
 #### .screenshot([path][, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -433,3 +433,18 @@ exports.pdf = function (path, options, done) {
   });
   this.child.emit('pdf', path, options);
 };
+
+/**
+ * Add a custom event.
+ * @param {String} name
+ * @param {Function} done
+ */
+
+exports.customevent = function(name, done){
+  debug('.customevent() for %s', name);
+  this.child.once('customevent', function(){
+    done();
+  });
+  this.child.emit('customevent', name);
+  return this;
+};

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -508,11 +508,25 @@ exports.cookies.set = function (name, value, done) {
 /**
  * Add a custom event.
  * @param {String} name
+ * @param {Function} handler (optional)
  * @param {Function} done
  */
 
-exports.bind = function(name, done){
+exports.bind = function(){
+  var name = arguments[0], handler, done;
+  if(arguments.length == 2) {
+    done = arguments[1];
+  } else if(arguments.length == 3) {
+    handler = arguments[1];
+    done = arguments[2];
+  }
+  
   debug('.bind() for %s', name);
+
+  if(handler){
+    this.child.on(name, handler);
+  }
+
   this.child.once('bind', function(){
     done();
   });
@@ -523,14 +537,35 @@ exports.bind = function(name, done){
 /**
  * Remove a custom event.
  * @param {String} name
+ * @param {Function} handler (optional)
  * @param {Function} done
  */
 
-exports.unbind = function(name, done){
+exports.unbind = function(){
+  var name = arguments[0], handler, done;
+  if(arguments.length == 2) {
+    done = arguments[1];
+  } else if(arguments.length == 3) {
+    handler = arguments[1];
+    done = arguments[2];
+  }
+  
   debug('.unbind() for %s', name);
-  this.child.once('unbind', function(){
+
+  if(handler){
+    this.child.removeListener(name, handler);
+  }
+  else{
+    this.child.removeAllListeners(name);
+  }
+
+  if(this.child.listeners(name).length == 0){
+    this.child.once('unbind', function(){
+      done();
+    });
+    this.child.emit('unbind', name);
+  }else{
     done();
-  });
-  this.child.emit('unbind', name);
+  }
   return this;
 };

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -448,11 +448,26 @@ exports.pdf = function (path, options, done) {
  * @param {Function} done
  */
 
-exports.customevent = function(name, done){
-  debug('.customevent() for %s', name);
-  this.child.once('customevent', function(){
+exports.bind = function(name, done){
+  debug('.bind() for %s', name);
+  this.child.once('bind', function(){
     done();
   });
-  this.child.emit('customevent', name);
+  this.child.emit('bind', name);
+  return this;
+};
+
+/**
+ * Remove a custom event.
+ * @param {String} name
+ * @param {Function} done
+ */
+
+exports.unbind = function(name, done){
+  debug('.unbind() for %s', name);
+  this.child.once('unbind', function(){
+    done();
+  });
+  this.child.emit('unbind', name);
   return this;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -210,8 +210,8 @@ app.on('ready', function() {
    */
 
   parent.on('customevent', function(name){
-    renderer.on(name, function(event, args){
-      parent.emit(name, args);
+    renderer.on(name, function(){
+      parent.emit.apply(parent, [name].concat(sliced(arguments,1)))
     });
     parent.emit('customevent');
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -264,9 +264,11 @@ app.on('ready', function() {
    */
 
   parent.on('bind', function(name){
-    renderer.on(name, function(){
-      parent.emit.apply(parent, [name].concat(sliced(arguments,1)))
-    });
+    if(renderer.listeners(name).length == 0) {
+      renderer.on(name, function(){
+        parent.emit.apply(parent, [name].concat(sliced(arguments,1)))
+      });
+    }
     parent.emit('bind');
   });
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -206,6 +206,17 @@ app.on('ready', function() {
   });
 
   /**
+   * Custom Event
+   */
+
+  parent.on('customevent', function(name){
+    renderer.on(name, function(event, args){
+      parent.emit(name, args);
+    });
+    parent.emit('customevent');
+  });
+
+  /**
    * Send "ready" event to the parent process
    */
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -209,14 +209,23 @@ app.on('ready', function() {
   });
 
   /**
-   * Custom Event
+   * Custom Event Binding
    */
 
-  parent.on('customevent', function(name){
+  parent.on('bind', function(name){
     renderer.on(name, function(){
       parent.emit.apply(parent, [name].concat(sliced(arguments,1)))
     });
-    parent.emit('customevent');
+    parent.emit('bind');
+  });
+
+  /**
+   * Custom Event Unbinding
+   */
+
+  parent.on('unbind', function(name){
+    renderer.removeAllListeners(name);
+    parent.emit('unbind');
   });
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -637,6 +637,78 @@ describe('Nightmare', function () {
         });
       should.not.exist(eventResults);
     });
+
+    it('should be able to bind to a custom event with a handler', function*() {
+      var eventResults;
+      yield nightmare
+        .goto(fixture('events'))
+        .bind('sample-event', function(){
+             eventResults = arguments;
+        })
+        .evaluate(function(){
+          ipc.send('sample-event', 'sample', 3, {sample: 'sample'});
+        });
+      eventResults.should.be.ok;
+    });
+
+    it('should be able to unbind a custom event handler', function*() {
+      var eventResults, onResults;
+
+      var handler = function(){
+        eventResults = arguments;
+      }
+
+      yield nightmare
+        .goto(fixture('events'))
+        .bind('sample-event', handler)
+        .on('sample-event', function(){
+          onResults = arguments;
+        })
+        .unbind('sample-event', handler)
+        .evaluate(function(){
+          ipc.send('sample-event', 'sample', 3, {sample: 'sample'});
+        });
+      should.not.exist(eventResults);
+      onResults.should.be.ok;
+    });
+
+    it('should be able to unbind all custom event handlers', function*() {
+      var eventResults, onResults;
+
+      var handler = function(){
+        eventResults = arguments;
+      }
+
+      yield nightmare
+        .goto(fixture('events'))
+        .bind('sample-event', handler)
+        .on('sample-event', function(){
+          onResults = arguments;
+        })
+        .unbind('sample-event')
+        .evaluate(function(){
+          ipc.send('sample-event', 'sample', 3, {sample: 'sample'});
+        });
+      should.not.exist(eventResults);
+      should.not.exist(onResults);
+    });
+
+    it('should not emit multiple events for events bound more than once', function*() {
+      var count = 0;
+
+      yield nightmare
+        .goto(fixture('events'))
+        .bind('sample-event')
+        .bind('sample-event')
+        .on('sample-event', function(){
+          count++
+        })
+        .evaluate(function(){
+          ipc.send('sample-event', 'sample', 3, {sample: 'sample'});
+        });
+
+        count.should.equal(1);
+    });
     
     it('should fire an event on javascript window.alert', function*(){
       var alert = '';

--- a/test/index.js
+++ b/test/index.js
@@ -505,14 +505,14 @@ describe('Nightmare', function () {
       fired.should.be.true;
     });
 
-    it('should be able to have a custom event', function*() {
+    it('should be able to bind to a custom event', function*() {
       var eventResults;
       yield nightmare
         .goto(fixture('events'))
         .on('sample-event', function(){
           eventResults = arguments;
         })
-        .customevent('sample-event')
+        .bind('sample-event')
         .evaluate(function(){
           ipc.send('sample-event', 'sample', 3, {sample: 'sample'});
         });
@@ -520,6 +520,21 @@ describe('Nightmare', function () {
       eventResults[0].should.equal('sample');
       eventResults[1].should.equal(3);
       eventResults[2].sample.should.equal('sample');
+    });
+
+    it('should be able to unbind a custom event', function*() {
+      var eventResults;
+      yield nightmare
+        .goto(fixture('events'))
+        .on('sample-event', function(){
+          eventResults = arguments;
+        })
+        .bind('sample-event')
+        .unbind('sample-event')
+        .evaluate(function(){
+          ipc.send('sample-event', 'sample', 3, {sample: 'sample'});
+        });
+      should.not.exist(eventResults);
     });
     
     it('should fire an event on javascript window.alert', function*(){

--- a/test/index.js
+++ b/test/index.js
@@ -504,6 +504,23 @@ describe('Nightmare', function () {
         .goto('https://alskdjfasdfuuu.com');
       fired.should.be.true;
     });
+
+    it('should be able to have a custom event', function*() {
+      var eventResults;
+      yield nightmare
+        .goto(fixture('events'))
+        .on('sample-event', function(){
+          eventResults = arguments;
+        })
+        .customevent('sample-event')
+        .evaluate(function(){
+          ipc.send('sample-event', 'sample', 3, {sample: 'sample'});
+        });
+      eventResults.length.should.equal(3);
+      eventResults[0].should.equal('sample');
+      eventResults[1].should.equal(3);
+      eventResults[2].sample.should.equal('sample');
+    });
   });
 
   describe('options', function () {


### PR DESCRIPTION
Adds ability to add custom events that can be emitted with `ipc.send` from `evaluate` or `inject`.  Fixes #354.