### PR TITLE
run tests under an `xvfb` wrapper when headless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,26 @@
 GREP ?=.
+#check if xvfb is running
+XVFB_RUNNING = $(shell pgrep "Xvfb" > /dev/null; echo $$?)
+#set the circle project name if not set
+CIRCLE_PROJECT_REPONAME ?= 1
+#set headless if not set
+HEADLESS ?= 1
+
+#debug the environment variables
+$(info $(CIRCLE_PROJECT_REPONAME)$(HEADLESS)$(XVFB_RUNNING))
 
 test: node_modules
+#if this build is not on circle, is not headless, and xvfb is not already running,
+#run mocha as usual
+#otherwise, run mocha under the xvfb wrapper
+ifeq ($(CIRCLE_PROJECT_REPONAME)$(HEADLESS)$(XVFB_RUNNING), 111)
 	@rm -rf /tmp/nightmare
 	@node_modules/.bin/mocha --harmony --grep "$(GREP)"
+else
+	echo 'running under xvfb wrapper'
+	@rm -rf /tmp/nightmare
+	@./test/bb-xvfb node_modules/.bin/mocha --harmony --grep "$(GREP)"
+endif
 
 node_modules: package.json
 	@npm install

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ ifeq ($(CIRCLE_PROJECT_REPONAME)$(HEADLESS)$(XVFB_RUNNING), 111)
 	@rm -rf /tmp/nightmare
 	@node_modules/.bin/mocha --harmony --grep "$(GREP)"
 else
-	echo 'running under xvfb wrapper'
 	@rm -rf /tmp/nightmare
 	@./test/bb-xvfb node_modules/.bin/mocha --harmony --grep "$(GREP)"
 endif

--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,14 @@ CIRCLE_PROJECT_REPONAME ?= 1
 #set headless if not set
 HEADLESS ?= 1
 
-#debug the environment variables
-$(info $(CIRCLE_PROJECT_REPONAME)$(HEADLESS)$(XVFB_RUNNING))
-
 test: node_modules
+	@rm -rf /tmp/nightmare
 #if this build is not on circle, is not headless, and xvfb is not already running,
 #run mocha as usual
 #otherwise, run mocha under the xvfb wrapper
 ifeq ($(CIRCLE_PROJECT_REPONAME)$(HEADLESS)$(XVFB_RUNNING), 111)
-	@rm -rf /tmp/nightmare
 	@node_modules/.bin/mocha --harmony --grep "$(GREP)"
 else
-	@rm -rf /tmp/nightmare
 	@./test/bb-xvfb node_modules/.bin/mocha --harmony --grep "$(GREP)"
 endif
 

--- a/Readme.md
+++ b/Readme.md
@@ -530,6 +530,8 @@ make test
   18 passing (1m)
 ```
 
+Note that if you are using `xvfb`, `make test` will automatically run the tests under an `xvfb-run` wrapper.  If you are planning to run the tests headlessly without running `xvfb` first, set the `HEADLESS` environment variable to `0`.
+
 ## License (MIT)
 
 ```

