### PR TITLE
Ensure cookies are not shared across tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -465,7 +465,8 @@ describe('Nightmare', function () {
     var nightmare;
 
     beforeEach(function() {
-      nightmare = Nightmare().goto(fixture('cookie'));
+      nightmare = Nightmare({webPreferences: {partition: 'test-partition'}})
+        .goto(fixture('cookie'));
     });
 
     afterEach(function*() {


### PR DESCRIPTION
This makes sure the Nightmare browser session in cookie tests uses a temporary in-memory store so that it doesn't pick up cookies from other runs of nightmare (not a problem in CI because it's a clean environment every time, but a big help when developing locally). Ran into this while working on #468 because some of the cookie tests were failing right off the bat for me!