### PR TITLE
Fix failed wait with queued up functions

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -201,7 +201,8 @@ Nightmare.prototype.run = function(fn) {
   // next function
   function next (err, res) {
     var item = steps.shift();
-    if (!item) return done.apply(self, arguments);
+    // Immediately halt execution if an error has been thrown, or we have no more queued up steps.
+    if (err || !item) return done.apply(self, arguments);
     var args = item[1] || [];
     var method = item[0];
     args.push(once(after));

--- a/test/index.js
+++ b/test/index.js
@@ -829,6 +829,20 @@ describe('Nightmare', function () {
       didFail.should.be.true;
     });
 
+    it('should wait and fail with waitTimeout with queued functions', function*() {
+      var didFail = false;
+      try {
+        nightmare = Nightmare({waitTimeout: 254});
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait('foobar')
+          .exists('baz');
+      } catch (e) {
+        didFail = true;
+      }
+      didFail.should.be.true;
+    });
+
     /*
     PENDING FIX UPSTREAM
     https://github.com/atom/electron/issues/1362


### PR DESCRIPTION
If a wait function times out and throws an error with functions queued up (i.e. the wait function is not the last step in a chain of actions) execution should fail immediately, yielding the error that was thrown.

If anything else is missing from this PR let me know and I'll be happy to address. Thanks for all the hard work that has gone into this project, it's a pleasure to use!

It seems like the following GitHub issues are related:
https://github.com/segmentio/nightmare/issues/397
https://github.com/segmentio/nightmare/issues/171
