### PR TITLE
Removed useless mocha opt

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --slow 3s
 --timeout 10s
---require mocha-generators


### PR DESCRIPTION
mocha-generators is now required in `test/index.js` explicitly.