### PR TITLE
Fixed 'args is not defined' error for paths option

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -54,7 +54,7 @@ function Nightmare(options) {
 
 
   if(options.paths) {
-    args.push(JSON.stringify(options.paths));
+    electronArgs.push(JSON.stringify(options.paths));
   }
 
   this.proc = proc.spawn(electron_path, [runner].concat(electronArgs), {

--- a/test/index.js
+++ b/test/index.js
@@ -725,6 +725,11 @@ describe('Nightmare', function () {
 
       result.should.be.ok;
     });
+
+    it('should be constructable with paths', function*() {
+      nightmare = Nightmare({ paths:{} });
+      nightmare.should.be.ok;
+    });
   });
 
   describe('Nightmare.action(name, fn)', function() {


### PR DESCRIPTION
This fixes the typo.