### PR TITLE
Expose media playback events

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -133,6 +133,8 @@ function Nightmare(options) {
     this.child.on('crashed', function () { log('crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
     this.child.on('plugin-crashed', function () { log('plugin-crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
     this.child.on('destroyed', function () { log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('media-started-playing', function () { log('media-started-playing', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('media-paused', function () { log('media-paused', JSON.stringify(Array.prototype.slice.call(arguments))); });
 
     this.child.once('ready', (versions) => {
       this.engineVersions = versions;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -136,6 +136,8 @@ app.on('ready', function() {
     win.webContents.on('crashed', forward('crashed'));
     win.webContents.on('plugin-crashed', forward('plugin-crashed'));
     win.webContents.on('destroyed', forward('destroyed'));
+    win.webContents.on('media-started-playing', forward('media-started-playing'));
+    win.webContents.on('media-paused', forward('media-paused'));
 
     win.webContents.on('did-start-loading', function() {
       if (win.webContents.isLoadingMainFrame()) {


### PR DESCRIPTION
Makes it possible to listen for `media-started-playing` and `media-paused` with the on method.

Useful in testing apps that deal with audio playback.
