### PR TITLE
PDF Options Out of Date

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -203,7 +203,7 @@ This event is triggered if `alert` is used on the page.
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
 #### .pdf(path, options)
-Saves a PDF with A4 size pages of the current page to the specified `path`. Options are [here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#webcontents-printtopdf-options-callback).
+Saves a PDF to the specified `path`. Options are [here](https://github.com/atom/electron/blob/v0.35.2/docs/api/web-contents.md#webcontentsprinttopdfoptions-callback).
 
 #### .title()
 Returns the title of the current page.


### PR DESCRIPTION
I've noticed that you're bundling `0.35.2` which includes additional options for `printToPDF`, including additional paper sizes like `letter`, `A5` etc. 

The current documentation points to an older version of Electron docs which do not show all possible settings. This PR updates the link to reference the docs specifically for `0.35.2`