--- a/test/bb-xvfb
+++ b/test/bb-xvfb
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# bb-xvfb <command> <and> <its> <arguments...>
+#
+# Wrapper for XVFB.  Capture XVFB logs where we can see them.  Dump
+# XVFB framebuffer where can we can see it.  Use a standard display size
+# and dpi for all of our XVFB-wrapped tests.
+#
+# pulled from: https://gist.github.com/tullmann/2d8d38444c5e81a41b6d
+# original issue: https://github.com/angular/protractor/issues/2419#issuecomment-156527809
+
+# Note: "32" is not a valid depth for xvfb: https://bugs.freedesktop.org/show_bug.cgi?id=17453 (from 2008)
+SCREEN_SIZE="1280x1024x24+32"
+
+BINDIR="$(dirname $0)"
+TMPDIR=/tmp
+
+if [ ! -d "$TMPDIR" ]; then
+    echo "Invalid tmp directory: ${TMPDIR}"
+    exit 1
+fi
+
+# Avoid race conditions in google-chrome startup by making sure there is a
+# dbus message bus up and running.
+# See https://code.google.com/p/chromium/issues/detail?id=309093
+DBUS="dbus-launch --exit-with-session"
+
+WAITFORX="${BINDIR}/waitForX"
+
+XVFBDIR="${TMPDIR}/xvfb.$$"
+mkdir -p "${XVFBDIR}"
+
+ERRFILE="${XVFBDIR}/xvfb.log"
+
+# Pass the "-fbdir" to force xvfb to use a memory-mapped file.  This makes screenshots and debugging easier.
+# To display said framebuffer contents: xwud -in ${XVFBDIR}/Xvfb_screen0
+
+exec xvfb-run \
+    --error-file="${ERRFILE}" \
+    --auto-servernum \
+    --server-args="-fbdir ${XVFBDIR} -screen 0 ${SCREEN_SIZE} -dpi 96 -ac" \
+    ${WAITFORX} ${RECORD} ${DBUS} "$@"
+
+#eof

--- a/test/bb-xvfb
+++ b/test/bb-xvfb
@@ -39,6 +39,6 @@ exec xvfb-run \
     --error-file="${ERRFILE}" \
     --auto-servernum \
     --server-args="-fbdir ${XVFBDIR} -screen 0 ${SCREEN_SIZE} -dpi 96 -ac" \
-    ${WAITFORX} ${RECORD} ${DBUS} "$@"
+    ${WAITFORX} ${DBUS} "$@"
 
 #eof

--- a/test/waitForX
+++ b/test/waitForX
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# waitForX [<cmd> [<arg> ...]]
+#
+# Wait for X Server to be ready, then run the given command once X server
+# is ready.  (Or simply return if no command is provided.)
+#
+# pulled from: https://gist.github.com/tullmann/476cc71169295d5c3fe6
+# original issue: https://github.com/angular/protractor/issues/2419#issuecomment-156527809
+
+function LOG {
+    echo $(date -R): $0: $*
+}
+
+if [ -z "$DISPLAY" ]; then
+    LOG "FATAL: No DISPLAY environment variable set.  No X."
+    exit 13
+fi
+
+#LOG "Waiting for X Server $DISPLAY to be available"
+
+MAX=120 # About 60 seconds
+CT=0
+while ! xdpyinfo >/dev/null 2>&1; do
+    sleep 0.50s
+    CT=$(( CT + 1 ))
+    if [ "$CT" -ge "$MAX" ]; then
+        LOG "FATAL: $0: Gave up waiting for X server $DISPLAY"
+        exit 11
+    fi
+done
+
+#LOG "X is available"
+
+if [ -n "$1" ]; then
+    exec "$@"
+fi
+
+#eof


### PR DESCRIPTION
Changes the makefile to run tests under an `xfvb` wrapper called `bb-xvfb` under one or more the following conditions:
 * `make test` is executed on CircleCI.
 * `make test` is executed on a box where `xvfb` is running.
 * `make test` is executed in an environment where the `HEADLESS` variable is set and not equal to `1`.

(Disclaimer: my ability with GNU Make is pitiful, any pointers on how to make the Makefile better would be appreciated.)

The wrapper enforces starting `xvfb`, waiting for an X server to be ready, followed by starting `dbus` for IPC messaging, followed by your command.  In the case of `make test`, the unit tests are executed.

The original problem is explained in [Chromium bug 309093](https://bugs.chromium.org/p/chromium/issues/detail?id=309093), and I found that the [Protractor](http://angular.github.io/protractor/#/) project (an Angular test automation suite that uses a Chrome WebDriver to run tests) already had hit this problem.  The scripts used are ~~plagiarised~~ borrowed from [angular/protractor#2419](https://github.com/angular/protractor/issues/2419#issuecomment-156527809).  (Thanks to @tullmann for providing the fix.)

This PR should fix #561.

Thoughts?