### PR TITLE
handle will-download

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -116,6 +116,12 @@ var nightmare = Nightmare({
 });
 ```
 
+##### ignoreDownloads
+Defines whether or not downloads should be ignored.
+
+##### downloadTimeout
+This will throw an eception if the `.wait('downloads-complete')` didn't return `true` within the set timeframe.
+
 #### .useragent(useragent)
 Set the `useragent` used by electron.
 
@@ -178,6 +184,11 @@ Wait until the element `selector` is present e.g. `.wait('#pay-button')`
 #### .wait(fn[, arg1, arg2,...])
 Wait until the `fn` evaluated on the page with `arg1, arg2,...` returns `true`. All the `args` are optional. See `.evaluate()` for usage.
 
+#### .wait('downloads-complete')
+Wait until all downloads are in a state of `'completed'`, `'interrupted'`, or `'cancelled'`
+
+#### .emit(eventType[, arg1, arg2,...])
+Sends an event of `eventType` to the Electron process.
 
 ### Extract from the Page
 
@@ -198,6 +209,30 @@ This event is triggered if `console.log` is used on the page. But this event is 
 
 ##### .on('page-alert', message)
 This event is triggered if `alert` is used on the page.
+
+##### .on('download', event, downloadItem)
+This event is triggered when Electron emits `'will-download'`.  This event is also emitted after downloads are started when [`DownloadItem`](https://github.com/atom/electron/blob/master/docs/api/download-item.md) emits `'updated'` or `'done'`.   The possible values for `event` are `'started'`, `'cancelled'`, `'interrupted'`, or `'completed'`.  Note that by listening to `'download'`, Nightmare expects the default download behavior to be overridden. 
+
+Downloads should be completed using `Nightmare.emit('download', action, downloadItem)`.  The possible values for `action` are `'cancel'`, `'continue'` for default behavior, or a file path (file name and extension inclusive) to save the download to an alternative location. The `downloadItem` parameter should use the item passed by `'download'`.
+
+For example:
+
+```javascript
+var nightmare = Nightmare();
+nightmare.on('download', function(event, downloadItem){
+  if(state == 'start'){
+    nightmare.emit('download', '/some/path/file.zip', downloadItem);
+  }
+});
+
+yield nightmare
+  .goto('https://github.com/segmentio/nightmare')
+  .click('a[href="/segmentio/nightmare/archive/master.zip"]')
+  .wait('downloads-complete');
+```
+
+By default, downloads are saved to the path defined in `paths.downloads`.  Also by default, downloads are automatically accepted (`nightmare.emit('download', 'continue', downloadItem)` is performed automatically internally in Nightmare) unless `ignoreDownloads` is specified.
+
 
 #### .screenshot([path][, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.

--- a/Readme.md
+++ b/Readme.md
@@ -120,7 +120,7 @@ var nightmare = Nightmare({
 Defines whether or not downloads should be ignored.
 
 ##### downloadTimeout
-This will throw an eception if the `.wait('downloads-complete')` didn't return `true` within the set timeframe.
+This will throw an exception if the `.wait('downloads-complete')` didn't return `true` within the set timeframe.
 
 #### .useragent(useragent)
 Set the `useragent` used by electron.
@@ -219,8 +219,8 @@ For example:
 
 ```javascript
 var nightmare = Nightmare();
