### PR TITLE
fix eventemitter leak message

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -61,7 +61,8 @@ function Nightmare(options) {
   this.proc = proc.spawn(electron_path, [runner].concat(electronArgs), {
     stdio: [null, null, null, 'ipc']
   });
-
+  
+  process.setMaxListeners(Infinity);
   process.on('uncaughtException', function(err) {
     console.error(err.stack);
     self.proc.disconnect();


### PR DESCRIPTION
if you spin up 10 nightmare processes, you get nasty console messages about an event emitter leak because 10+ listeners will be attached to process. this tells node everything is okay and we meant to do this.