### PR TITLE
Added 'electronPath' option to customize Electron path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -116,6 +116,15 @@ var nightmare = Nightmare({
 });
 ```
 
+#### electronPath
+The path to prebuilt Electron binary.  This is useful for testing on different version Electron.  Note that Nightmare only supports the version this package depending on.  Please use this option at your own risk.
+
+```js
+var nightmare = Nightmare({
+  electronPath: require('electron-prebuilt')
+});
+```
+
 #### .useragent(useragent)
 Set the `useragent` used by electron.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -9,7 +9,7 @@ var debug = require('debug')('nightmare');
  * Module dependencies
  */
 
-var electron_path = require('electron-prebuilt');
+var default_electron_path = require('electron-prebuilt');
 var source = require('function-source');
 var proc = require('child_process');
 var actions = require('./actions');
@@ -52,6 +52,7 @@ function Nightmare(options) {
   var self = this;
   self.optionWaitTimeout = options.waitTimeout;
 
+  var electron_path = options.electronPath || default_electron_path
 
   if(options.paths) {
     electronArgs.push(JSON.stringify(options.paths));

--- a/test/index.js
+++ b/test/index.js
@@ -730,6 +730,11 @@ describe('Nightmare', function () {
       nightmare = Nightmare({ paths:{} });
       nightmare.should.be.ok;
     });
+
+    it('should allow to use external Electron', function*() {
+      nightmare = Nightmare({ electronPath: require('electron-prebuilt') });
+      nightmare.should.be.ok;
+    })
   });
 
   describe('Nightmare.action(name, fn)', function() {


### PR DESCRIPTION
I added `electronPath` option to options of `Nightmare()`.

I added this because I want to use Nightmare for end-to-end Electron app testing (e.g. Nightmare uses Electron v0.35.2 but my app uses new API introduced on Electron v0.35.4).  Nightmare now fixes Electron version.  I agree that it's reasonable bacause Nightmare can't support all versions of Electron.  So I added notation to document.