### PR TITLE
blur text inputs when finished with type() or insert()

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -155,16 +155,17 @@ exports.type = function() {
   debug('.type() %s into %s', text, selector);
   var child = this.child;
 
-  if((text || '') == '') {
-    this.evaluate_now(function(selector) {
-      document.querySelector(selector).value = '';
-    }, done, selector);
-  } else {
-    focusSelector.bind(this)(function() {
-      child.once('type', blurSelector.bind(this, done, selector));
+  focusSelector.bind(this)(function() {
+    var blurDone = blurSelector.bind(this, done, selector);
+    if ((text || '') == '') {
+      this.evaluate_now(function(selector) {
+        document.querySelector(selector).value = '';
+      }, blurDone, selector);
+    } else {
+      child.once('type', blurDone);
       child.emit('type', text);
-    }, selector);
-  }
+    }
+  }, selector);
 };
 
 /**
@@ -184,16 +185,17 @@ exports.insert = function(selector, text, done) {
   debug('.insert() %s into %s', text, selector);
   var child = this.child;
 
-  if((text || '') == '') {
-    this.evaluate_now(function(selector) {
-      document.querySelector(selector).value = '';
-    }, done, selector);
-  } else {
-    focusSelector.bind(this)(function() {
-      child.once('insert', blurSelector.bind(this, done, selector));
+  focusSelector.bind(this)(function() {
+    var blurDone = blurSelector.bind(this, done, selector);
+    if ((text || '') == '') {
+      this.evaluate_now(function(selector) {
+        document.querySelector(selector).value = '';
+      }, blurDone, selector);
+    } else {
+      child.once('insert', blurDone);
       child.emit('insert', text);
-    }, selector);
-  }
+    }
+  }, selector);
 }
 
 /**

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -119,6 +119,23 @@ exports.mouseover = function(selector, done) {
 };
 
 /**
+ * Helper functions for type() and insert() to focus/blur
+ * so that we trigger DOM events.
+ */
+
+var focusSelector = function(done, selector) {
+  return this.evaluate_now(function(selector) {
+    document.querySelector(selector).focus();
+  }, done.bind(this), selector);
+};
+
+var blurSelector = function(done, selector) {
+  return this.evaluate_now(function(selector) {
+    document.querySelector(selector).blur();
+  }, done.bind(this), selector);
+};
+
+/**
  * Type into an element.
  *
  * @param {String} selector
@@ -138,15 +155,13 @@ exports.type = function() {
   debug('.type() %s into %s', text, selector);
   var child = this.child;
 
-  if((text || '') == ''){
-    this.evaluate_now(function(selector){
+  if((text || '') == '') {
+    this.evaluate_now(function(selector) {
       document.querySelector(selector).value = '';
     }, done, selector);
   } else {
-    this.evaluate_now(function (selector) {
-      document.querySelector(selector).focus();
-    }, function() {
-      child.once('type', done);
+    focusSelector.bind(this)(function() {
+      child.once('type', blurSelector.bind(this, done, selector));
       child.emit('type', text);
     }, selector);
   }
@@ -160,25 +175,22 @@ exports.type = function() {
  * @param {Function} done
  */
 
-exports.insert = function (selector, text, done) {
+exports.insert = function(selector, text, done) {
   if (arguments.length === 2) {
     done = text
     text = null
   }
 
-  debug('.insert() %s into %s', text, selector)
-
+  debug('.insert() %s into %s', text, selector);
   var child = this.child;
 
-  if((text || '') == ''){
-    this.evaluate_now(function(selector){
+  if((text || '') == '') {
+    this.evaluate_now(function(selector) {
       document.querySelector(selector).value = '';
     }, done, selector);
   } else {
-    this.evaluate_now(function (selector) {
-      document.querySelector(selector).focus();
-    }, function() {
-      child.once('insert', done);
+    focusSelector.bind(this)(function() {
+      child.once('insert', blurSelector.bind(this, done, selector));
       child.emit('insert', text);
     }, selector);
   }


### PR DESCRIPTION
I was inspired to do this because some event listeners e.g. 'change' are triggered on blur, so they don't happen until we actually click/focus another element.

P.S. insert and type are very similar - there's some potential for refactoring but I don't know what style we would prefer.