### PR TITLE
Goto should fail if the page doesn’t load

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -168,6 +168,23 @@ Complete any queue operations, disconnect and close the electron process.
 #### .goto(url)
 Load the page at `url`.
 
+When a page load is successful, `goto` returns an object with metadata about the page load, including:
+
+- `url`: The URL that was loaded
+- `code`: The HTTP status code (e.g. 200, 404, 500)
+- `method`: The HTTP method used (e.g. "GET", "POST")
+- `referrer`: The page that the window was displaying prior to this load or an empty string if this is the first page load.
+- `headers`: An object representing the response headers for the request as in `{header1-name: header1-value, header2-name: header2-value}`
+
+If the page load fails, the error will be an object wit the following properties:
+
+- `message`: A string describing the type of error
+- `code`: The underlying error code describing what went wrong. Note this is NOT the HTTP status code. For possible values, see https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
+- `details`: A string with additional details about the error. This may be null or an empty string.
+- `url`: The URL that failed to load
+
+Note that any valid response from a server is considered “successful.” That means things like 404 “not found” errors are successful results for `goto`. Only things that would cause no page to appear in the browser window, such as no server responding at the given address, the server hanging up in the middle of a response, or invalid URLs, are errors.
+
 #### .back()
 Go back to the previous page.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -144,6 +144,7 @@ function Nightmare(options) {
   // proporate events through to debugging
   this.child.on('did-finish-load', function () { log('did-finish-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('did-fail-load', function () { log('did-fail-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
+  this.child.on('did-fail-provisional-load', function () { log('did-fail-provisional-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('did-frame-finish-load', function () { log('did-frame-finish-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('did-start-loading', function () { log('did-start-loading', JSON.stringify(Array.prototype.slice.call(arguments))); });
   this.child.on('did-stop-loading', function () { log('did-stop-loading', JSON.stringify(Array.prototype.slice.call(arguments))); });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,7 +3,8 @@
  */
 
 var parent = require('./ipc')(process);
-var BrowserWindow = require('electron').BrowserWindow;
+var electron = require('electron');
+var BrowserWindow = electron.BrowserWindow;
 var defaults = require('deep-defaults');
 var assign = require('object-assign');
 var join = require('path').join;
@@ -11,7 +12,10 @@ var sliced = require('sliced');
 var renderer = require('electron').ipcMain;
 var app = require('electron').app;
 var fs = require('fs');
+var urlFormat = require('url');
 var FrameManager = require('./frame-manager');
+
+const KNOWN_PROTOCOLS = ['http', 'https', 'file', 'about'];
 
 /**
  * Handle uncaught exceptions in the main electron process
@@ -225,11 +229,33 @@ app.on('ready', function() {
         parent.emit('goto', error, data);
       }
 
-      win.webContents.on('did-fail-load', handleFailure);
-      win.webContents.on('did-get-response-details', handleDetails);
-      win.webContents.on('did-finish-load', handleFinish);
-      win.webContents.loadURL(url, {
-        extraHeaders: extraHeaders
+      // In most environments, loadURL handles this logic for us, but in some
+      // it just hangs for unhandled protocols. Mitigate by checking ourselves.
+      function canLoadProtocol(url, callback) {
+        var protocol = (urlFormat.parse(url).protocol || '').replace(/:$/, '');
+        if (!protocol || KNOWN_PROTOCOLS.includes(protocol)) {
+          return callback(true);
+        }
+        electron.protocol.isProtocolHandled(protocol, callback);
+      }
+
+      canLoadProtocol(url, function(canLoad) {
+        if (canLoad) {
+          win.webContents.on('did-fail-load', handleFailure);
+          win.webContents.on('did-get-response-details', handleDetails);
+          win.webContents.on('did-finish-load', handleFinish);
+          win.webContents.loadURL(url, {
+            extraHeaders: extraHeaders
+          });
+          return;
+        }
+
+        done({
+          message: 'navigation error',
+          code: -1000,
+          details: 'unhandled protocol',
+          url: url
+        });
       });
     }
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -479,22 +479,3 @@ function forward(event) {
     parent.emit.apply(parent, [event].concat(sliced(arguments)));
   };
 }
-
-/**
- * URL pattern matching
- *
- * This is something of a poor man's imitation of Electron's URL matcher, which
- * is much more complicated:
- * https://github.com/electron/electron/blob/master/chromium_src/extensions/common/url_pattern.cc
- * It should work with most patterns designed for Electron's matcher, though.
- */
-function patternToRegExp(pattern) {
-  const source = pattern.split('*').map(function(part, index) {
-    return (index %2) ? '.*' : escapeRegExp(part);
-  }).join('');
-  return new RegExp('^' + source);
-}
-
-function escapeRegExp(text) {
-  return text.replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&');
-}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -60,7 +60,7 @@ if (!processArgs.dock && app.dock) {
  */
 
 app.on('ready', function() {
-  var win, frameManager, options, currentLoadingUrl, startedLoading;
+  var win, frameManager, options;
 
   /**
    * create a browser window
@@ -130,43 +130,6 @@ app.on('ready', function() {
     win.webContents.on('plugin-crashed', forward('plugin-crashed'));
     win.webContents.on('destroyed', forward('destroyed'));
 
-    // `goto` needs to be able to listen for new requests starting in order to
-    // determine the actual URL that is being loaded (Electron will 'clean up'
-    // the URL under the hood, so the URL string passed to `goto` may not match
-    // the actual requests being made).
-    // Because webRequest allows only one handler at a time, we have to protect
-    // against a plugin disrupting our handler, so replace `onBeforeRequest`
-    // with a function that mimics the built-in behavior.
-    var webRequest = win.webContents.session.webRequest;
-    // If a request handler is registered, `beforeRequestHandler` will run it
-    // and return `true`. If none is present, return `false`.
-    var beforeRequestHandler = () => false;
-    webRequest.onBeforeRequest(function(details, callback) {
-      if (details.resourceType === 'mainFrame') {
-        startedLoading = true;
-        currentLoadingUrl = details.url;
-      }
-      beforeRequestHandler(details, callback) || callback({cancel: false});
-    });
-    webRequest.onBeforeRequest = function(filters, handler) {
-      if (arguments.length < 2) {
-        handler = filters;
-        filters = [];
-      }
-
-      if (!handler) { return () => false; }
-
-      var patterns = filters.map(patternToRegExp);
-      beforeRequestHandler = function(details, callback) {
-        var url = details.url;
-        if (!patterns.length || patterns.some(pattern => pattern.test(url))) {
-          handler(details, callback);
-          return true;
-        }
-        return false;
-      };
-    }
-
     parent.emit('browser-initialize');
   });
 
@@ -187,14 +150,10 @@ app.on('ready', function() {
     if (win.webContents.getURL() == url) {
       parent.emit('goto');
     } else {
-      currentLoadingUrl = url;
-      startedLoading = false;
       var responseData = {};
 
-      function handleFailure(event, code, detail, failedUrl) {
-        // No indicator for whether this is from the main frame, so use the URL
-        // as a proxy. See: https://github.com/electron/electron/issues/5013
-        if (!startedLoading || failedUrl === currentLoadingUrl) {
+      function handleFailure(event, code, detail, failedUrl, isMainFrame) {
+        if (isMainFrame) {
           done({
             message: 'navigation error',
             code: code,
@@ -205,8 +164,8 @@ app.on('ready', function() {
       }
 
       function handleDetails(
-        event, status, newUrl, oldUrl, statusCode, method, referrer, headers) {
-        if (newUrl === currentLoadingUrl) {
+        event, status, newUrl, oldUrl, statusCode, method, referrer, headers, resourceType) {
+        if (resourceType === 'mainFrame') {
           responseData = {
             url: newUrl,
             code: statusCode,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -56,7 +56,7 @@ if (!processArgs.dock && app.dock) {
  */
 
 app.on('ready', function() {
-  var win, frameManager, options;
+  var win, frameManager, options, currentLoadingUrl, startedLoading;
 
   /**
    * create a browser window
@@ -112,6 +112,7 @@ app.on('ready', function() {
 
     win.webContents.on('did-finish-load', forward('did-finish-load'));
     win.webContents.on('did-fail-load', forward('did-fail-load'));
+    win.webContents.on('did-fail-provisional-load', forward('did-fail-provisional-load'));
     win.webContents.on('did-frame-finish-load', forward('did-frame-finish-load'));
     win.webContents.on('did-start-loading', forward('did-start-loading'));
     win.webContents.on('did-stop-loading', forward('did-stop-loading'));
@@ -124,6 +125,43 @@ app.on('ready', function() {
     win.webContents.on('crashed', forward('crashed'));
     win.webContents.on('plugin-crashed', forward('plugin-crashed'));
     win.webContents.on('destroyed', forward('destroyed'));
+
+    // `goto` needs to be able to listen for new requests starting in order to
+    // determine the actual URL that is being loaded (Electron will 'clean up'
+    // the URL under the hood, so the URL string passed to `goto` may not match
+    // the actual requests being made).
+    // Because webRequest allows only one handler at a time, we have to protect
+    // against a plugin disrupting our handler, so replace `onBeforeRequest`
+    // with a function that mimics the built-in behavior.
+    var webRequest = win.webContents.session.webRequest;
+    // If a request handler is registered, `beforeRequestHandler` will run it
+    // and return `true`. If none is present, return `false`.
+    var beforeRequestHandler = () => false;
+    webRequest.onBeforeRequest(function(details, callback) {
+      if (details.resourceType === 'mainFrame') {
+        startedLoading = true;
+        currentLoadingUrl = details.url;
+      }
+      beforeRequestHandler(details, callback) || callback({cancel: false});
+    });
+    webRequest.onBeforeRequest = function(filters, handler) {
+      if (arguments.length < 2) {
+        handler = filters;
+        filters = [];
+      }
+
+      if (!handler) { return () => false; }
+
+      var patterns = filters.map(patternToRegExp);
+      beforeRequestHandler = function(details, callback) {
+        var url = details.url;
+        if (!patterns.length || patterns.some(pattern => pattern.test(url))) {
+          handler(details, callback);
+          return true;
+        }
+        return false;
+      };
+    }
 
     parent.emit('browser-initialize');
   });
@@ -145,11 +183,53 @@ app.on('ready', function() {
     if (win.webContents.getURL() == url) {
       parent.emit('goto');
     } else {
+      currentLoadingUrl = url;
+      startedLoading = false;
+      var responseData = {};
+
+      function handleFailure(event, code, detail, failedUrl) {
+        // No indicator for whether this is from the main frame, so use the URL
+        // as a proxy. See: https://github.com/electron/electron/issues/5013
+        if (!startedLoading || failedUrl === currentLoadingUrl) {
+          done({
+            message: 'navigation error',
+            code: code,
+            details: detail,
+            url: failedUrl || url
+          });
+        }
+      }
+
+      function handleDetails(
+        event, status, newUrl, oldUrl, statusCode, method, referrer, headers) {
+        if (newUrl === currentLoadingUrl) {
+          responseData = {
+            url: newUrl,
+            code: statusCode,
+            method: method,
+            referrer: referrer,
+            headers: headers
+          };
+        }
+      }
+
+      // We will have already unsubscribed if load failed, so assume success.
+      function handleFinish(event) {
+        done(null, responseData);
+      }
+
+      function done(error, data) {
+        win.webContents.removeListener('did-fail-load', handleFailure);
+        win.webContents.removeListener('did-get-response-details', handleDetails);
+        win.webContents.removeListener('did-finish-load', handleFinish);
+        parent.emit('goto', error, data);
+      }
+
+      win.webContents.on('did-fail-load', handleFailure);
+      win.webContents.on('did-get-response-details', handleDetails);
+      win.webContents.on('did-finish-load', handleFinish);
       win.webContents.loadURL(url, {
         extraHeaders: extraHeaders
-      });
-      win.webContents.once('did-finish-load', function() {
-        parent.emit('goto');
       });
     }
   });
@@ -356,9 +436,9 @@ app.on('ready', function() {
 
   parent.on('action', function(name, fntext){
     var fn = new Function('with(this){ parent.emit("log", "adding action for '+ name +'"); return ' + fntext + '}')
-      .call({ 
-        require: require, 
-        parent: parent 
+      .call({
+        require: require,
+        parent: parent
       });
     fn(name, options, parent, win, renderer, function(err){
       parent.emit('action', err);
@@ -411,4 +491,23 @@ function forward(event) {
   return function () {
     parent.emit.apply(parent, [event].concat(sliced(arguments)));
   };
+}
+
+/**
+ * URL pattern matching
+ *
+ * This is something of a poor man's imitation of Electron's URL matcher, which
+ * is much more complicated:
+ * https://github.com/electron/electron/blob/master/chromium_src/extensions/common/url_pattern.cc
+ * It should work with most patterns designed for Electron's matcher, though.
+ */
+function patternToRegExp(pattern) {
+  const source = pattern.split('*').map(function(part, index) {
+    return (index %2) ? '.*' : escapeRegExp(part);
+  }).join('');
+  return new RegExp('^' + source);
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&');
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -227,7 +227,9 @@ app.on('ready', function() {
         win.webContents.removeListener('did-fail-load', handleFailure);
         win.webContents.removeListener('did-get-response-details', handleDetails);
         win.webContents.removeListener('did-finish-load', handleFinish);
-        parent.emit('goto', error, data);
+        // wait a tick before notifying to resolve race conditions for events
+        setImmediate(() => parent.emit('goto', error, data));
+
       }
 
       // In most environments, loadURL handles this logic for us, but in some

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -223,6 +223,7 @@ app.on('ready', function() {
       }
 
       function done(error, data) {
+        win.webContents.removeListener('did-fail-provisional-load', handleFailure);
         win.webContents.removeListener('did-fail-load', handleFailure);
         win.webContents.removeListener('did-get-response-details', handleDetails);
         win.webContents.removeListener('did-finish-load', handleFinish);
@@ -241,6 +242,9 @@ app.on('ready', function() {
 
       canLoadProtocol(url, function(canLoad) {
         if (canLoad) {
+          // NOTE: fail-provisional triggers fail-load, but triggers it *later,*
+          // causing a race with did-finish. So hook fail-provisional directly.
+          win.webContents.on('did-fail-provisional-load', handleFailure);
           win.webContents.on('did-fail-load', handleFailure);
           win.webContents.on('did-get-response-details', handleDetails);
           win.webContents.on('did-finish-load', handleFinish);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -182,7 +182,6 @@ app.on('ready', function() {
       }
 
       function done(error, data) {
-        win.webContents.removeListener('did-fail-provisional-load', handleFailure);
         win.webContents.removeListener('did-fail-load', handleFailure);
         win.webContents.removeListener('did-get-response-details', handleDetails);
         win.webContents.removeListener('did-finish-load', handleFinish);
@@ -203,9 +202,6 @@ app.on('ready', function() {
 
       canLoadProtocol(url, function(canLoad) {
         if (canLoad) {
-          // NOTE: fail-provisional triggers fail-load, but triggers it *later,*
-          // causing a race with did-finish. So hook fail-provisional directly.
-          win.webContents.on('did-fail-provisional-load', handleFailure);
           win.webContents.on('did-fail-load', handleFailure);
           win.webContents.on('did-get-response-details', handleDetails);
           win.webContents.on('did-finish-load', handleFinish);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron-prebuilt": "^0.37.5",
+    "electron-prebuilt": "^0.37.6",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",

--- a/test/fixtures/navigation/invalid-frame.html
+++ b/test/fixtures/navigation/invalid-frame.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Navigation</title>
+  </head>
+  <body>
+    <iframe src="http://this-is-not-a-real-domain.com/non-existent.html" width="300" height="300">
+    </iframe>
+  </body>
+</html>

--- a/test/fixtures/navigation/invalid-image.html
+++ b/test/fixtures/navigation/invalid-image.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Navigation</title>
+  </head>
+  <body>
+    <img src="http://this-is-not-a-real-domain.com/non-existent.jpg" />
+  </body>
+</html>

--- a/test/fixtures/navigation/valid-frame.html
+++ b/test/fixtures/navigation/valid-frame.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Navigation</title>
+  </head>
+  <body>
+    <iframe src="/navigation" width="300" height="300">
+    </iframe>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -150,6 +150,40 @@ describe('Nightmare', function () {
           return (expectedA === textA && expectedB === textB);
         }, 'A', 'B');
     });
+
+    it('should fail if navigation target is invalid', function(done) {
+      nightmare.goto('http://this-is-not-a-real-domain.com')
+        .then(function() {
+          done(new Error('Navigation to an invalid domain succeeded'));
+        })
+        .catch(function(error) {
+          done();
+        });
+    });
+
+    it('should not fail if the URL loads but a resource fails', function(done) {
+      nightmare.goto(fixture('navigation/invalid-image'))
+        .then(function() {
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should not fail if a child frame fails', function(done) {
+      nightmare.goto(fixture('navigation/invalid-frame'))
+        .then(function() {
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should not fail if the response was a valid error (e.g. 404)', function(done) {
+      nightmare.goto(fixture('navigation/not-a-real-page'))
+        .then(function() {
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('evaluation', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -77,7 +77,9 @@ describe('Nightmare', function () {
     var nightmare;
 
     beforeEach(function() {
-      nightmare = Nightmare({webPreferences: {partition: 'test-partition'}});
+      nightmare = Nightmare({
+        webPreferences: {partition: 'test-partition' + Math.random()}
+      });
     });
 
     afterEach(function*() {

--- a/test/index.js
+++ b/test/index.js
@@ -35,16 +35,8 @@ process.setMaxListeners(0);
 var base = 'http://localhost:7500/';
 
 describe('Nightmare', function () {
-  var serverInstance;
   before(function (done) {
-    serverInstance = server.listen(7500, done);
-  });
-
-  beforeEach(function() {
-    // restart the server if it's been stopped by a test
-    if (!serverInstance.listening) {
-      serverInstance = server.listen(7500);
-    }
+    server.listen(7500, done);
   });
 
   it('should be constructable', function*() {
@@ -217,11 +209,7 @@ describe('Nightmare', function () {
     });
 
     it('should fail if the response dies in flight', function(done) {
-      nightmare.on('did-start-loading', function() {
-        serverInstance.close();
-      });
-
-      nightmare.goto(fixture('navigation'))
+      nightmare.goto(fixture('do-not-respond'))
         .then(function() {
           done(new Error('Navigation succeeded but server connection died'));
         })

--- a/test/server.js
+++ b/test/server.js
@@ -72,6 +72,24 @@ app.use(serve(path.resolve(__dirname, 'fixtures')));
 app.use('/files', serve(path.resolve(__dirname, 'files')));
 
 /**
+ * Simulate Node v5's `listening` property
+ */
+
+var _listen = app.listen;
+app.listen = function() {
+  var instance = _listen.apply(app, arguments);
+  if (instance.listening == null) {
+    instance.on('listening', function() {
+      instance.listening = true;
+    });
+    instance.on('close', function() {
+      instance.listening = false;
+    });
+    return instance;
+  }
+};
+
+/**
  * Start if not required.
  */
 

--- a/test/server.js
+++ b/test/server.js
@@ -60,6 +60,14 @@ app.get('/redirect', function (req, res) {
 });
 
 /**
+ * Simply hang up on the connection for testing interrupted page loads
+ */
+
+app.get('/do-not-respond', function(req, res) {
+  res.socket.end();
+});
+
+/**
  * Serve the fixtures directory as static files.
  */
 
@@ -70,24 +78,6 @@ app.use(serve(path.resolve(__dirname, 'fixtures')));
  */
 
 app.use('/files', serve(path.resolve(__dirname, 'files')));
-
-/**
- * Simulate Node v5's `listening` property
- */
-
-var _listen = app.listen;
-app.listen = function() {
-  var instance = _listen.apply(app, arguments);
-  if (instance.listening == null) {
-    instance.on('listening', function() {
-      instance.listening = true;
-    });
-    instance.on('close', function() {
-      instance.listening = false;
-    });
-    return instance;
-  }
-};
 
 /**
  * Start if not required.

--- a/test/server.js
+++ b/test/server.js
@@ -50,6 +50,16 @@ app.get('/headers', function (req, res) {
 });
 
 /**
+ * Redirect to the provided URL for testing redirects and headers
+ */
+
+app.get('/redirect', function (req, res) {
+  var code = Number(req.query.code) || 301;
+  var url = req.query.url || '/';
+  res.redirect(code, url);
+});
+
+/**
  * Serve the fixtures directory as static files.
  */
 


### PR DESCRIPTION
~~**This is just a work-in-progress at the moment, but filing the PR as there are open questions…**~~

This adds tests (which fail), but no implementation—I need to work out the best solution for https://github.com/atom/electron/issues/5013 and https://github.com/atom/electron/issues/4396 (this second one I can’t actually reproduce, so it may have been fixed). For the former, the simplest solution is probably tracking the URL of the failed page and comparing it to the URL of the main frame. Need to make sure that works right for redirects, though. A more exacting solution might be to track resource requests on the `session` object, though doing so requires a bit more rigamarole.

There is also an open question of how this should behave w/r/t error responses (e.g. 404, 500, etc). For now, I’m planning to take the approach that any valid response (including things like 404s and 500s) are successes (after all, you might be trying to test a 404 page with Nightmare), but I can also imagine someone wanting the option to treat any non-2xx response as a failure. Maybe that’s something to wait for as a feature request, though? Curious what others think.