### PR TITLE
Add yet another method to populate a text into an element

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -153,6 +153,22 @@ exports.type = function() {
 };
 
 /**
+ * Populate a text into an element
+ *
+ * @param {String} selector
+ * @param {String} text
+ * @param {Function} done
+ */
+
+exports.populate = function(selector, text, done) {
+  debug('populate() %s into %s', text, selector);
+  this.evaluate_now(function(selector, text) {
+    var element = document.querySelector(selector);
+    element.value = text;
+  }, done, selector, text);
+};
+
+/**
  * Check a checkbox, fire change event
  *
  * @param {String} selector

--- a/test/index.js
+++ b/test/index.js
@@ -355,6 +355,29 @@ describe('Nightmare', function () {
       title.should.equal('Manipulation - Result - Nightmare');
     });
 
+    it('should populate', function*() {
+      var string = 'github nightmare';
+      var value = yield nightmare
+        .goto(fixture('manipulation'))
+        .populate('input[type=search]', string)
+        .evaluate(function () {
+          return document.querySelector('input[type=search]').value;
+        });
+      value.should.equal(string);
+    });
+
+    it('should populate a long text', function*() {
+      var string = "";
+      for(var i=0; i<100; i++) string += "github nightmare";
+      var value = yield nightmare
+        .goto(fixture('manipulation'))
+        .populate('input[type=search]', string)
+        .evaluate(function () {
+          return document.querySelector('input[type=search]').value;
+        });
+        value.should.equal(string);
+    });
+
     it('should checkbox', function*() {
       var checkbox = yield nightmare
         .goto(fixture('manipulation'))


### PR DESCRIPTION
As I mentioned in #414, `type()` has an issue that `done()` is called before Electron actually fires an input event.
This is an limitation of Electron's API, but it causes populating a long text into an element to fail in a certain situation.

So this pull request add a `populate` action to provide a more reliable way to populate a text.