### PR TITLE
Enable support for IFrames, fixes #203

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -173,11 +173,12 @@ It can be called again from inside an iframe, so you can traverse a series of em
 
 To go back to the root `document`, call `.exitIframe()`.
 
-If the iframe you are entering comes from another domain, you may want to create your first `Nightmare` instance with `{'web-preferences': {'web-security': false}}` as in:
+If the iframe you are entering comes from another domain, you may want to create your first `Nightmare` instance with `{'webPreferences': {'webSecurity': false}}` as in:
 
 ```
-var nightmare = Nightmare({show: true, 'web-preferences': {'web-security': false}});
+var nightmare = Nightmare({show: true, 'webPreferences': {'webSecurity': false}});
 ```
+You may want to check those and other possible configurations in the [Electron BrowserWindow options](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions) (the same documentation listed above in [Nightmare(options)](#nightmareoptions)).
 
 #### .exitIframe()
 Exit from all iframe elements entered with `.enterIframe(selector)` and return to the root document.

--- a/Readme.md
+++ b/Readme.md
@@ -164,6 +164,26 @@ Go forward to the next page.
 #### .refresh()
 Refresh the current page.
 
+#### .enterIframe(selector)
+Enter in the `selector` iframe element and use its `document` as the `document` for subsequent actions.
+
+Any action called after this will act as if it was called from inside the iframe element.
+
+It can be called again from inside an iframe, so you can traverse a series of embedded iframes.
+
+To go back to the root `document`, call `.exitIframe()`.
+
+If the iframe you are entering comes from another domain, you may want to create your first `Nightmare` instance with `{'web-preferences': {'web-security': false}}` as in:
+
+```
+var nightmare = Nightmare({show: true, 'web-preferences': {'web-security': false}});
+```
+
+#### .exitIframe()
+Exit from all iframe elements entered with `.enterIframe(selector)` and return to the root document.
+
+Any action called after this will act as normal.
+
 #### .click(selector)
 Clicks the `selector` element once.
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -295,6 +295,20 @@ exports.enterToIframe = function(selector, done){
     }, done, selector);
 };
 
+/*
+ * Exit from all Iframes and go to the main document
+ *
+ * @param {Function} done
+ */
+
+exports.exitIframe = function(done){
+  debug('.exitIframe()');
+  this.evaluate_now(function() {
+      var element = __nightmare.rootDocument;
+      __nightmare.currentDocument = element;
+    }, done);
+};
+
 /**
  * Wait
  *

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -280,6 +280,21 @@ exports.refresh = function(done) {
   }, done);
 };
 
+/*
+ * Enter to IFrame and run actions as if from inside
+ *
+ * @param {String} selector
+ * @param {Function} done
+ */
+
+exports.enterToIframe = function(selector, done){
+  debug('.enterToIframe() ' + selector);
+  this.evaluate_now(function(selector) {
+      var element = __nightmare.currentDocument.querySelector(selector).contentDocument;
+      __nightmare.currentDocument = element;
+    }, done, selector);
+};
+
 /**
  * Wait
  *

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -287,8 +287,8 @@ exports.refresh = function(done) {
  * @param {Function} done
  */
 
