### PR TITLE
Fix inject an event for console.log

### DIFF
--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -12,19 +12,13 @@ var minstache = require('minstache');
 
 var execute = [
   "(function javascript () {",
-  "  var log = console.log;",
   "  var ipc = __nightmare.ipc;",
-  "  var sliced = __nightmare.sliced;",
-  "  console.log = function() {",
-  "    ipc.send('log', sliced(arguments).map(String));",
-  "  }",
   "  try {",
   "    var response = ({{!src}})({{!args}})",
   "    ipc.send('response', response);",
   "  } catch (e) {",
   "    ipc.send('error', e.message);",
   "  }",
-  "  console.log = log;",
   "})()"
 ].join("\n");
 
@@ -36,19 +30,13 @@ var execute = [
 
 var inject = [
   "(function javascript () {",
-  "  var log = console.log;",
   "  var ipc = __nightmare.ipc;",
-  "  var sliced = __nightmare.sliced;",
-  "  console.log = function() {",
-  "    ipc.send('log', sliced(arguments));",
-  "  }",
   "  try {",
   "    var response = (function () { {{!src}} })()",
   "    ipc.send('response', response);",
   "  } catch (e) {",
   "    ipc.send('error', e.message);",
   "  }",
-  "  console.log = log;",
   "})()"
 ].join("\n");
 

--- a/test/fixtures/events/index.html
+++ b/test/fixtures/events/index.html
@@ -5,9 +5,13 @@
   </head>
   <body>
     <h1>Hello World!</h1>
+    <button>click</button>
   </body>
   <script>
     console.log('my log');
+    document.querySelector('button').addEventListener('click', function() {
+      console.log('clicked');
+    });
     thisIsAnError(foobar);
   </script>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -739,9 +739,12 @@ describe('Nightmare', function () {
         if (type === 'log') log = str
       });
 
-      yield nightmare.goto(fixture('events'))
-
+      yield nightmare.goto(fixture('events'));
       log.should.equal('my log');
+
+      yield nightmare.click('button')
+      log.should.equal('clicked');
+
     });
 
     it('should fire an event on page load failure', function*() {


### PR DESCRIPTION
Currently, `on('console', function() {})` cannot catch `console.log` event when it is called in `nightmare.click(selector)`.

I guess nightmare injects wrong `ipc.send` for `console.log` at `lib/javascript.js`.
nightmare injects an event for `console.log` at `lib/preload.js` already. So the injecting at `lib/javascript.js`  seems to be unnecessary.
Additionally, it doesn't match the interface in between `lib/preload.js` and `lib/javascript.js`.

https://github.com/segmentio/nightmare/blob/master/lib/preload.js#L14


