### PR TITLE
Add headers() method, and optional headers param to goto()

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -71,6 +71,7 @@ function Nightmare(options) {
   this.ending = false;
   this.ended = false;
   this._queue = [];
+  this._headers = {};
 
   this.child = child(this.proc);
   this.child.once('ready', function() {
@@ -116,17 +117,36 @@ Nightmare.prototype.ready = function(fn) {
   return this;
 };
 
+/**
+ * Override headers for all HTTP requests
+ */
+
+Nightmare.prototype.header = function(header, value) {
+  if (header && typeof value !== 'undefined') {
+    this._headers[header] = value;
+  } else {
+    this._headers = header || {};
+  }
+
+  return this;
+};
 
 /**
  * Go to a `url`
  */
 
-Nightmare.prototype.goto = function(url) {
+Nightmare.prototype.goto = function(url, headers) {
   debug('queueing action "goto" for %s', url);
   var child = this.child;
+
+  headers = headers || {};
+  for (var key in this._headers) {
+    headers[key] = headers[key] || this._headers[key];
+  }
+
   this.queue(function(fn) {
     child.once('goto', fn);
-    child.emit('goto', url);
+    child.emit('goto', url, headers);
   });
   return this;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -100,11 +100,18 @@ app.on('ready', function() {
    * goto
    */
 
-  parent.on('goto', function(url) {
+  parent.on('goto', function(url, headers) {
+    var extraHeaders = '';
+    for (var key in headers) {
+      extraHeaders += key + ': ' + headers[key] + '\n';
+    }
+
     if (win.webContents.getUrl() == url) {
       parent.emit('goto');
     } else {
-      win.webContents.loadUrl(url);
+      win.webContents.loadUrl(url, {
+        extraHeaders: extraHeaders
+      });
       win.webContents.once('did-finish-load', function() {
         parent.emit('goto');
       });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "defaults": "^1.0.2",
-    "electron-prebuilt": "^0.33.0",
+    "electron-prebuilt": "^0.35.2",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",

--- a/test/index.js
+++ b/test/index.js
@@ -567,19 +567,38 @@ describe('Nightmare', function () {
       result.height.should.eql(size.height);
     });
 
-    /*
-    NOT AVAILABLE UPSTREAM in electron
-
-    it('should set headers', function*() {
-      var headers = yield Nightmare()
-        .headers({ 'X-Nightmare-Header': 'hello world' })
+    it('should set a single header', function*() {
+      nightmare = Nightmare();
+      var headers = yield nightmare
+        .header('X-Nightmare-Header', 'hello world')
         .goto(fixture('headers'))
         .evaluate(function () {
           return JSON.parse(document.querySelector('pre').innerHTML);
         });
       headers['x-nightmare-header'].should.equal('hello world');
     });
-    */
+
+    it('should set all headers', function*() {
+      nightmare = Nightmare();
+      var headers = yield nightmare
+        .header({ 'X-Foo': 'foo', 'X-Bar': 'bar'})
+        .goto(fixture('headers'))
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      headers['x-foo'].should.equal('foo');
+      headers['x-bar'].should.equal('bar');
+    });
+
+    it('should set headers for that request', function*() {
+      nightmare = Nightmare();
+      var headers = yield nightmare
+        .goto(fixture('headers'), { 'X-Nightmare-Header': 'hello world' })
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      headers['x-nightmare-header'].should.equal('hello world');
+    });
 
     it('should allow web-preferece settings', function*() {
       nightmare = Nightmare({'web-preferences': {'web-security': false}});

--- a/test/server.js
+++ b/test/server.js
@@ -43,6 +43,9 @@ app.get('/auth', basicAuth('my', 'auth'), function (req, res) {
  */
 
 app.get('/headers', function (req, res) {
+  res.header('Cache-Control', 'no-cache');
+  res.header('Expires', '-1');
+  res.header('Pragma', 'no-cache');
   res.send(req.headers);
 });
 


### PR DESCRIPTION
Adds a headers() method to override headers for all requests from that instance of nightmare.

``` javascript
yield nightmare
  .headers({ 'X-Nightmare-Header': 'hello world' })
  .goto('localhost:3000/');
```

And adds an optional param to goto(), specifying headers to use for that specific request:

``` javascript
yield nightmare
  .goto('localhost:3000/', { 'X-Nightmare-Header': 'hello world' });
```

Fixes #325 