### PR TITLE
Followed new BrowserWindow option naming

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -49,13 +49,13 @@ app.on('ready', function() {
    */
 
   parent.on('browser-initialize', function(options) {
-    var webPreferences = defaults(options['web-preferences'] || {}, {
-      'preload': join(__dirname, 'preload.js'),
-      'node-integration': false
+    var webPreferences = defaults(options['webPreferences'] || {}, {
+      preload: join(__dirname, 'preload.js'),
+      nodeIntegration: false
     });
 
     options = defaults(options, {
-      'web-preferences': webPreferences,
+      webPreferences: webPreferences,
       show: false
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -715,8 +715,8 @@ describe('Nightmare', function () {
       headers['x-nightmare-header'].should.equal('hello world');
     });
 
-    it('should allow web-preferece settings', function*() {
-      nightmare = Nightmare({'web-preferences': {'web-security': false}});
+    it('should allow webPrefereces settings', function*() {
+      nightmare = Nightmare({webPreferences: {webSecurity: false}});
       var result = yield nightmare
         .goto(fixture('options'))
         .evaluate(function () {


### PR DESCRIPTION
Option naming of `BrowserWindow` was changed at Electron v0.35. (e.g. `max-width` -> `maxWidth`)

Documentation:
https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions