### PR TITLE
Support Chrome command line switches

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -116,6 +116,19 @@ var nightmare = Nightmare({
 });
 ```
 
+##### switches
+The command line switches used by the Chrome browser that are also supported by Electron. Here's a list of supported Chrome command line switches:
+https://github.com/atom/electron/blob/master/docs/api/chrome-command-line-switches.md
+
+```js
+var nightmare = Nightmare({
+  switches: {
+    'proxy-server': '1.2.3.4:5678',
+    'ignore-certificate-errors': true
+  }
+});
+```
+
 ##### electronPath
 The path to prebuilt Electron binary.  This is useful for testing on different version Electron.  Note that Nightmare only supports the version this package depending on.  Please use this option at your own risk.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -54,14 +54,18 @@ function Nightmare(options) {
 
   var electron_path = options.electronPath || default_electron_path
 
-  if(options.paths) {
-    electronArgs.push(JSON.stringify(options.paths));
+  if (options.paths) {
+    electronArgs.paths = options.paths;
   }
 
-  this.proc = proc.spawn(electron_path, [runner].concat(electronArgs), {
+  if (options.switches) {
+    electronArgs.switches = options.switches;
+  }
+
+  this.proc = proc.spawn(electron_path, [runner].concat(JSON.stringify(electronArgs)), {
     stdio: [null, null, null, 'ipc']
   });
-  
+
   process.setMaxListeners(Infinity);
   process.on('uncaughtException', function(err) {
     console.error(err.stack);

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -48,7 +48,7 @@ var template = require('./javascript');
 function Nightmare(options) {
   if (!(this instanceof Nightmare)) return new Nightmare(options);
   options = options || {};
-  var electronArgs = [];
+  var electronArgs = {};
   var self = this;
   self.optionWaitTimeout = options.waitTimeout;
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -26,13 +26,13 @@ process.on('uncaughtException', function(e) {
 
 if (process.argv.length > 2) {
   var processArgs = JSON.parse(process.argv[2]);
-  paths = processArgs.paths
+  var paths = processArgs.paths;
   if (paths) {
     for (var i in paths) {
-      app.setPath(i, paths[i]);
+      app.setPath(paths[i]);
     }
   }
-  switches = processArgs.switches
+  var switches = processArgs.switches;
   if (switches) {
     for (var i in switches) {
       app.commandLine.appendSwitch(i, switches[i]);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -25,9 +25,18 @@ process.on('uncaughtException', function(e) {
  */
 
 if (process.argv.length > 2) {
-  var paths = JSON.parse(process.argv[2]);
-  for (var i in paths) {
-    app.setPath(i, paths[i]);
+  var processArgs = JSON.parse(process.argv[2]);
+  paths = processArgs.paths
+  if (paths) {
+    for (var i in paths) {
+      app.setPath(i, paths[i]);
+    }
+  }
+  switches = processArgs.switches
+  if (switches) {
+    for (var i in switches) {
+      app.commandLine.appendSwitch(i, switches[i]);
+    }
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -811,6 +811,11 @@ describe('Nightmare', function () {
       nightmare.should.be.ok;
     });
 
+    it('should be constructable with switches', function*() {
+      nightmare = Nightmare({ switches:{} });
+      nightmare.should.be.ok;
+    });
+
     it('should allow to use external Electron', function*() {
       nightmare = Nightmare({ electronPath: require('electron-prebuilt') });
       nightmare.should.be.ok;


### PR DESCRIPTION
Support [Chrome command line switches](https://github.com/atom/electron/blob/master/docs/api/chrome-command-line-switches.md) (e.g. proxy-server, ignore-certificate-errors).