### PR TITLE
add events for prompt, alert, confirm, and the other console events

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -94,16 +94,18 @@ package for Mocha, which enables the support for generators.
 #### Nightmare(options)
 Create a new instance that can navigate around the web. The available options are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions), along with the following nightmare-specific options.
 
-##### waitTimeout
+##### Nightmare options
+
+###### waitTimeout
 This will throw an exception if the `.wait()` didn't return `true` within the set timeframe.
 
 ```js
 var nightmare = Nightmare({
-  waitTimeout: 1000 //(ms)
+  waitTimeout: 1000 // in ms
 });
 ```
 
-##### paths
+###### paths
 The default system paths that Electron knows about. Here's a list of available paths: https://github.com/atom/electron/blob/master/docs/api/app.md#appgetpathname
 
 You can overwrite them in Nightmare by doing the following:
@@ -188,16 +190,47 @@ Returns whether the selector exists or not on the page.
 Returns whether the selector is visible or not
 
 #### .on(event, callback)
-Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents). Additional to the electron-events we provide nightmare-events `'page-error'`, `'page-alert'`, and `'page-log'`.
+Capture page events with the callback. You have to call `.on()` before calling `.goto()`. Supported events are [documented here](http://electron.atom.io/docs/v0.30.0/api/browser-window/#class-webcontents).
 
-##### .on('page-error', errorMessage, errorStack)
+##### Additional "page" events
+
+###### .on('page', function(type="error", message, stack))
 This event is triggered if any javscript exception is thrown on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is throwing an exception.
 
-##### .on('page-log', errorMessage, errorStack)
-This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
+##### "page" events
 
-##### .on('page-alert', message)
-This event is triggered if `alert` is used on the page.
+Listen for `window.addEventListener('error')`, `alert(...)`, `prompt(...)` & `confirm(...)`.
+
+###### .on('page', function(type="error", message, stack))
+
+Listen for top-level page errors. This will get triggered when an error is thrown on the page.
+
+###### .on('page', function(type="alert", message))
+
+Nightmare disables `window.alert` from popping up by default, but you can still listen for the contents of the alert dialog.
+
+###### .on('page', function(type="prompt", message, response))
+
+Nightmare disables `window.prompt` from popping up by default, but you can still listen for the message to come up. If you need to handle the confirmation differently, you'll need to use your own preload script.
+
+###### .on('page', function(type="confirm", message, response))
+
+Nightmare disables `window.confirm` from popping up by default, but you can still listen for the message to come up. If you need to handle the confirmation differently, you'll need to use your own preload script.
+
+###### .on('console', function(type [, arguments, ...]))
+
+`type` will be either `log`, `warn` or `error` and `arguments` are what gets passed from the console.
+
+##### Additional "console" events
+
+Listen for `console.log(...)`, `console.warn(...)`, and `console.error(...)`.
+
+###### .on('console', function(type [, arguments, ...]))
+
+`type` will be either `log`, `warn` or `error` and `arguments` are what gets passed from the console.
+
+##### .on('console', function(type, errorMessage, errorStack))
+This event is triggered if `console.log` is used on the page. But this event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
 
 #### .screenshot([path][, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -2,19 +2,45 @@ window.__nightmare = {};
 __nightmare.ipc = require('ipc');
 __nightmare.sliced = require('sliced');
 
+// Listen for error events
 window.addEventListener('error', function(e) {
-  __nightmare.ipc.send('page-error', e.message, e.error.stack);
+  __nightmare.ipc.send('page', 'error', e.message, e.error.stack);
 });
 
 (function(){
+  // listen for console.log
   var defaultLog = console.log;
   console.log = function() {
-    __nightmare.ipc.send('page-log', arguments);
+    __nightmare.ipc.send('console', 'log', arguments);
     return defaultLog.apply(this, arguments);
   };
 
-  var defaultAlert = window.alert;
-  window.alert = function(message){
-    __nightmare.ipc.send('page-alert', message);
+  // listen for console.warn
+  var defaultWarn = console.warn;
+  console.warn = function() {
+    __nightmare.ipc.send('console', 'warn', arguments);
+    return defaultWarn.apply(this, arguments);
   };
+
+  // listen for console.error
+  var defaultError = console.error;
+  console.error = function() {
+    __nightmare.ipc.send('console', 'error', arguments);
+    return defaultError.apply(this, arguments);
+  };
+
+  // overwrite the default alert
+  window.alert = function(message){
+    __nightmare.ipc.send('page', 'alert', message);
+  };
+
+  // overwrite the default prompt
+  window.prompt = function(message, defaultResponse){
+    __nightmare.ipc.send('page', 'prompt', message, defaultResponse);
+  }
+
+  // overwrite the default confirm
+  window.confirm = function(message, defaultResponse){
+    __nightmare.ipc.send('page', 'confirm', message, defaultResponse);
+  }
 })()

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,8 +4,8 @@
 
 var parent = require('./ipc')(process);
 var BrowserWindow = require('browser-window');
+var defaults = require('deep-defaults');
 var assign = require('object-assign');
-var defaults = require('defaults');
 var join = require('path').join;
 var sliced = require('sliced');
 var renderer = require('ipc');
@@ -49,15 +49,17 @@ app.on('ready', function() {
    */
 
   parent.on('browser-initialize', function(options) {
-    var webPreferences = defaults(options['webPreferences'] || {}, {
-      preload: join(__dirname, 'preload.js'),
-      nodeIntegration: false
-    });
+    options = defaults(options || {}, {
+      show: false,
+      webPreferences: {
+        preload: join(__dirname, 'preload.js'),
+        nodeIntegration: false
+      }
+    })
 
-    options = defaults(options, {
-      webPreferences: webPreferences,
-      show: false
-    });
+    /**
+     * Create a new Browser Window
+     */
 
     win = new BrowserWindow(options);
 
@@ -75,14 +77,13 @@ app.on('ready', function() {
     /**
      * Pass along web content events
      */
-    renderer.on('page-error', function(event, errorMessage, errorStack) {
-      parent.emit('page-error', errorMessage, errorStack);
+
+    renderer.on('page', function(sender/*, arguments, ... */) {
+      parent.emit.apply(parent, ['page'].concat(sliced(arguments, 1)))
     });
-    renderer.on('page-log', function(event, args) {
-      parent.emit('page-log', args);
-    });
-    renderer.on('page-alert', function(event, message){
-      parent.emit('page-alert', message);
+
+    renderer.on('console', function(sender/*, arguments, ... */) {
+      parent.emit.apply(parent, ['console'].concat(sliced(arguments, 1)))
     });
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));
@@ -189,12 +190,13 @@ app.on('ready', function() {
 
   parent.on('pdf', function(path, options) {
     // https://github.com/fraserxu/electron-pdf/blob/master/index.js#L98
-    options = defaults(options, {
+    options = defaults(options || {}, {
       marginType: 0,
       printBackground: true,
       printSelectionOnly: false,
       landscape: false
     });
+
     win.printToPDF(options, function (err, data) {
       if (err) return parent.emit('pdf', arguments);
       fs.writeFile(path, data, function (err) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "description": "A high-level browser automation library.",
   "dependencies": {
     "debug": "^2.2.0",
+    "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
     "electron-prebuilt": "^0.35.2",
     "enqueue": "^1.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -576,8 +576,10 @@ describe('Nightmare', function () {
     it('should fire an event on javascript error', function*() {
       var fired = false;
       nightmare
-        .on('page-error', function (errorMessage, errorStack) {
-          fired = true;
+        .on('page', function (type, errorMessage, errorStack) {
+          if (type === 'error') {
+            fired = true;
+          }
         });
       yield nightmare
         .goto(fixture('events'));
@@ -587,8 +589,10 @@ describe('Nightmare', function () {
     it('should fire an event on javascript console.log', function*() {
       var log = '';
       nightmare
-        .on('page-log', function (logs) {
-          log = logs[0];
+        .on('console', function (type, logs) {
+          if (type === 'log') {
+            log = logs[0];
+          }
         });
       yield nightmare
         .goto(fixture('events'))
@@ -608,9 +612,12 @@ describe('Nightmare', function () {
 
     it('should fire an event on javascript window.alert', function*(){
       var alert = '';
-      nightmare.on('page-alert', function(message){
-        alert = message;
+      nightmare.on('page', function(type, message){
+        if (type === 'alert') {
+          alert = message;
+        }
       });
+
       yield nightmare
         .goto(fixture('events'))
         .evaluate(function(){
@@ -619,6 +626,43 @@ describe('Nightmare', function () {
       alert.should.equal('my alert');
     });
 
+    it('should fire an event on javascript window.prompt', function*(){
+      var prompt = '';
+      var response = ''
+      nightmare.on('page', function(type, message, res){
+        if (type === 'prompt') {
+          prompt = message;
+          response = res
+        }
+      });
+
+      yield nightmare
+        .goto(fixture('events'))
+        .evaluate(function(){
+          prompt('my prompt', 'hello!');
+        });
+      prompt.should.equal('my prompt');
+      response.should.equal('hello!');
+    });
+
+    it('should fire an event on javascript window.confirm', function*(){
+      var confirm = '';
+      var response = ''
+      nightmare.on('page', function(type, message, res){
+        if (type === 'confirm') {
+          confirm = message;
+          response = res
+        }
+      });
+
+      yield nightmare
+        .goto(fixture('events'))
+        .evaluate(function(){
+          confirm('my confirm', 'hello!');
+        });
+      confirm.should.equal('my confirm');
+      response.should.equal('hello!');
+    });
   });
 
   describe('options', function () {


### PR DESCRIPTION
**BREAKING:** changed `page-error`, `page-alert`, and `page-log` to `nightmare.on("page", function (type, ... ))`

it allows you to hook into the following console events:

- console.log
- console.warn
- console.error

and the following window events:

- alert
- prompt
- confirm

This PR also prevents prompts, alerts, and confirms from freezing the process while emitting events for each.