### PR TITLE
Add webRequest APIs

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -608,3 +608,49 @@ exports.cookies.clear = function (name, done) {
   this.child.once('cookie.clear', done);
   this.child.emit('cookie.clear', cookies);
 };
+
+/**
+ * The webRequest namespace of webRequest Generator
+ */
+
+exports.webRequest = {};
+
+function generateWebRequestAPI(event) {
+
+  /**
+   * The webRequest API Function
+   *
+   * @param {Object} filter (optional)
+   * @param {Function} listener
+   */
+  return function() {
+    var args = sliced(arguments);
+    var newArgs = [];
+
+    if ( typeof args[0] === 'object') {
+      newArgs.push(args.shift());
+    } else {
+      newArgs.push(String(args.shift()));
+    }
+
+    if ( args.length > 1 ) {
+      newArgs.push(String(args.shift()));
+    }
+
+    var done = args.shift();
+
+    debug(event + '()');
+
+    this.child.once(event, done);
+    this.child.emit.apply(this, [event].concat(newArgs));
+  }
+}
+
+exports.webRequest.onBeforeRequest = generateWebRequestAPI('webRequest.onBeforeRequest');
+exports.webRequest.onBeforeSendHeaders = generateWebRequestAPI('webRequest.onBeforeSendHeaders');
+exports.webRequest.onSendHeaders = generateWebRequestAPI('webRequest.onSendHeaders');
+exports.webRequest.onHeadersReceived = generateWebRequestAPI('webRequest.onHeadersReceived');
+exports.webRequest.onResponseStarted = generateWebRequestAPI('webRequest.onResponseStarted');
+exports.webRequest.onBeforeRedirect = generateWebRequestAPI('webRequest.onBeforeRedirect');
+exports.webRequest.onCompleted = generateWebRequestAPI('webRequest.onCompleted');
+exports.webRequest.onErrorOccurred = generateWebRequestAPI('webRequest.onErrorOccurred');

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -129,6 +129,14 @@ function Nightmare(options) {
   this.child.on('crashed', function () { log('crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('plugin-crashed', function () { log('plugin-crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('destroyed', function () { log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onBeforeRequest', function() { log('webRequest.onBeforeRequest', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onBeforeSendHeaders', function() { log('webRequest.onBeforeSendHeaders', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onSendHeaders', function() { log('webRequest.onSendHeaders', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onHeadersReceived', function() { log('webRequest.onHeadersReceived', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onResponseStarted', function() { log('webRequest.onResponseStarted', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onBeforeRedirect', function() { log('webRequest.onBeforeRedirect', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onCompleted', function() { log('webRequest.onCompleted', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('webRequest.onErrorOccurred', function() { log('webRequest.onErrorOccurred', JSON.stringify(Array.prototype.slice.call(arguments))); });
 }
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -347,6 +347,185 @@ app.on('ready', function() {
   });
 
   /**
+   * webRequest.onBeforeRequest
+   */
+
+  parent.on('webRequest.onBeforeRequest', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+    var arg2 = args.length ? args.pop() : null;
+
+    if (typeof arg1 === 'object' && arg2) {
+      win.webContents.session.webRequest.onBeforeRequest(arg1, function (details, cb) {
+        parent.emit('webRequest.onBeforeRequest', details);
+        var fn = new Function('with(this){return ' + arg2 + '}').call({});
+        fn(details, cb);
+      });
+    } else if (!!arg1) {
+      win.webContents.session.webRequest.onBeforeRequest(function (details, cb) {
+        parent.emit('webRequest.onBeforeRequest', details);
+        var fn = new Function('with(this){return ' + arg1 + '}').call({});
+        fn(details, cb);
+      });
+    } else {
+      win.webContents.session.webRequest.onBeforeRequest(null);
+    }
+
+    parent.emit('webRequest.onBeforeRequest');
+  });
+
+  /**
+   * webRequest.onBeforeSendHeaders
+   */
+
+  parent.on('webRequest.onBeforeSendHeaders', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+    var arg2 = args.length ? args.pop() : null;
+
+    if (typeof arg1 === 'object' && arg2) {
+      win.webContents.session.webRequest.onBeforeSendHeaders(arg1, function (details, cb) {
+        parent.emit('webRequest.onBeforeSendHeaders', details);
+        var fn = new Function('with(this){return ' + arg2 + '}').call({});
+        return fn(details, cb);
+      });
+    } else if ( arg1 ) {
+      win.webContents.session.webRequest.onBeforeSendHeaders(function (details, cb) {
+        parent.emit('webRequest.onBeforeSendHeaders', details);
+        var fn = new Function('with(this){return ' + arg1 + '}').call({});
+        return fn(details, cb);
+      });
+    } else {
+      win.webContents.session.webRequest.onBeforeSendHeaders(null);
+    }
+
+    parent.emit('webRequest.onBeforeSendHeaders');
+  });
+
+  /**
+   * webRequest.onSendHeaders
+   */
+
+  parent.on('webRequest.onSendHeaders', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+
+    if (typeof arg1 === 'object') {
+      win.webContents.session.webRequest.onSendHeaders(arg1, function (details) {
+        parent.emit('webRequest.onSendHeaders', details);
+      });
+    } else {
+      win.webContents.session.webRequest.onSendHeaders(null);
+    }
+
+    parent.emit('webRequest.onSendHeaders');
+  });
+
+  /**
+   * webRequest.onHeadersReceived
+   */
+
+  parent.on('webRequest.onHeadersReceived', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+    var arg2 = args.length ? args.pop() : { cancel : false };
+
+    if ( typeof arg1 === 'object' && arg2 ) {
+      win.webContents.session.webRequest.onHeadersReceived(arg1, function(details, callback) {
+        parent.emit('webRequest.onHeadersReceived', details);
+        var fn = new Function('with(this){return ' + arg2 + '}').call({});
+        return fn(details, callback);
+      });
+    } else if ( arg1 ) {
+      win.webContents.session.webRequest.onHeadersReceived(function(details, callback) {
+        parent.emit('webRequest.onHeadersReceived', details);
+        var fn = new Function('with(this){return ' + arg1 + '}').call({});
+        return fn(details, callback);
+      });
+    } else {
+      win.webContents.session.webRequest.onHeadersReceived(null);
+    }
+
+    parent.emit('webRequest.onHeadersReceived');
+  });
+
+  /**
+   * webRequest.onResponseStarted
+   */
+
+  parent.on('webRequest.onResponseStarted', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+
+    if ( typeof arg1 === 'object' ) {
+      win.webContents.session.webRequest.onResponseStarted(arg1, function(details) {
+        parent.emit('webRequest.onResponseStarted', details);
+      });
+    } else {
+      win.webContents.session.webRequest.onResponseStarted(null);
+    }
+
+    parent.emit('webRequest.onResponseStarted');
+  });
+
+  /**
+   * webRequest.onBeforeRedirect
+   */
+
+  parent.on('webRequest.onBeforeRedirect', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+
+    if ( typeof arg1 === 'object' ) {
+      win.webContents.session.webRequest.onBeforeRedirect(arg1, function(details) {
+        parent.emit('webRequest.onBeforeRedirect', details);
+      });
+    } else {
+      win.webContents.session.webRequest.onBeforeRedirect(null);
+    }
+
+    parent.emit('webRequest.onBeforeRedirect');
+  });
+
+  /**
+   * webRequest.onCompleted
+   */
+
+  parent.on('webRequest.onCompleted', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+
+    if ( typeof arg1 === 'object' ) {
+      win.webContents.session.webRequest.onCompleted(arg1, function(details) {
+        parent.emit('webRequest.onCompleted', details);
+      });
+    } else {
+      win.webContents.session.webRequest.onCompleted(null);
+    }
+
+    parent.emit('webRequest.onCompleted');
+  });
+
+  /**
+   * webRequest.onErrorOccurred
+   */
+
+  parent.on('webRequest.onErrorOccurred', function () {
+    var args = sliced(arguments);
+    var arg1 = args.length ? args.pop() : null;
+
+    if ( typeof arg1 === 'object' ) {
+      win.webContents.session.webRequest.onErrorOccurred(arg1, function (details) {
+        parent.emit('webRequest.onErrorOccurred', details);
+      });
+    } else {
+      win.webContents.session.webRequest.onErrorOccurred(null);
+    }
+
+    parent.emit('webRequest.onErrorOccurred');
+  });
+
+  /**
    * Send "ready" event to the parent process
    */
 

--- a/test/fixtures/webrequest/index.html
+++ b/test/fixtures/webrequest/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Nightmare not lading fonts - DEMO</title>
+    <style>
+      body {
+        font-family: Oswald;
+      }
+    </style>
+    <link href='http://fonts.googleapis.com/css?family=Oswald' rel='stylesheet'>
+  </head>
+  <body>
+    <h1>This should be written in Oswald.</h1>
+    <script src="http://code.jquery.com/jquery.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
I added the [`webRequest` API](https://github.com/atom/electron/blob/master/docs/api/session.md#seswebrequest) feature which is related to #461.

Please consider the way of working except name of api.

Still, I prefer to make this as a plugin like the way of @rosshinkley [made] (https://github.com/rosshinkley/nightmare-load-filter).
