### PR TITLE
Add an html action

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -278,7 +278,7 @@ This event is triggered if `console.log` is used on the page. But this event is 
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
 #### .html(path, saveType)
-Save the current page as html as files to disk at the given path.
+Save the current page as html as files to disk at the given path. Save type options are [here](https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback).
 
 #### .pdf(path, options)
 Saves a PDF to the specified `path`. Options are [here](https://github.com/atom/electron/blob/v0.35.2/docs/api/web-contents.md#webcontentsprinttopdfoptions-callback).

--- a/Readme.md
+++ b/Readme.md
@@ -277,6 +277,9 @@ This event is triggered if `console.log` is used on the page. But this event is 
 #### .screenshot([path][, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
+#### .html(path, saveType)
+Save the current page as html as files to disk at the given path.
+
 #### .pdf(path, options)
 Saves a PDF to the specified `path`. Options are [here](https://github.com/atom/electron/blob/v0.35.2/docs/api/web-contents.md#webcontentsprinttopdfoptions-callback).
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -498,6 +498,35 @@ exports.screenshot = function (path, clip, done) {
 };
 
 /**
+ * Save the current file as html to disk.
+ *
+ * @param {String} path the full path to the file to save to
+ * @param {String} saveType
+ * @param {Function} done
+ */
+
+exports.html = function (path, saveType, done) {
+  debug('.html()');
+  if (typeof path === 'function' && !saveType && !done) {
+    done = path;
+    saveType = undefined;
+    path = undefined;
+  } else if (typeof path === 'object' && typeof saveType === 'function' && !done) {
+    done = saveType;
+    saveType = path;
+    path = undefined;
+  } else if (typeof saveType === 'function' && !done) {
+    done = saveType;
+    saveType = undefined;
+  }
+  this.child.once('html', function (err) {
+    if (err) debug(err);
+    done(err);
+  });
+  this.child.emit('html', path, saveType);
+}
+
+/**
  * Take a pdf.
  *
  * @param {String} path

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -253,6 +253,18 @@ app.on('ready', function() {
   });
 
   /**
+   * html
+   */
+
+  parent.on('html', function(path, saveType) {
+    // https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback
+    saveType = saveType || 'HTMLComplete'
+    win.webContents.savePage(path, saveType, function (err) {
+      parent.emit('html', err);
+    });
+  });
+
+  /**
    * pdf
    */
 

--- a/test/index.js
+++ b/test/index.js
@@ -691,6 +691,14 @@ describe('Nightmare', function () {
       stats.size.should.be.at.least(1000);
     });
 
+    it('should save as html', function*() {
+      yield nightmare
+        .goto(fixture('manipulation'))
+        .html(tmp_dir+'/test.html');
+      var stats = fs.statSync(tmp_dir+'/test.html');
+      stats.should.be.ok;
+    });
+
     it('should render a PDF', function*() {
       yield nightmare
         .goto(fixture('manipulation'))


### PR DESCRIPTION
- [ ] @reinpk 
- [ ] @matthewmueller
- [ ] @rosshinkley 

This works very similar to the screenshot or pdf actions, except it saves the page as html to disk. Its a pretty straight forward pass through to the corresponding electron api.