### PR TITLE
Synchronize screenshots using frame subscription API

### DIFF
--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -1,14 +1,13 @@
 const parent = require('./ipc')(process);
 const EventEmitter = require('events');
 const util = require('util');
+const semver = require('semver');
 
 const RENDER_ELEMENT_ID = '__NIGHTMARE_RENDER__';
 
-// NOTE: we cannot unsubscribe from frame notifications due to:
-//   https://github.com/atom/electron/issues/4441
-// but in a future release of Electron, we should replace this with:
-//   semver.gte(process.versions.electron, '[fixed version]')
-const CAN_UNSUBSCRIBE = false;
+// NOTE: Electron crashes when unsubscribing from frames prior to v0.36.8. For
+// more info, see https://github.com/atom/electron/issues/4441
+const CAN_UNSUBSCRIBE = semver.gte(process.versions.electron, '0.36.8');
 
 module.exports = FrameManager;
 

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -1,4 +1,6 @@
 const parent = require('./ipc')(process);
+const EventEmitter = require('events');
+const util = require('util');
 
 const RENDER_ELEMENT_ID = '__NIGHTMARE_RENDER__';
 
@@ -8,67 +10,68 @@ const RENDER_ELEMENT_ID = '__NIGHTMARE_RENDER__';
 //   semver.gte(process.versions.electron, '[fixed version]')
 const CAN_UNSUBSCRIBE = false;
 
+module.exports = FrameManager;
+
 /**
- * FrameManager is used to coordinate the rendering of a browser window.
- * Because Electron's capturePage() implementation can wind up returning an
- * out-of-date image, this API should be used when screenshotting to ensure
- * that a screenshot will be up-to-date.
- *
- * Instantiate a FrameManager with an Electron BrowserWindow instance,
- * Then call `waitForFrame(callback)` with a callback to get a frame.
+ * FrameManager is an event emitter that produces a 'data' event each time the
+ * browser window draws to the screen.
+ * The primary use for this is to ensure that calling `capturePage()` on a
+ * window will produce an image that is up-to-date with the state of the page.
  */