-nightmare.on('download', function(event, downloadItem){
-  if(state == 'start'){
+nightmare.on('download', function(state, downloadItem){
+  if(state == 'started'){
     nightmare.emit('download', '/some/path/file.zip', downloadItem);
   }
 });

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -233,8 +233,13 @@ exports.wait = function () {
     waitms(arg, done);
   }
   else if (typeof arg === 'string') {
-    debug('.wait() for ' + arg + ' element');
-    waitelem(this, arg, done);
+    if(arg == 'downloads-complete'){
+      debug('.wait() for downloads');
+      waitDownloads(this, done);
+    } else {
+      debug('.wait() for ' + arg + ' element');
+      waitelem(this, arg, done);
+    }
   }
   else if (typeof arg === 'function') {
     debug('.wait() for fn');
@@ -273,6 +278,39 @@ function waitelem (self, selector, done) {
   waitfn(self, elementPresent, done);
 }
 
+var _waitMsPassed = 0;
+var _timeoutMs = 250;
+
+/**
+ * Wait until downloads are complete.
+ *
+ * @param {Nightmare} self
+ * @param {Function} done
+ */
+
+function waitDownloads (self, done) {
+  var dldone = function(){
+    return Object.keys(self._downloads).map(key => self._downloads[key]).filter(function(item){
+      return item.state != 'completed' && item.state != 'interrupted' && item.state != 'cancelled';
+    }) == 0;
+  };
+
+  if(dldone()){
+    return done();
+    _waitMsPassed = 0;
+  }
+  else if(self.optionDownloadTimeout && _waitMsPassed > self.optionDownloadTimeout){
+    _waitMsPassed = 0;
+    return done(new Error('.wait() for download timed out after ' + self.optionDownloadTimeout + 'msec'));
+  }
+  else{
+    _waitMsPassed += _timeoutMs;
+    setTimeout(function(){
+      waitDownloads(self, done);
+    }, _timeoutMs);
+  }
+}
+
 /**
  * Wait until evaluated function returns true.
  *
@@ -282,8 +320,6 @@ function waitelem (self, selector, done) {
  * @param {Function} done
  */
 
-var _waitMsPassed = 0;
-var _timeoutMs = 250;
 function waitfn (self, fn/**, arg1, arg2..., done**/) {
   var args = sliced(arguments);
   var done = args[args.length-1];

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -51,6 +51,7 @@ function Nightmare(options) {
   var electronArgs = [];
   var self = this;
   self.optionWaitTimeout = options.waitTimeout;
+  self.optionDownloadTimeout = options.downloadTimeout;
 
 
   if(options.paths) {
@@ -74,6 +75,7 @@ function Nightmare(options) {
   this.ended = false;
   this._queue = [];
   this._headers = {};
+  this._downloads = {};
 
   // initialize namespaces
   Nightmare.namespaces.forEach(function (name) {
@@ -125,6 +127,19 @@ function Nightmare(options) {
   this.child.on('crashed', function () { log('crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('plugin-crashed', function () { log('plugin-crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('destroyed', function () { log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments))); });
+
+  this.child.on('download', function(state, downloadInfo){
+    log('download', downloadInfo.filename + ' is ' + state);
+    self._downloads[downloadInfo.filename] = downloadInfo;
+    self._downloads[downloadInfo.filename].state = state;
+    if(self.child.listeners('download').length == 1 && state == 'started'){
+      if(options.ignoreDownloads) {
+        self.emit('download', 'cancel', downloadInfo);
+      } else {
+        self.emit('download', 'continue', downloadInfo);
+      }
+    }
+  });
 }
 
 /**
@@ -284,6 +299,15 @@ Nightmare.prototype.on = function(event, handler) {
   this.child.on(event, handler);
   return this;
 };
+
+/**
+ * emit
+ */
+
+Nightmare.prototype.emit = function(){
+  this.child.emit.apply(this, sliced(arguments));
+  return this;
+}
 
 /**
  * Queue

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -100,6 +100,67 @@ app.on('ready', function() {
     win.webContents.on('plugin-crashed', forward('plugin-crashed'));
     win.webContents.on('destroyed', forward('destroyed'));
 
+    win.webContents.session.on('will-download', function(event, downloadItem, webContents){
+      parent.emit('log', 'will-download');
+      if(options.ignoreDownloads){
+        downloadItem.cancel();
+        return;
+      }
+
+      var downloadInfo = {
+        filename: downloadItem.getFilename(),
+        mimetype: downloadItem.getMimeType(),
+        receivedBytes: 0,
+        totalBytes: downloadItem.getTotalBytes(),
+        url: downloadItem.getURL(),
+        path: join(app.getPath('downloads'), downloadItem.getFilename())
+      };
+
+      downloadItem.on('done', function(e, state){
+        if(state == 'completed'){
+          fs.renameSync(join(app.getPath('downloads'), downloadItem.getFilename()), downloadInfo.path);
+        }
+        parent.emit('download', state, downloadInfo); 
+      });
+
+      downloadItem.on('updated', function(event){
+        downloadInfo.receivedBytes = event.sender.getReceivedBytes();
+        parent.emit('download', 'updated', downloadInfo);
+      });
+
+      downloadItem.setSavePath(downloadInfo.path);
+      downloadItem.pause();
+
+      var handler = function(){
+        var item, path;
+        if(arguments.length == 1 && arguments[0] === Object(arguments[0])){
+          item = arguments[0];
+        }
+        else if(arguments.length == 2){
+          path = arguments[0];
+          item = arguments[1];
+        }
+        parent.removeListener('download', handler);
+        if(item.filename == downloadItem.getFilename()){
+          if(path == 'cancel'){
+            downloadItem.cancel();
+          }
+          else {
+            if(path && path !== 'continue'){
+              //.setSavePath() does not overwrite the first .setSavePath() call
+              //use `fs.rename` when download is completed
+              downloadInfo.path = path;
+            }
+
+            downloadItem.resume();
+          }
+        }
+      };
+
+      parent.on('download', handler);
+      parent.emit('download', 'started', downloadInfo);
+    });
+
     parent.emit('browser-initialize');
   });
 


### PR DESCRIPTION
Allow users to automatically accept, automatically ignore, or handle downloads on a per-case basis. Fixes #332 and #371 with the addition of the `ignoreDownloads` option, should fix #151 with the `download` event and the various ways that can be used.
