### PR TITLE
Kill electron process when Nightmare's process exits/dies

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -74,7 +74,14 @@ function Nightmare(options) {
     endInstance(self);
   });
 
-  process.on('exit', endInstance.bind(null, self));
+  // if the process nightmare is running in dies, make sure to kill electron
+  var endSelf = endInstance.bind(null, self);
+  process.on('exit', endSelf);
+  process.on('SIGINT', endSelf);
+  process.on('SIGTERM', endSelf);
+  process.on('SIGQUIT', endSelf);
+  process.on('SIGHUP', endSelf);
+  process.on('SIGBREAK', endSelf);
 
   // initial state
   this.state = 'initial';

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -71,9 +71,10 @@ function Nightmare(options) {
   process.setMaxListeners(Infinity);
   process.on('uncaughtException', function(err) {
     console.error(err.stack);
-    self.proc.disconnect();
-    self.proc.kill();
+    endInstance(self);
   });
+
+  process.on('exit', endInstance.bind(null, self));
 
   // initial state
   this.state = 'initial';
@@ -104,11 +105,10 @@ function Nightmare(options) {
   });
 
   this.child.on('uncaughtException', function(stack) {
-    console.error('Nightmare runner error:\n\n%s\n', '\t' + stack.replace(/\n/g, '\n\t'))
-    self.proc.disconnect()
-    self.proc.kill()
-    process.exit(1)
-  })
+    console.error('Nightmare runner error:\n\n%s\n', '\t' + stack.replace(/\n/g, '\n\t'));
+    endInstance(self);
+    process.exit(1);
+  });
 
   this.child.on('page', function(type) {
     log.apply(null, ['page-' + type].concat(sliced(arguments, 1)));
@@ -129,6 +129,14 @@ function Nightmare(options) {
   this.child.on('crashed', function () { log('crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('plugin-crashed', function () { log('plugin-crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('destroyed', function () { log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments))); });
+}
+
+function endInstance(instance) {
+  if (instance.proc.connected) {
+    instance.proc.disconnect();
+    instance.proc.kill();
+    instance.ended = true;
+  }
 }
 
 /**
@@ -218,9 +226,7 @@ Nightmare.prototype.run = function(fn) {
   function done () {
     self.running = false;
     if (self.ending) {
-      self.proc.disconnect();
-      self.proc.kill();
-      self.ended = true;
+      endInstance(self);
     }
     return fn.apply(self, arguments);
   }

--- a/test/files/nightmare-unended.js
+++ b/test/files/nightmare-unended.js
@@ -1,0 +1,10 @@
+// This script is used to start a nightmare run but not end it. It reports its
+// Electron process's pid, then we kill it and test to see whether that pid is
+// still running.
+var Nightmare = require('../..');
+var nightmare = Nightmare();
+nightmare
+  .goto('about:blank')
+  .run(function() {
+    process.send(nightmare.proc.pid);
+  });


### PR DESCRIPTION
If the process Nightmare is running in exits or is killed (via a graceful process.exit() call, interrupt signal, etc), this ensures that the underlying Electron process Nightmare is managing also gets closed and cleaned up so users don't have have tons of rogue Electrons running.

Fixes #474.