### PR TITLE
Don't subscribe to frames until there are actual listeners for frame data

### DIFF
--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -23,8 +23,8 @@ function FrameManager(window) {
   this.on('newListener', subscribe);
   this.on('removeListener', unsubscribe);
 
-  function subscribe() {
-    if (!subscribed) {
+  function subscribe(eventName) {
+    if (!subscribed && eventName === 'data') {
       parent.emit('log', 'subscribing to browser window frames');
       window.webContents.beginFrameSubscription(receiveFrame);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -726,6 +726,19 @@ describe('Nightmare', function () {
       firstPixel.should.deep.equal([0, 153, 0]);
     });
 
+    it('should not subscribe to frames until necessary', function() {
+      var didSubscribe = false;
+      var FrameManager = require('../lib/frame-manager.js');
+      var manager = FrameManager({
+        webContents: {
+          beginFrameSubscription: function() { didSubscribe = true; },
+          endFrameSubscription: function() {},
+          executeJavaScript: function() {}
+        }
+      });
+      didSubscribe.should.be.false;
+    });
+
     it('should load jquery correctly', function*() {
       var loaded = yield nightmare
         .goto(fixture('rendering'))


### PR DESCRIPTION
Turns out I missed a condition on event subscription in Frame Manager that caused it to always automatically subscribe to frames upon instantiation, dramatically increasing overhead. This should fix that.

(Noticed while working on #553; I think this could be causing the slowdowns and test timeouts there, or at least exacerbating them.)