### PR TITLE
Yahoo example, vo removal

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,16 +32,16 @@ var nightmare = Nightmare({ show: true })
 nightmare
   .goto('http://yahoo.com')
   .type('input[title="Search"]', 'github nightmare')
-  .click('#UHSearchWeb')
+  .click('#uh-search-button')
   .wait('#main')
   .evaluate(function () {
     return document.querySelector('#main .searchCenterMiddle li a').href
   })
+  .end()
   .then(function (result) {
     console.log(result)
   })
 
-nightmare.end()
 ```
 
 You can run this with:

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ Many thanks to [@matthewmueller](https://github.com/matthewmueller) for his help
 Let's search on Yahoo:
 
 ```js
-var Nightmare = require('./');
+var Nightmare = require('nightmare');
 var nightmare = Nightmare({ show: true })
 
 nightmare
@@ -428,28 +428,22 @@ $ npm install --save nightmare
 #### Execution
 Nightmare is a node module that can be used in a Node.js script or module. Here's a simple script to open a web page:
 ```js
-var Nightmare = require('../nightmare');
-var vo = require('vo');
+var Nightmare = require('nightmare'),
+  nightmare = Nightmare();
 
-vo(run)(function(err, result) {
-  if (err) throw err;
-});
-
-function *run() {
-  var nightmare = Nightmare();
-  var title = yield nightmare
-    .goto('http://cnn.com')
-    .evaluate(function() {
-      return document.title;
-    });
-  console.log(title);
-  yield nightmare.end();
-}
+nightmare.goto('http://cnn.com')
+  .evaluate(function(){
+    return document.title;
+  })
+  .end()
+  .then(function(title){
+    console.log(title);
+  })
 ```
 If you save this as `cnn.js`, you can run it on the command line like this:
 
 ```bash
-npm install vo nightmare
+npm install nightmare
 node --harmony cnn.js
 ```
 


### PR DESCRIPTION
Fixes #490, addresses @Mr0grog's comments from #482.  Also removes `vo` from the CNN example based on [@matthewmueller's comment](https://github.com/segmentio/nightmare/pull/482#issuecomment-184525044).

That being said: why the move to excise `vo`?  Is it to remove the external dependency?  I still think showing an example of using `vo` or `co` with `yield` is helpful.  Thoughts?