### PR TITLE
added: Nightmare.action(name, action | namespace) and nightmare.use(plugin)

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -18,7 +18,7 @@ var keys = Object.keys;
 
 exports.title = function(done) {
   debug('.title() getting it');
-  this._evaluate(function() {
+  this.evaluate_now(function() {
     return document.title;
   }, done);
 };
@@ -31,7 +31,7 @@ exports.title = function(done) {
 
 exports.url = function(done) {
   debug('.url() getting it');
-  this._evaluate(function() {
+  this.evaluate_now(function() {
     return document.location.href;
   }, done);
 };
@@ -45,7 +45,7 @@ exports.url = function(done) {
 
 exports.visible = function(selector, done) {
   debug('.visible() for ' + selector);
-  this._evaluate(function(selector) {
+  this.evaluate_now(function(selector) {
     var elem = document.querySelector(selector);
     if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
     else return false;
@@ -61,7 +61,7 @@ exports.visible = function(selector, done) {
 
 exports.exists = function(selector, done) {
   debug('.exists() for ' + selector);
-  this._evaluate(function(selector) {
+  this.evaluate_now(function(selector) {
     return (document.querySelector(selector)!==null);
   }, done, selector);
 };
@@ -75,7 +75,7 @@ exports.exists = function(selector, done) {
 
 exports.click = function(selector, done) {
   debug('.click() on ' + selector);
-  this._evaluate(function (selector) {
+  this.evaluate_now(function (selector) {
     var element = document.querySelector(selector);
     var event = document.createEvent('MouseEvent');
     event.initEvent('click', true, true);
@@ -92,7 +92,7 @@ exports.click = function(selector, done) {
 
 exports.mousedown = function(selector, done) {
   debug('.mousedown() on ' + selector);
-  this._evaluate(function (selector) {
+  this.evaluate_now(function (selector) {
     var element = document.querySelector(selector);
     var event = document.createEvent('MouseEvent');
     event.initEvent('mousedown', true, true);
@@ -109,7 +109,7 @@ exports.mousedown = function(selector, done) {
 
 exports.mouseover = function(selector, done) {
   debug('.mouseover() on ' + selector);
-  this._evaluate(function (selector) {
+  this.evaluate_now(function (selector) {
     var element = document.querySelector(selector);
     var event = document.createEvent('MouseEvent');
     event.initMouseEvent('mouseover', true, true);
@@ -127,7 +127,7 @@ exports.mouseover = function(selector, done) {
 
 exports.type = function(selector, text, done) {
   debug('.type() %s into %s', text, selector);
-  this._evaluate(function (selector, text) {
+  this.evaluate_now(function (selector, text) {
     var elem = document.querySelector(selector);
     elem.focus();
     elem.value = text;
@@ -144,7 +144,7 @@ exports.type = function(selector, text, done) {
 
 exports.check = function(selector, done) {
   debug('.check() ' + selector);
-  this._evaluate(function(selector) {
+  this.evaluate_now(function(selector) {
     var element = document.querySelector(selector);
     var event = document.createEvent('HTMLEvents');
     element.checked = true;
@@ -165,7 +165,7 @@ exports.check = function(selector, done) {
 
 exports.select = function(selector, option, done) {
   debug('.select() ' + selector);
-  this._evaluate(function(selector, option) {
+  this.evaluate_now(function(selector, option) {
     var element = document.querySelector(selector);
     var event = document.createEvent('HTMLEvents');
     element.value = option;
@@ -182,7 +182,7 @@ exports.select = function(selector, option, done) {
 
 exports.back = function(done) {
   debug('.back()');
-  this._evaluate(function() {
+  this.evaluate_now(function() {
     window.history.back();
   }, done);
 };
@@ -195,7 +195,7 @@ exports.back = function(done) {
 
 exports.forward = function(done) {
   debug('.forward()');
-  this._evaluate(function() {
+  this.evaluate_now(function() {
     window.history.forward();
   }, done);
 };
@@ -208,7 +208,7 @@ exports.forward = function(done) {
 
 exports.refresh = function(done) {
   debug('.refresh()');
-  this._evaluate(function() {
+  this.evaluate_now(function() {
     window.location.reload();
   }, done);
 };
@@ -304,7 +304,7 @@ function waitfn (self, fn/**, arg1, arg2..., done**/) {
     }
   };
   var newArgs = [fn, waitDone].concat(args.slice(2,-1));
-  self._evaluate.apply(self, newArgs);
+  self.evaluate_now.apply(self, newArgs);
 }
 
 /**
@@ -320,7 +320,7 @@ exports.evaluate = function (fn/**, arg1, arg2..., done**/) {
   var done = args[args.length-1];
   var newArgs = [fn, done].concat(args.slice(1,-1));
   debug('.evaluate() fn on the page');
-  this._evaluate.apply(this, newArgs);
+  this.evaluate_now.apply(this, newArgs);
 };
 
 /**
@@ -392,7 +392,7 @@ exports.useragent = function(useragent, done) {
 
 exports.scrollTo = function (y, x, done) {
   debug('.scrollTo()');
-  this._evaluate(function (y, x) {
+  this.evaluate_now(function (y, x) {
     window.scrollTo(x, y);
   }, done, y, x);
 };

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -75,8 +75,12 @@ function Nightmare(options) {
   this._queue = [];
   this._headers = {};
 
-  // initialize subproperties
-  this.cookies = this.cookies()
+  // initialize namespaces
+  Nightmare.namespaces.forEach(function (name) {
+    if ('function' === typeof this[name]) {
+      this[name] = this[name]()
+    }
+  }, this)
 
   this.child = child(this.proc);
   this.child.once('ready', function() {
@@ -122,6 +126,12 @@ function Nightmare(options) {
   this.child.on('plugin-crashed', function () { log('plugin-crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('destroyed', function () { log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments))); });
 }
+
+/**
+ * Namespaces to initialize
+ */
+
+Nightmare.namespaces = [];
 
 /**
  * ready
@@ -172,6 +182,7 @@ Nightmare.prototype.goto = function(url, headers) {
  */
 
 Nightmare.prototype.run = function(fn) {
+  debug('running')
   var ready = [this.ready.bind(this)];
   var steps = [ready].concat(this.queue());
   this.running = true;
@@ -213,10 +224,14 @@ Nightmare.prototype.run = function(fn) {
 };
 
 /**
- * evaluate
+ * run the code now (do not queue it)
+ *
+ * you should not use this, unless you know what you're doing
+ * it should be used for plugins and custom actions, not for
+ * normal API usage
  */
 
-Nightmare.prototype._evaluate = function(js_fn, done) {
+Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var child = this.child;
 
   child.once('javascript', function(err, result) {
@@ -299,11 +314,24 @@ Nightmare.prototype.then = function(fulfill, reject) {
 };
 
 /**
- * Attach all the actions.
+ * use
  */
 
-Object.keys(actions).forEach(function (name) {
-  var fn = actions[name];
+Nightmare.prototype.use = function(fn) {
+  fn(this)
+  return this
+};
+
+
+/**
+ * Static: Support attaching custom actions
+ *
+ * @param {String} name - method name
+ * @param {Function|Object} fn - implementation
+ * @return {Nightmare}
+ */
+
+ Nightmare.action = function(name, fn) {
 
   // support functions and objects
   // if it's an object, wrap it's
@@ -311,6 +339,9 @@ Object.keys(actions).forEach(function (name) {
   if (typeof fn === 'function') {
     Nightmare.prototype[name] = queued(name, fn)
   } else {
+    if (!~Nightmare.namespaces.indexOf(name)) {
+      Nightmare.namespaces.push(name);
+    }
     Nightmare.prototype[name] = function() {
       var self = this;
       return keys(fn).reduce(function (obj, key) {
@@ -329,4 +360,15 @@ Object.keys(actions).forEach(function (name) {
       return this;
     }
   }
+
+  return this;
+};
+
+/**
+ * Attach all the actions.
+ */
+
+Object.keys(actions).forEach(function (name) {
+  var fn = actions[name];
+  Nightmare.action(name, fn);
 });


### PR DESCRIPTION
With this change, Nightmare now supports both `nightmare.use(plugin)` and `Nightmare.action(name, action | namespace)`

Originally I thought we could combine them, but they actually do two different things. `action` extends the prototype and ensures that the action is properly queued. `use` is helpful for re-using and abstracting out tasks you want to perform on nightmare.