### PR TITLE
Uncomment OS X dock hide

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -44,7 +44,11 @@ if (process.argv.length > 2) {
  * Hide the dock
  */
 
-// app.dock.hide();
+// app.dock is not defined when running
+// electron in a platform other than OS X
+if (app.dock) {
+  app.dock.hide();
+}
 
 /**
  * Listen for the app being "ready"


### PR DESCRIPTION
Hiding the application dock icon gives a more polished experience and
abstracts the user from Nightmare's internals.

I believe this was commented out by mistake.