### PR TITLE
add debug to inspect how electron exited

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -69,8 +69,15 @@ function Nightmare(options) {
   });
 
   this.proc.on('close', function(code) {
-    debug('electron child process exited with code ' + code)
-  })
+    var help = {
+      127: 'command not found - you may not have electron installed correctly',
+      126: 'permission problem or command is not an executable - you may not have all the necessary dependencies for electron',
+      1: 'general error - you may need xvfb',
+      0: 'success!'
+    };
+
+    debug('electron child process exited with code ' + code + ': ' + help[code]);
+  });
 
   process.setMaxListeners(Infinity);
   process.on('uncaughtException', function(err) {

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -68,6 +68,10 @@ function Nightmare(options) {
     stdio: [null, null, null, 'ipc']
   });
 
+  this.proc.on('close', function(code) {
+    debug('electron child process exited with code ' + code)
+  })
+
   process.setMaxListeners(Infinity);
   process.on('uncaughtException', function(err) {
     console.error(err.stack);


### PR DESCRIPTION
Yesterday, I ran up against #224, and before finding all of the helpful info there (_thank you everyone_), I was doing my own debugging based on the [exit code](http://tldp.org/LDP/abs/html/exitcodes.html) of the electron child process. This should hopefully make it easier to identify potential issues when ["it just quits."](https://github.com/segmentio/nightmare/issues/224#issuecomment-177268035)

If you're seeing exit code 127, you may not have electron installed correctly.
If you're seeing exit code 126, you may not have all the necessary dependencies for electron (:wave: gtk).
If you're seeing exit code 1, xvfb is a likely suspect in my experience.
If you're seeing exit code 0, electron appears to be working fine and it's something else.

Do you agree the exit code is helpful when debugging? Should these possible problems be included in the source, README, or wiki?