### PR TITLE
Fix Readme examples to work with vo 2.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ Let's search on Yahoo:
 var Nightmare = require('nightmare');
 var vo = require('vo');
 
-vo(function* () {
+vo.pipeline(function* () {
   var nightmare = Nightmare({ show: true });
   var link = yield nightmare
     .goto('http://yahoo.com')
@@ -431,11 +431,12 @@ $ npm install --save nightmare
 #### Execution
 Nightmare is a node module that can be used in a Node.js script or module. Here's a simple script to open a web page:
 ```js
-var Nightmare = require('../nightmare');
+var Nightmare = require('nightmare');
 var vo = require('vo');
 
-vo(run)(function(err, result) {
-  if (err) throw err;
+vo(run)(function(err) {
+  if (err) console.log(err);
+  process.exit();
 });
 
 function *run() {


### PR DESCRIPTION
Figured the docs should be updated so more people don't have trouble as in #477.

I wound up making significant changes to the last example so that it would actually still work safely in the case of an error. It seems that, if the vo callback that is handling the error throws, then vo just continues execution as normal in the `run` function and doesn't raise the error. So `undefined` is logged and it looks like no error happened, but no title was found, either. I changed it to log the error, but that also means the handler has to call `process.exit()` otherwise it hangs because `nightmare.end()` is never called because of the error getting the title. Maybe it would just be better to use try/catch/finally instead, since generators allow that:

```js
vo(run)();

function *run() {
  var nightmare = Nightmare();
  try {
    var title = yield nightmare
      .goto('http://cnn.com')
      .evaluate(function() {
        return document.title;
      });
    console.log(title);
  }
  catch(error) {
    console.error(error);
  }
  finally {
    yield nightmare.end();
  }
}
```