### PR TITLE
Implement dock option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,6 +138,15 @@ var nightmare = Nightmare({
 });
 ```
 
+##### dock (OS X)
+A boolean to optionally show the Electron icon in the dock (defaults to `false`).  This is useful for testing purposes.
+
+```js
+var nightmare = Nightmare({
+  dock: true
+});
+```
+
 #### .useragent(useragent)
 Set the `useragent` used by electron.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -62,6 +62,8 @@ function Nightmare(options) {
     electronArgs.switches = options.switches;
   }
 
+  electronArgs.dock = options.dock || false;
+
   this.proc = proc.spawn(electron_path, [runner].concat(JSON.stringify(electronArgs)), {
     stdio: [null, null, null, 'ipc']
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -46,7 +46,7 @@ if (process.argv.length > 2) {
 
 // app.dock is not defined when running
 // electron in a platform other than OS X
-if (app.dock) {
+if (!processArgs.dock && app.dock) {
   app.dock.hide();
 }
 


### PR DESCRIPTION
The dock icon is now hidden by default by the following pull request:
https://github.com/segmentio/nightmare/pull/426

This OS X specific option allows the dock icon to be shown again, mainly
for testing purposes, and makes no harm in other operating systems.

Fixes: https://github.com/segmentio/nightmare/issues/377