### PR TITLE
Pass uncaughtExceptions back to the default handler after cleanup

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -80,9 +80,9 @@ function Nightmare(options) {
 
   process.setMaxListeners(Infinity);
   process.on('uncaughtException', function(err) {
-    debug(err.stack);
+    console.error(err.stack);
     endInstance(self);
-    throw err;
+    process.exit(1);
   });
 
   // if the process nightmare is running in dies, make sure to kill electron

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -80,8 +80,9 @@ function Nightmare(options) {
 
   process.setMaxListeners(Infinity);
   process.on('uncaughtException', function(err) {
-    console.error(err.stack);
+    debug(err.stack);
     endInstance(self);
+    throw err;
   });
 
   // if the process nightmare is running in dies, make sure to kill electron

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -82,7 +82,11 @@ function Nightmare(options) {
   process.on('uncaughtException', function(err) {
     console.error(err.stack);
     endInstance(self);
-    process.exit(1);
+    // This allows any user defined 'uncaughtException' handlers
+    // to run before exiting
+    process.nextTick(function() {
+        process.exit(1);
+    });
   });
 
   // if the process nightmare is running in dies, make sure to kill electron

--- a/test/files/nightmare-error.js
+++ b/test/files/nightmare-error.js
@@ -1,0 +1,5 @@
+// This script is used to start nightmare 
+// but then throw a user space error
+var Nightmare = require('../..');
+var nightmare = Nightmare();
+throw new Error("uncaught");

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,16 @@ describe('Nightmare', function () {
     });
   });
 
+  it('should exit with a non-zero code on uncaughtExecption', function(done) {
+    var child = child_process.fork(
+      path.join(__dirname, 'files', 'nightmare-error.js'), [], {silent: true});
+
+      child.once('exit', function(code) {
+        code.should.not.equal(0);
+        done();
+      });
+  });
+
   describe('navigation', function () {
     var nightmare;
 


### PR DESCRIPTION
Nightmare adds an `uncaughtException` listener to clean up the child process. However adding a listener [overrides the default behaviour](https://nodejs.org/docs/latest/api/process.html#process_event_uncaughtexception) and can cause an exit code of zero.

### Steps to reproduce:
```js
// a.js
var Nightmare = require("nightmare");
var n = Nightmare();
var a = require("does-not-exist");
```
And then running `node a.js; echo $?` show the error but reports an exit code of `0`.

### Fix:
Re-throw the error so node can pick it back up. I also changed the `console.log` to a `debug` as the default handler prints a stack trace.