### PR TITLE
Fixes multiple instances of nightmare using the same waitTimeout value

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -356,28 +356,30 @@ function waitelem (self, selector, done) {
  */
 
 var _timeoutMs = 250;
-function waitfn (self, fn/**, arg1, arg2..., done**/) {
-  self._waitMsPassed = self._waitMsPassed || 0;
-  var args = sliced(arguments);
-  var done = args[args.length-1];
-  var waitDone = function (err, result) {
-    if (result) {
-      self._waitMsPassed = 0;
-      return done();
-    }
-    else if (self.optionWaitTimeout && self._waitMsPassed > self.optionWaitTimeout) {
-      self._waitMsPassed = 0;
-      return done(new Error('.wait() timed out after '+self.optionWaitTimeout+'msec'));
-    }
-    else {
-      self._waitMsPassed += _timeoutMs;
-      setTimeout(function () {
-        waitfn.apply(self, args);
-      }, _timeoutMs);
-    }
-  };
-  var newArgs = [fn, waitDone].concat(args.slice(2,-1));
-  self.evaluate_now.apply(self, newArgs);
+function waitfn() {
+  var waitMsPassed = 0;
+  return tick.apply(this, arguments)
+
+  function tick (self, fn/**, arg1, arg2..., done**/) {
+    var args = sliced(arguments);
+    var done = args[args.length-1];
+    var waitDone = function (err, result) {
+      if (result) {
+        return done();
+      }
+      else if (self.optionWaitTimeout && waitMsPassed > self.optionWaitTimeout) {
+        return done(new Error('.wait() timed out after '+self.optionWaitTimeout+'msec'));
+      }
+      else {
+        waitMsPassed += _timeoutMs;
+        setTimeout(function () {
+          tick.apply(self, args);
+        }, _timeoutMs);
+      }
+    };
+    var newArgs = [fn, waitDone].concat(args.slice(2,-1));
+    self.evaluate_now.apply(self, newArgs);
+  }
 }
 
 /**

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -355,22 +355,22 @@ function waitelem (self, selector, done) {
  * @param {Function} done
  */
 
-var _waitMsPassed = 0;
 var _timeoutMs = 250;
 function waitfn (self, fn/**, arg1, arg2..., done**/) {
+  self._waitMsPassed = self._waitMsPassed || 0;
   var args = sliced(arguments);
   var done = args[args.length-1];
   var waitDone = function (err, result) {
     if (result) {
-      _waitMsPassed = 0;
+      self._waitMsPassed = 0;
       return done();
     }
-    else if (self.optionWaitTimeout && _waitMsPassed > self.optionWaitTimeout) {
-      _waitMsPassed = 0;
+    else if (self.optionWaitTimeout && self._waitMsPassed > self.optionWaitTimeout) {
+      self._waitMsPassed = 0;
       return done(new Error('.wait() timed out after '+self.optionWaitTimeout+'msec'));
     }
     else {
-      _waitMsPassed += _timeoutMs;
+      self._waitMsPassed += _timeoutMs;
       setTimeout(function () {
         waitfn.apply(self, args);
       }, _timeoutMs);


### PR DESCRIPTION
Previously if you had multiple instances of nightmare spun up and all using .wait() they would all share a single waitTimeout counter. This resulted in some elements firing incorrectly and others not firing when they should. Instead the waitTimeout value has been attached to the nightmare instance which also makes it observable. Alternatively you could create a closure but I think this is nicer.