### PR TITLE
Workaround for Electron event sender crash

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -356,9 +356,9 @@ app.on('ready', function() {
 
   parent.on('action', function(name, fntext){
     var fn = new Function('with(this){ parent.emit("log", "adding action for '+ name +'"); return ' + fntext + '}')
-      .call({ 
-        require: require, 
-        parent: parent 
+      .call({
+        require: require,
+        parent: parent
       });
     fn(name, options, parent, win, renderer, function(err){
       parent.emit('action', err);
@@ -407,8 +407,12 @@ app.on('ready', function() {
  * Forward events
  */
 
-function forward(event) {
-  return function () {
-    parent.emit.apply(parent, [event].concat(sliced(arguments)));
+function forward(name) {
+  return function (event) {
+    // trying to send the event's `sender` can crash electron, so strip it
+    // https://github.com/electron/electron/issues/5180
+    var safeEvent = Object.assign({}, event);
+    delete safeEvent.sender;
+    parent.emit.apply(parent, [name, safeEvent].concat(sliced(arguments, 1)));
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1188,8 +1188,7 @@ describe('Nightmare', function () {
     });
 
     it('should support extending nightmare', function*() {
-      var nightmare = Nightmare()
-      var tagName = yield Nightmare()
+      var tagName = yield nightmare
         .goto(fixture('simple'))
         .use(select('h1'))
 
@@ -1233,19 +1232,23 @@ describe('Nightmare', function () {
 
   describe('devtools', function(){
     beforeEach(function() {
-      Nightmare.action('checkDevTools',
+      Nightmare.action('waitForDevTools',
         function(ns, options, parent, win, renderer, done){
-          parent.on('checkDevTools', function(){
-            parent.emit('checkDevTools', null, win.webContents.isDevToolsOpened());
+          parent.on('waitForDevTools', function() {
+            function opened() { parent.emit('waitForDevTools', null, true); }
+            if (win.webContents.isDevToolsOpened()) {
+              return opened();
+            }
+            win.webContents.once('devtools-opened', opened);
           });
           done();
         },
         function(done){
-          this.child.once('checkDevTools', done);
-          this.child.emit('checkDevTools');
+          this.child.once('waitForDevTools', done);
+          this.child.emit('waitForDevTools');
         });
       nightmare = Nightmare({show:true, openDevTools:true});
-      
+
     });
 
     afterEach(function*(){
@@ -1255,8 +1258,7 @@ describe('Nightmare', function () {
     it('should open devtools', function*(){
       var devToolsOpen = yield nightmare
         .goto(fixture('simple'))
-        .wait(2000)
-        .checkDevTools();
+        .waitForDevTools();
 
       devToolsOpen.should.be.true;
     });


### PR DESCRIPTION
Electron has a potential crasher (on OS X, at least) when the devtools are open: https://github.com/electron/electron/issues/5180

This is an extremely simple workaround. Nightmare’s event forwarding code sends the `event.sender` argument, which may contain properties that crash Electron when accessed. Nightmare triggers the crash by stringifying everything when forwarding the event across IPC. This simply avoid including the `sender`.

I *think* it would be nicer not to send the `event` object at all (since this patch leaves it as an empty object in most cases and I don’t think it provided any users with useful data), but I am ever so slightly worried that changing which arguments are where in the events could bite somebody. This seemed safer.