-module.exports = function FrameManager(window) {
+function FrameManager(window) {
+  if (!(this instanceof FrameManager)) return new FrameManager(window);
+
+  EventEmitter.call(this);
   var subscribed = false;
   var requestedFrame = false;
-  var callbacks = [];
+  var self = this;
+
+  this.on('newListener', subscribe);
+  this.on('removeListener', unsubscribe);
 
   function subscribe() {
     if (!subscribed) {
+      parent.emit('log', 'subscribing to browser window frames');
       window.webContents.beginFrameSubscription(receiveFrame);
     }
   }
 
   function unsubscribe() {
-    if (CAN_UNSUBSCRIBE && !callbacks.length) {
+    if (CAN_UNSUBSCRIBE && !self.listenerCount('data')) {
+      parent.emit('log', 'unsubscribing from browser window frames')
       window.webContents.endFrameSubscription();
       subscribed = false;
     }
   }
 
-  function receiveFrame() {
-    var args = arguments;
+  function receiveFrame(buffer) {
     requestedFrame = false;
-    callbacks
-      .splice(0, callbacks.length)
-      .forEach(function(callback) {
-        callback.apply(null, args);
-      });
-
-    // unsubscribe is called last in case callbacks added new subscribers
-    unsubscribe();
+    self.emit('data', buffer);
   }
 
-  function requestFrame() {
+  /**
+   * In addition to listening for events, calling `requestFrame` will ensure
+   * that a frame is queued up to render (instead of just waiting for the next
+   * time the browser chooses to draw a frame).
+   * @param  {Function} [callback] Called when the frame is rendered.
+   */
+  this.requestFrame = function(callback) {
+    if (callback) {
+      this.once('data', callback);
+    }
     if (!requestedFrame) {
+      parent.emit('log', 'altering page to force rendering');
       requestedFrame = true;
       window.webContents.executeJavaScript(
         '(' + triggerRender + ')("' + RENDER_ELEMENT_ID + '")');
     }
-  }
-
-  return {
-    waitForFrame: function(callback) {
-      if (callbacks.indexOf(callback === -1)) {
-        callbacks.push(callback);
-      }
-      subscribe();
-      requestFrame();
-    }
-  }
+  };
 };
 
-// this function runs in the render process and alters the render tree, forcing
-// Chromium to draw a new frame.
+util.inherits(FrameManager, EventEmitter);
+
+// this runs in the render process and alters the render tree, forcing Chromium
+// to draw a new frame.
 var triggerRender = (function (id) {
   var renderElement = document.getElementById(id);
   if (renderElement) {

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -1,13 +1,8 @@
 const parent = require('./ipc')(process);
 const EventEmitter = require('events');
 const util = require('util');
-const semver = require('semver');
 
 const RENDER_ELEMENT_ID = '__NIGHTMARE_RENDER__';
-
-// NOTE: Electron crashes when unsubscribing from frames prior to v0.36.8. For
-// more info, see https://github.com/atom/electron/issues/4441
-const CAN_UNSUBSCRIBE = semver.gte(process.versions.electron, '0.36.8');
 
 module.exports = FrameManager;
 
@@ -36,7 +31,7 @@ function FrameManager(window) {
   }
 
   function unsubscribe() {
-    if (CAN_UNSUBSCRIBE && !self.listenerCount('data')) {
+    if (!self.listenerCount('data')) {
       parent.emit('log', 'unsubscribing from browser window frames')
       window.webContents.endFrameSubscription();
       subscribed = false;

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -1,0 +1,88 @@
+const parent = require('./ipc')(process);
+
+const RENDER_ELEMENT_ID = '__NIGHTMARE_RENDER__';
+
+// NOTE: we cannot unsubscribe from frame notifications due to:
+//   https://github.com/atom/electron/issues/4441
+// but in a future release of Electron, we should replace this with:
+//   semver.gte(process.versions.electron, '[fixed version]')
+const CAN_UNSUBSCRIBE = false;
+
+/**
+ * FrameManager is used to coordinate the rendering of a browser window.
+ * Because Electron's capturePage() implementation can wind up returning an
+ * out-of-date image, this API should be used when screenshotting to ensure
+ * that a screenshot will be up-to-date.
+ *
+ * Instantiate a FrameManager with an Electron BrowserWindow instance,
+ * Then call `waitForFrame(callback)` with a callback to get a frame.
+ */
+module.exports = function FrameManager(window) {
+  var subscribed = false;
+  var requestedFrame = false;
+  var callbacks = [];
+
+  function subscribe() {
+    if (!subscribed) {
+      window.webContents.beginFrameSubscription(receiveFrame);
+    }
+  }
+
+  function unsubscribe() {
+    if (CAN_UNSUBSCRIBE && !callbacks.length) {
+      window.webContents.endFrameSubscription();
+      subscribed = false;
+    }
+  }
+
+  function receiveFrame() {
+    var args = arguments;
+    requestedFrame = false;
+    callbacks
+      .splice(0, callbacks.length)
+      .forEach(function(callback) {
+        callback.apply(null, args);
+      });
+
+    // unsubscribe is called last in case callbacks added new subscribers
+    unsubscribe();
+  }
+
+  function requestFrame() {
+    if (!requestedFrame) {
+      requestedFrame = true;
+      window.webContents.executeJavaScript(
+        '(' + triggerRender + ')("' + RENDER_ELEMENT_ID + '")');
+    }
+  }
+
+  return {
+    waitForFrame: function(callback) {
+      if (callbacks.indexOf(callback === -1)) {
+        callbacks.push(callback);
+      }
+      subscribe();
+      requestFrame();
+    }
+  }
+};
+
+// this function runs in the render process and alters the render tree, forcing
+// Chromium to draw a new frame.
+var triggerRender = (function (id) {
+  var renderElement = document.getElementById(id);
+  if (renderElement) {
+    renderElement.remove();
+  }
+  else {
+    renderElement = document.createElement('div');
+    renderElement.id = id;
+    renderElement.setAttribute('style',
+      'position: absolute;' +
+      'left: 0;' +
+      'top: 0;' +
+      'width: 1px;' +
+      'height: 1px;');
+    document.documentElement.appendChild(renderElement);
+  }
+}).toString();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -249,8 +249,70 @@ app.on('ready', function() {
       parent.emit('screenshot', img.toPng());
     }];
     if (clip) args.unshift(clip);
-    win.capturePage.apply(win, args);
+    frameManager.waitForFrame(function() {
+      win.capturePage.apply(win, args);
+    });
   });
+
+  var frameManager = (function() {
+    // NOTE: we cannot unsubscribe from frame notifications due to:
+    //   https://github.com/atom/electron/issues/4441
+    // but in a future release of Electron, we should replace this with:
+    //   semver.gte(process.versions.electron, '[fixed version]')
+    var canUnsubscribe = false;
+    var subscribed = false;
+    var renderRequested = false;
+    var callbacks = [];
+    return {
+      waitForFrame: function(callback) {
+        if (callbacks.indexOf(callback === -1)) {
+          callbacks.push(callback);
+        }
+        if (!subscribed) {
+          win.webContents.beginFrameSubscription(this.receiveFrame);
+        }
+        if (!renderRequested) {
+          forceRender();
+          renderRequested = true;
+        }
+      },
+      receiveFrame: function() {
+        renderRequested = false;
+        if (canUnsubscribe) {
+          subscribed = false;
+          win.webContents.endFrameSubscription();
+        }
+        var args = arguments;
+        callbacks
+          .splice(0, callbacks.length)
+          .forEach(function(callback) {
+            callback.apply(null, args);
+          });
+      }
+    };
+
+    // force a frame to draw by adding a tiny transparent div (or removing it)
+    function forceRender() {
+      win.webContents.executeJavaScript('(' + function() {
+        var renderElement = document.getElementById('__NIGHTMARE_RENDER__');
+        if (renderElement) {
+          renderElement.remove();
+        }
+        else {
+          renderElement = document.createElement('div');
+          renderElement.id = '__NIGHTMARE_RENDER__';
+          renderElement.setAttribute('style',
+            'position: absolute;' +
+            'left: 0;' +
+            'top: 0;' +
+            'width: 1px;' +
+            'height: 1px;' +
+            'z-index: -100;');
+          document.documentElement.appendChild(renderElement);
+        }
+      } + ')()');
+    }
+  })();
 
   /**
    * pdf

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -11,6 +11,7 @@ var sliced = require('sliced');
 var renderer = require('electron').ipcMain;
 var app = require('electron').app;
 var fs = require('fs');
+var FrameManager = require('./frame-manager');
 
 /**
  * Handle uncaught exceptions in the main electron process
@@ -56,6 +57,7 @@ if (!processArgs.dock && app.dock) {
 
 app.on('ready', function() {
   var win;
+  var frameManager;
 
   /**
    * create a browser window
@@ -81,6 +83,8 @@ app.on('ready', function() {
      * Window Docs:
      * https://github.com/atom/electron/blob/master/docs/api/browser-window.md
      */
+
+    frameManager = FrameManager(win);
 
     /**
      * Window options
@@ -253,66 +257,6 @@ app.on('ready', function() {
       win.capturePage.apply(win, args);
     });
   });
-
-  var frameManager = (function() {
-    // NOTE: we cannot unsubscribe from frame notifications due to:
-    //   https://github.com/atom/electron/issues/4441
-    // but in a future release of Electron, we should replace this with:
-    //   semver.gte(process.versions.electron, '[fixed version]')
-    var canUnsubscribe = false;
-    var subscribed = false;
-    var renderRequested = false;
-    var callbacks = [];
-    return {
-      waitForFrame: function(callback) {
-        if (callbacks.indexOf(callback === -1)) {
-          callbacks.push(callback);
-        }
-        if (!subscribed) {
-          win.webContents.beginFrameSubscription(this.receiveFrame);
-        }
-        if (!renderRequested) {
-          forceRender();
-          renderRequested = true;
-        }
-      },
-      receiveFrame: function() {
-        renderRequested = false;
-        if (canUnsubscribe) {
-          subscribed = false;
-          win.webContents.endFrameSubscription();
-        }
-        var args = arguments;
-        callbacks
-          .splice(0, callbacks.length)
-          .forEach(function(callback) {
-            callback.apply(null, args);
-          });
-      }
-    };
-
-    // force a frame to draw by adding a tiny transparent div (or removing it)
-    function forceRender() {
-      win.webContents.executeJavaScript('(' + function() {
-        var renderElement = document.getElementById('__NIGHTMARE_RENDER__');
-        if (renderElement) {
-          renderElement.remove();
-        }
-        else {
-          renderElement = document.createElement('div');
-          renderElement.id = '__NIGHTMARE_RENDER__';
-          renderElement.setAttribute('style',
-            'position: absolute;' +
-            'left: 0;' +
-            'top: 0;' +
-            'width: 1px;' +
-            'height: 1px;' +
-            'z-index: -100;');
-          document.documentElement.appendChild(renderElement);
-        }
-      } + ')()');
-    }
-  })();
 
   /**
    * pdf

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -253,7 +253,7 @@ app.on('ready', function() {
       parent.emit('screenshot', img.toPng());
     }];
     if (clip) args.unshift(clip);
-    frameManager.waitForFrame(function() {
+    frameManager.requestFrame(function() {
       win.capturePage.apply(win, args);
     });
   });

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
     "basic-auth-connect": "^1.0.0",
     "chai": "^3.4.1",
     "express": "^4.13.3",
-    "mocha-generators": "^1.2.0",
     "mocha": "^2.3.0",
+    "mocha-generators": "^1.2.0",
     "multer": "1.1.0",
+    "pngjs": "^2.2.0",
     "serve-static": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "object-assign": "^4.0.1",
     "once": "^1.3.3",
     "rimraf": "^2.4.3",
+    "semver": "^5.1.0",
     "sliced": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron-prebuilt": "^0.36.7",
+    "electron-prebuilt": "^0.36.8",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",
@@ -29,7 +29,6 @@
     "object-assign": "^4.0.1",
     "once": "^1.3.3",
     "rimraf": "^2.4.3",
-    "semver": "^5.1.0",
     "sliced": "1.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -655,7 +655,7 @@ describe('Nightmare', function () {
     // the timing accuracy of screenshots -- it might pass once, but likely not
     // several times in a row.
     for (var i = 0; i < 3; i++) {
-      it('should screenshot an up-to-date image of the page (' + i + ')', function *() {
+      it('should screenshot an up-to-date image of the page (' + i + ')', function*() {
         var image = yield nightmare
           .goto('about:blank')
           .viewport(100, 100)
@@ -669,6 +669,21 @@ describe('Nightmare', function () {
         firstPixel.should.deep.equal([0, 153, 0]);
       });
     }
+
+    it('should screenshot an an idle page', function*() {
+      var image = yield nightmare
+        .goto('about:blank')
+        .viewport(100, 100)
+        .evaluate(function() { document.body.style.background = '#900';  })
+        .evaluate(function() { document.body.style.background = '#090';  })
+        .wait(1000)
+        .screenshot();
+
+      var png = new PNG();
+      var imageData = yield png.parse.bind(png, image);
+      var firstPixel = Array.from(imageData.data.slice(0, 3));
+      firstPixel.should.deep.equal([0, 153, 0]);
+    });
 
     it('should load jquery correctly', function*() {
       var loaded = yield nightmare

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ var fs = require('fs');
 var mkdirp = require('mkdirp');
 var path = require('path');
 var rimraf = require('rimraf');
+var PNG = require('pngjs').PNG;
 
 /**
  * Temporary directory
@@ -649,6 +650,25 @@ describe('Nightmare', function () {
       Buffer.isBuffer(image).should.be.true;
       image.length.should.be.at.least(300);
     });
+
+    // repeat this test 3 times, since the concern here is non-determinism in
+    // the timing accuracy of screenshots -- it might pass once, but likely not
+    // several times in a row.
+    for (var i = 0; i < 3; i++) {
+      it('should screenshot an up-to-date image of the page (' + i + ')', function *() {
+        var image = yield nightmare
+          .goto('about:blank')
+          .viewport(100, 100)
+          .evaluate(function() { document.body.style.background = '#900';  })
+          .evaluate(function() { document.body.style.background = '#090';  })
+          .screenshot();
+
+        var png = new PNG();
+        var imageData = yield png.parse.bind(png, image);
+        var firstPixel = Array.from(imageData.data.slice(0, 3));
+        firstPixel.should.deep.equal([0, 153, 0]);
+      });
+    }
 
     it('should load jquery correctly', function*() {
       var loaded = yield nightmare

--- a/test/index.js
+++ b/test/index.js
@@ -659,8 +659,8 @@ describe('Nightmare', function () {
         var image = yield nightmare
           .goto('about:blank')
           .viewport(100, 100)
-          .evaluate(function() { document.body.style.background = '#900';  })
-          .evaluate(function() { document.body.style.background = '#090';  })
+          .evaluate(function() { document.body.style.background = '#900'; })
+          .evaluate(function() { document.body.style.background = '#090'; })
           .screenshot();
 
         var png = new PNG();
@@ -674,8 +674,8 @@ describe('Nightmare', function () {
       var image = yield nightmare
         .goto('about:blank')
         .viewport(100, 100)
-        .evaluate(function() { document.body.style.background = '#900';  })
-        .evaluate(function() { document.body.style.background = '#090';  })
+        .evaluate(function() { document.body.style.background = '#900'; })
+        .evaluate(function() { document.body.style.background = '#090'; })
         .wait(1000)
         .screenshot();
 


### PR DESCRIPTION
This is meant to address #468.

The basic gist of the change is to add a `FrameManager` object that emits events whenever the browsers renders a new frame and use that to figure out when to call `capturePage()`.

Some notes:

- At current, this can trigger pretty massive memory consumption. Due to a bug in Electron (https://github.com/atom/electron/issues/4441), trying to unsubscribe from frames can cause a crash (and there's no way to know whether that will happen ahead of time and smartly wait until it's safe). That means that, once we start subscribing, we don't stop until the window is closed (i.e. until nightmare's `end()` method is called).

  For reference, a really simple nightmare session takes 20-30 MB of RAM on my machine, but once a screenshot is taken, that can boost to as high as 360 MB. (You can actually watch V8 manage memory here—the electron process will slowly grow to a few hundred megabytes and then get chopped back down to less than 50, then start growing again…)

  Anyway, there's already a patch on the way for this in Electron (https://github.com/atom/electron/pull/4451), but I don't know when it will land and ship. Once it does, the code here can be very easily adjusted to smartly unsubscribe if it's safe based on the version of Electron we're running in: https://github.com/Mr0grog/nightmare/blob/a179e2ed6e7b1d72d8cd518a9b464c0bf0a68220/lib/frame-manager.js#L11

- FrameManager is an event emitter, so it could pretty easily support some interesting other behaviors in the future, like rendering video of the page in action. It knows how to manage frame subscriptions in Electron when listeners are attached/detached.

- It's likely this would be better off in that future case as a readable stream, but managing push/pull/buffering vs. whenever Chromium decides to render a frame seemed potentially non-trivial (or at least require lots of testing and probably some nuance with finding an appropriate high-water mark), so I didn't bother with that for now.

Anyway, hope this helps and looks good to you all. It's covered by tests, too. Let me know if there's anything that should be changed.