### PR TITLE
fix setting electron paths

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -29,7 +29,7 @@ if (process.argv.length > 2) {
   var paths = processArgs.paths;
   if (paths) {
     for (var i in paths) {
-      app.setPath(paths[i]);
+      app.setPath(i, paths[i]);
     }
   }
   var switches = processArgs.switches;

--- a/test/index.js
+++ b/test/index.js
@@ -846,7 +846,7 @@ describe('Nightmare', function () {
     });
 
     it('should be constructable with paths', function*() {
-      nightmare = Nightmare({ paths:{} });
+      nightmare = Nightmare({ paths:{ userData : __dirname } });
       nightmare.should.be.ok;
     });
 


### PR DESCRIPTION
Fix being able to construct nightmare with user defined paths. The electron method takes 2 arguments instead of 1.