-exports.enterToIframe = function(selector, done){
-  debug('.enterToIframe() ' + selector);
+exports.enterIframe = function(selector, done){
+  debug('.enterIframe() ' + selector);
   this.evaluate_now(function(selector) {
       var element = __nightmare.currentDocument.querySelector(selector).contentDocument;
       __nightmare.currentDocument = element;

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -246,6 +246,9 @@ Nightmare.prototype.run = function(fn) {
  * you should not use this, unless you know what you're doing
  * it should be used for plugins and custom actions, not for
  * normal API usage
+ *
+ * It also enables running actions in inner frames by embedding action names
+ * with a custom document element.
  */
 
 Nightmare.prototype.evaluate_now = function(js_fn, done) {
@@ -259,7 +262,20 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var args = Array.prototype.slice.call(arguments).slice(2);
   var argsList = JSON.stringify(args).slice(1,-1);
 
-  child.emit('javascript', template.execute({ src: String(js_fn), args: argsList }));
+  var sendJsFn = String(function(){
+    if (!__nightmare.currentDocument){
+      __nightmare.currentDocument = document;
+    }
+    return (function(){
+      var document = __nightmare.currentDocument;
+      return (js_fn)();
+    });
+  });
+
+  sendJsFn = sendJsFn.replace('js_fn', String(js_fn));
+
+  child.emit('javascript', template.execute({ src: sendJsFn, args: argsList }));
+
   return this;
 };
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -263,10 +263,8 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var argsList = JSON.stringify(args).slice(1,-1);
 
   var sendJsFn = String(function(){
-    return (function(){
-      var document = __nightmare.currentDocument;
-      return (js_fn).apply(this, arguments);
-    }.apply(this, arguments));
+    var document = __nightmare.currentDocument;
+    return (js_fn).apply(this, arguments);
   });
 
   sendJsFn = sendJsFn.replace('js_fn', String(js_fn));

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -262,14 +262,14 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var args = Array.prototype.slice.call(arguments).slice(2);
   var argsList = JSON.stringify(args).slice(1,-1);
 
-  var sendJsFn = String(function(){
+  var sendJsFn = String(function(argsList){
     if (!__nightmare.currentDocument){
       __nightmare.currentDocument = document;
     }
-    return (function(){
-      var document = __nightmare.currentDocument;
-      return (js_fn)();
-    });
+    return (function(argsList){
+      // var document = __nightmare.currentDocument;
+      return (js_fn)(argsList);
+    }(argsList));
   });
 
   sendJsFn = sendJsFn.replace('js_fn', String(js_fn));

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -263,10 +263,6 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var argsList = JSON.stringify(args).slice(1,-1);
 
   var sendJsFn = String(function(){
-    if (!__nightmare.rootDocument){
-      __nightmare.rootDocument = document;
-      __nightmare.currentDocument = document;
-    }
     return (function(){
       var document = __nightmare.currentDocument;
       return (js_fn).apply(this, arguments);

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -267,7 +267,7 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
       __nightmare.currentDocument = document;
     }
     return (function(argsList){
-      // var document = __nightmare.currentDocument;
+      var document = __nightmare.currentDocument;
       return (js_fn)(argsList);
     }(argsList));
   });

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -263,7 +263,8 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var argsList = JSON.stringify(args).slice(1,-1);
 
   var sendJsFn = String(function(argsList){
-    if (!__nightmare.currentDocument){
+    if (!__nightmare.rootDocument){
+      __nightmare.rootDocument = document;
       __nightmare.currentDocument = document;
     }
     return (function(argsList){

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -262,15 +262,15 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var args = Array.prototype.slice.call(arguments).slice(2);
   var argsList = JSON.stringify(args).slice(1,-1);
 
-  var sendJsFn = String(function(argsList){
+  var sendJsFn = String(function(){
     if (!__nightmare.rootDocument){
       __nightmare.rootDocument = document;
       __nightmare.currentDocument = document;
     }
-    return (function(argsList){
+    return (function(){
       var document = __nightmare.currentDocument;
-      return (js_fn)(argsList);
-    }(argsList));
+      return (js_fn).apply(this, arguments);
+    }.apply(this, arguments));
   });
 
   sendJsFn = sendJsFn.replace('js_fn', String(js_fn));

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -7,6 +7,10 @@ window.addEventListener('error', function(e) {
   __nightmare.ipc.send('page', 'error', e.message, e.error.stack);
 });
 
+// Track the current document or iframe document
+__nightmare.rootDocument = document;
+__nightmare.currentDocument = document;
+
 (function(){
   // listen for console.log
   var defaultLog = console.log;

--- a/test/fixtures/iframes/first.html
+++ b/test/fixtures/iframes/first.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>first</title>
+  </head>
+  <body>
+    <iframe src="second.html" id="first"></iframe>
+  </body>
+</html>

--- a/test/fixtures/iframes/index.html
+++ b/test/fixtures/iframes/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>root</title>
+  </head>
+  <body>
+    <iframe src="first.html" id="root"></iframe>
+  </body>
+</html>

--- a/test/fixtures/iframes/second.html
+++ b/test/fixtures/iframes/second.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>second</title>
+  </head>
+  <body>
+    <p>Second HTML page (second.html), inside an iframe in first.html, inside an iframe in index.html</p>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -151,6 +151,72 @@ describe('Nightmare', function () {
     });
   });
 
+  describe('iframes', function () {
+    var nightmare;
+
+    beforeEach(function() {
+      nightmare = Nightmare();
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should start in the main document', function*() {
+      var title = yield nightmare
+        .goto(fixture('iframes'))
+        .title()
+
+      title.should.equal('root')
+    });
+
+    it('should be able to enter an iframe', function*() {
+      var title = yield nightmare
+        .goto(fixture('iframes'))
+        .enterIframe('#root')
+        .title()
+
+      title.should.equal('first')
+    });
+
+    it('should be able to enter a nested iframe', function*() {
+      var title = yield nightmare
+        .goto(fixture('iframes'))
+        .enterIframe('#root')
+        .title()
+
+      title.should.equal('first')
+
+      var title = yield nightmare
+        .enterIframe('#first')
+        .title()
+
+      title.should.equal('second')
+    });
+
+    it('should be able to enter a (possibly nested) iframe and go back to the main document', function*() {
+      var title = yield nightmare
+        .goto(fixture('iframes'))
+        .enterIframe('#root')
+        .title()
+
+      title.should.equal('first')
+
+      var title = yield nightmare
+        .enterIframe('#first')
+        .title()
+
+      title.should.equal('second')
+
+      var title = yield nightmare
+        .exitIframe()
+        .title()
+
+      title.should.equal('root')
+    });
+
+  });
+
   describe('evaluation', function () {
     var nightmare;
 


### PR DESCRIPTION
Enable support for IFrames, fixes #203

It creates two variables in the browser object `__nightmare`: `currentDocument` and `rootDocument`.

`rootDocument` is a reference to the main `document` used normally.

`currentDocument` starts as a reference to the main `document` but is updated to be a reference to the `document` of an iframe element by the action `Nightmare.prototype.enterIframe(selector)`.

The method `Nightmare.prototype.enterIframe(selector)` also works from inside iframes, so it allows traversing an arbitrary tree of iframes.

The method `Nightmare.prototype.exitIframe()` gets out of the iframes and comes back to the root `document` element.

An example would be:

```
var Nightmare = require('nightmare');
var nightmare = Nightmare();
nightmare.goto('http://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe').then();

nightmare.title().then(function(res){console.log(res)});

nightmare.enterIframe('#iframeResult').enterIframe('iframe');

nightmare.title().then(function(res){console.log(res)});

nightmare.exitIframe();

nightmare.title().then(function(res){console.log(res)});

nightmare.end();
```

It would print to the console:

```
Tryit Editor v2.6
W3Schools Online Web Tutorials
Tryit Editor v2.6
```

The two additional actions (`.enterIframe(selector)` and `exitIframe()`) are also documented in the `Readme.md`.

---

The way it works is by embedding the functions called with `.evaluate_now()` in a closure (to have an independent scope that allows overriding the `document` variable) giving them a `document` variable extracted from the `__nightmare.currentDocument` in the browser. That way, other actions (methods of `Nightmare.prototype`) don't have to be modified and user's code using `.evaluate()` would also work as expected.