### PR TITLE
generators is supported in Node.js v4

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,8 +51,10 @@ You can run this with:
 
 ```shell
 npm install nightmare vo
-node --harmony yahoo.js
+node yahoo.js
 ```
+
+If you are using Node.js v0.12 or below, you need to add `--harmony` option.
 
 Or, let's run some mocha tests:
 


### PR DESCRIPTION
generators have been supported since Node.js v4 which was released in Sep 2015.
I guess `--harmony` option is already unnecessary as default.