### PR TITLE
Callback-based IPC

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -190,7 +190,7 @@ Enters the `text` provided into the `selector` element.  Empty or falsey values 
 
 `.type()` mimics a user typing in a textbox and will emit the proper keyboard events
 
-Key presses can also be fired using Unicode values with `.type()`. For example, if you wanted to fire an enter key press, you would  write `.type('document', '\u000d')`. 
+Key presses can also be fired using Unicode values with `.type()`. For example, if you wanted to fire an enter key press, you would  write `.type('document', '\u000d')`.
 
 > If you don't need the keyboard events, consider using `.insert()` instead as it will be faster and more robust.
 
@@ -418,25 +418,23 @@ var background = yield Nightmare()
 You can also add custom Electron actions.  The additional Electron action or namespace actions take `name`, `options`, `parent`, `win`, `renderer`, and `done`.  Note the Electron action comes first, mirroring how `.evaluate()` works.  For example:
 
 ```javascript
-Nightmare.action('echo',
+Nightmare.action('clearCache',
   function(name, options, parent, win, renderer, done) {
-    parent.on('echo', function(message) {
-      parent.emit('log', 'echo: ' + message);
+    parent.respondTo('clearCache', function(done) {
+      win.webContents.session.clearCache(done);
     });
     done();
   },
   function(message, done) {
-    this.child.emit('echo', message);
-    done();
-    return this;
+    this.child.call('clearCache', done);
   });
 
 yield Nightmare()
-  .goto('http://example.org')
-  .echo('hello there!');
+  .clearCache()
+  .goto('http://example.org');
 ```
 
-...would have a `nightmare:log` showing "hello there!" when run with `DEBUG=nightmare*`.
+...would clear the browser’s cache before navigating to `example.org`.
 
 #### .use(plugin)
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -449,10 +449,7 @@ exports.viewport = function (width, height, done) {
 
 exports.useragent = function(useragent, done) {
   debug('.useragent() to ' + useragent);
-  this.child.once('useragent', function () {
-    done();
-  });
-  this.child.emit('useragent', useragent);
+  this.child.call('useragent', useragent, done);
 };
 
 /**

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -146,8 +146,7 @@ exports.type = function() {
     this.evaluate_now(function (selector) {
       document.querySelector(selector).focus();
     }, function() {
-      child.once('type', done);
-      child.emit('type', text);
+      child.call('type', text, done);
     }, selector);
   }
 };
@@ -178,8 +177,7 @@ exports.insert = function (selector, text, done) {
     this.evaluate_now(function (selector) {
       document.querySelector(selector).focus();
     }, function() {
-      child.once('insert', done);
-      child.emit('insert', text);
+      child.call('insert', text, done);
     }, selector);
   }
 }
@@ -417,8 +415,7 @@ exports.inject = function (type, file, done) {
   }
   else if (type === 'css') {
     var css = fs.readFileSync(file, { encoding: 'utf-8' });
-    this.child.emit('css', css);
-    done();
+    this.child.call('css', css, done);
   }
   else {
     debug('unsupported file type in .inject()');
@@ -436,8 +433,7 @@ exports.inject = function (type, file, done) {
 
 exports.viewport = function (width, height, done) {
   debug('.viewport()');
-  this.child.emit('size', width, height);
-  done();
+  this.child.call('size', width, height, done);
 };
 
 /**
@@ -486,12 +482,11 @@ exports.screenshot = function (path, clip, done) {
     clip = (typeof path === 'string') ? undefined : path;
     path = (typeof path === 'string') ? path : undefined;
   }
-  this.child.once('screenshot', function (img) {
+  this.child.call('screenshot', path, clip, function (error, img) {
     var buf = new Buffer(img.data);
     debug('.screenshot() captured with length %s', buf.length);
     path ? fs.writeFile(path, buf, done) : done(null, buf);
   });
-  this.child.emit('screenshot', path, clip);
 };
 
 /**
@@ -516,11 +511,10 @@ exports.html = function (path, saveType, done) {
     done = saveType;
     saveType = undefined;
   }
-  this.child.once('html', function (err) {
-    if (err) debug(err);
-    done(err);
+  this.child.call('html', path, saveType, function (error) {
+    if (error) debug(error);
+    done(error);
   });
-  this.child.emit('html', path, saveType);
 }
 
 /**
@@ -544,13 +538,12 @@ exports.pdf = function (path, options, done) {
     done = options;
     options = undefined;
   }
-  this.child.once('pdf', function (err, pdf) {
-    if (err) debug(err);
+  this.child.call('pdf', path, options, function (error, pdf) {
+    if (error) debug(error);
     var buf = new Buffer(pdf.data);
     debug('.pdf() captured with length %s', buf.length);
     path ? fs.writeFile(path, buf, done) : done(null, buf);
   });
-  this.child.emit('pdf', path, options);
 };
 
 /**
@@ -582,8 +575,7 @@ exports.cookies.get = function (name, done) {
       break;
   }
 
-  this.child.once('cookie.get', done)
-  this.child.emit('cookie.get', query);
+  this.child.call('cookie.get', query, done);
 };
 
 /**
@@ -610,8 +602,7 @@ exports.cookies.set = function (name, value, done) {
       break;
   }
 
-  this.child.once('cookie.set', done);
-  this.child.emit('cookie.set', cookies);
+  this.child.call('cookie.set', cookies, done);
 };
 
 /**
@@ -631,8 +622,7 @@ exports.cookies.clear = function (name, done) {
       break;
   }
 
-  this.child.once('cookie.clear', done);
-  this.child.emit('cookie.clear', cookies);
+  this.child.call('cookie.clear', cookies, done);
 };
 
 /**
@@ -641,6 +631,5 @@ exports.cookies.clear = function (name, done) {
 
  exports.authentication = function (login, password, done) {
    debug('.authentication()');
-   this.child.once('authentication', done);
-   this.child.emit('authentication', login, password);
+   this.child.call('authentication', login, password, done);
  };

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -6,6 +6,14 @@
 
 var Emitter = require('events').EventEmitter;
 var sliced = require('sliced');
+var debug = require('debug')('nightmare:ipc');
+
+// If this process has a parent, redirect debug logs to it
+if (process.send) {
+  debug = function() {
+    process.send(['nightmare:ipc:debug'].concat(sliced(arguments)));
+  };
+}
 
 /**
  * Export `IPC`
@@ -34,6 +42,10 @@ function IPC(process) {
   }
 
   process.on('message', function(data) {
+    // handle debug logging specially
+    if (data[0] === 'nightmare:ipc:debug') {
+      debug.apply(null, sliced(data, 1));
+    }
     emit.apply(emitter, sliced(data));
   });
 
@@ -41,7 +53,7 @@ function IPC(process) {
     if(process.connected){
       process.send(sliced(arguments));
     }
-  }
+  };
 
   /**
    * Call a responder function in the associated process. (In the process,
@@ -97,6 +109,9 @@ function IPC(process) {
    * @param {Function} responder
    */
   emitter.respondTo = function(name, responder) {
+    if (responders[name]) {
+      debug(`Replacing responder named "${name}"`);
+    }
     responders[name] = responder;
   };
 

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies
  */
@@ -15,9 +17,16 @@ module.exports = IPC;
  * Initialize `IPC`
  */
 
+var instance = Symbol();
 function IPC(process) {
-  var emitter = new Emitter();
+  if (process[instance]) {
+    return process[instance];
+  }
+
+  var emitter = process[instance] = new Emitter();
   var emit = emitter.emit;
+  var callId = 0;
+  var responders = {};
 
   // no parent
   if (!process.send) {
@@ -33,6 +42,85 @@ function IPC(process) {
       process.send(sliced(arguments));
     }
   }
+
+  /**
+   * Call a responder function in the associated process. (In the process,
+   * responders can be registered with `ipc.respondTo()`.) The last argument
+   * should be a callback function, which will called with the results of the
+   * responder.
+   * This returns an event emitter. You can listen for the results of the
+   * responder using the `end` event (this is the same as passing a callback).
+   * Additionally, you can listen for `data` events, which the responder may
+   * send to indicate some sort of progress.
+   * @param  {String} name Name of the responder function to call
+   * @param  {...Objects} [arguments] Any number of arguments to send
+   * @param  {Function} [callback] A callback function that handles the results
+   * @return {Emitter}
+   */
+  emitter.call = function(name) {
+    var args = sliced(arguments, 1);
+    var callback = args.pop();
+    if (typeof callback !== 'function') {
+      args.push(callback);
+      callback = undefined;
+    }
+
+    var id = callId++;
+    var progress = new Emitter();
+
+    emitter.on(`CALL_DATA_${id}`, function() {
+      progress.emit.apply(progress, ['data'].concat(sliced(arguments)));
+    });
+
+    emitter.once(`CALL_RESULT_${id}`, function() {
+      progress.emit.apply(progress, ['end'].concat(sliced(arguments)));
+      emitter.removeAllListeners(`CALL_DATA_${id}`);
+      progress.removeAllListeners();
+      progress = undefined;
+      if (callback) {
+        callback.apply(null, arguments);
+      }
+    });
+
+    emitter.emit.apply(emitter, ['CALL', id, name].concat(args));
+    return progress;
+  };
+
+  /**
+   * Register a responder to be called from other processes with `ipc.call()`.
+   * The responder should be a function that accepts any number of arguments,
+   * where the last argument is a callback function. When the responder has
+   * finished its work, it MUST call the callback. The first argument should be
+   * an error, if any, and the second should be the results.
+   * Only one responder can be registered for a given name.
+   * @param {String} name The name to register the responder under.
+   * @param {Function} responder
+   */
+  emitter.respondTo = function(name, responder) {
+    responders[name] = responder;
+  };
+
+  emitter.on('CALL', function(id, name) {
+    var args = sliced(arguments, 2);
+    var responder = responders[name];
+    var done = function() {
+      emitter.emit.apply(
+        emitter, [`CALL_RESULT_${id}`].concat(sliced(arguments)));
+    };
+    done.progress = function() {
+      emitter.emit.apply(
+        emitter, [`CALL_DATA_${id}`].concat(sliced(arguments)));
+    };
+    if (!responder) {
+      return done(`Nothing responds to "${name}"`);
+    }
+    try {
+      responder.apply(null, sliced(arguments, 2).concat([done]));
+    }
+    catch (error) {
+      done(error);
+    }
+  });
 
   return emitter;
 }

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -281,17 +281,11 @@ Nightmare.prototype.run = function(fn) {
  */
 
 Nightmare.prototype.evaluate_now = function(js_fn, done) {
-  var child = this.child;
-
-  child.once('javascript', function(err, result) {
-    if (err) return done(err);
-    done(null, result);
-  });
-
   var args = Array.prototype.slice.call(arguments).slice(2);
   var argsList = JSON.stringify(args).slice(1,-1);
+  var source = template.execute({ src: String(js_fn), args: argsList });
 
-  child.emit('javascript', template.execute({ src: String(js_fn), args: argsList }));
+  this.child.call('javascript', source, done);
   return this;
 };
 
@@ -300,14 +294,7 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
  */
 
 Nightmare.prototype._inject = function(js, done) {
-  var child = this.child;
-
-  child.once('javascript', function(err, result) {
-    if (err) return done(err);
-    done(null, result);
-  });
-
-  child.emit('javascript', template.inject({ src: js }));
+  this.child.call('javascript', template.inject({ src: js }), done);
   return this;
 };
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -118,17 +118,15 @@ function Nightmare(options) {
   Object.keys(Nightmare.childActions).forEach(function(key){
     debug('queueing child action addition for "%s"', key);
     this.queue(function(done){
-      this.child.once('action', done);
-      this.child.emit('action', key, String(Nightmare.childActions[key]));
+      this.child.call('action', key, String(Nightmare.childActions[key]), done);
     });
   }, this);
 
   this.child = child(this.proc);
   this.child.once('ready', function() {
-    self.child.once('browser-initialize', function() {
+    self.child.call('browser-initialize', options, function() {
       self.state = 'ready';
     });
-    self.child.emit('browser-initialize', options);
   });
 
   // propagate console.log(...) through
@@ -222,8 +220,7 @@ Nightmare.prototype.goto = function(url, headers) {
   }
 
   this.queue(function(fn) {
-    child.once('goto', fn);
-    child.emit('goto', url, headers);
+    child.call('goto', url, headers, fn);
   });
   return this;
 };
@@ -256,10 +253,9 @@ Nightmare.prototype.run = function(fn) {
 
   function after (err, res) {
     var args = sliced(arguments);
-    self.child.once('continue', function() {
+    self.child.call('continue', function() {
       next.apply(self, args);
     });
-    self.child.emit('continue');
   }
 
   function done () {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -66,7 +66,7 @@ app.on('ready', function() {
    * create a browser window
    */
 
-  parent.on('browser-initialize', function(opts) {
+  parent.respondTo('browser-initialize', function(opts, done) {
     options = defaults(opts || {}, {
       show: false,
       alwaysOnTop: true,
@@ -130,7 +130,7 @@ app.on('ready', function() {
     win.webContents.on('plugin-crashed', forward('plugin-crashed'));
     win.webContents.on('destroyed', forward('destroyed'));
 
-    parent.emit('browser-initialize');
+    done();
   });
 
   /**
@@ -141,20 +141,20 @@ app.on('ready', function() {
    * goto
    */
 
-  parent.on('goto', function(url, headers) {
+  parent.respondTo('goto', function(url, headers, done) {
     var extraHeaders = '';
     for (var key in headers) {
       extraHeaders += key + ': ' + headers[key] + '\n';
     }
 
     if (win.webContents.getURL() == url) {
-      parent.emit('goto');
+      done();
     } else {
       var responseData = {};
 
       function handleFailure(event, code, detail, failedUrl, isMainFrame) {
         if (isMainFrame) {
-          done({
+          cleanup({
             message: 'navigation error',
             code: code,
             details: detail,
@@ -178,15 +178,15 @@ app.on('ready', function() {
 
       // We will have already unsubscribed if load failed, so assume success.
       function handleFinish(event) {
-        done(null, responseData);
+        cleanup(null, responseData);
       }
 
-      function done(error, data) {
+      function cleanup(error, data) {
         win.webContents.removeListener('did-fail-load', handleFailure);
         win.webContents.removeListener('did-get-response-details', handleDetails);
         win.webContents.removeListener('did-finish-load', handleFinish);
         // wait a tick before notifying to resolve race conditions for events
-        setImmediate(() => parent.emit('goto', error, data));
+        setImmediate(() => done(error, data));
 
       }
 
@@ -211,7 +211,7 @@ app.on('ready', function() {
           return;
         }
 
-        done({
+        cleanup({
           message: 'navigation error',
           code: -1000,
           details: 'unhandled protocol',
@@ -245,16 +245,18 @@ app.on('ready', function() {
    * css
    */
 
-  parent.on('css', function(css) {
+  parent.respondTo('css', function(css, done) {
     win.webContents.insertCSS(css);
+    done();
   });
 
   /**
    * size
    */
 
-  parent.on('size', function(width, height) {
+  parent.respondTo('size', function(width, height, done) {
     win.setSize(width, height);
+    done();
   });
 
   parent.respondTo('useragent', function(useragent, done) {
@@ -266,14 +268,13 @@ app.on('ready', function() {
    * type
    */
 
-  parent.on('type', function (value) {
+  parent.respondTo('type', function (value, done) {
     var chars = String(value).split('')
 
     function type () {
       var ch = chars.shift()
       if (ch === undefined) {
-        parent.emit('type');
-        return;
+        return done();
       }
 
       // keydown
@@ -311,19 +312,19 @@ app.on('ready', function() {
    * Insert
    */
 
-  parent.on('insert', function(value) {
+  parent.respondTo('insert', function(value, done) {
     win.webContents.insertText(String(value))
-    parent.emit('insert')
+    done();
   })
 
   /**
    * screenshot
    */
 
-  parent.on('screenshot', function(path, clip) {
+  parent.respondTo('screenshot', function(path, clip, done) {
     // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
     var args = [function handleCapture (img) {
-      parent.emit('screenshot', img.toPng());
+      done(null, img.toPng());
     }];
     if (clip) args.unshift(clip);
     frameManager.requestFrame(function() {
@@ -335,11 +336,11 @@ app.on('ready', function() {
    * html
    */
 
-  parent.on('html', function(path, saveType) {
+  parent.respondTo('html', function(path, saveType, done) {
     // https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback
     saveType = saveType || 'HTMLComplete'
-    win.webContents.savePage(path, saveType, function (err) {
-      parent.emit('html', err);
+    win.webContents.savePage(path, saveType, function (error) {
+      done(error);
     });
   });
 
@@ -347,7 +348,7 @@ app.on('ready', function() {
    * pdf
    */
 
-  parent.on('pdf', function(path, options) {
+  parent.respondTo('pdf', function(path, options, done) {
     // https://github.com/fraserxu/electron-pdf/blob/master/index.js#L98
     options = defaults(options || {}, {
       marginType: 0,
@@ -356,9 +357,9 @@ app.on('ready', function() {
       landscape: false
     });
 
-    win.webContents.printToPDF(options, function (err, data) {
-      if (err) return parent.emit('pdf', arguments);
-      parent.emit('pdf', null , data);
+    win.webContents.printToPDF(options, function (error, data) {
+      if (error) return done(arguments);
+      done(null , data);
     });
   });
 
@@ -366,15 +367,15 @@ app.on('ready', function() {
    * Get cookies
    */
 
-  parent.on('cookie.get', function (query) {
+  parent.respondTo('cookie.get', function (query, done) {
     var details = assign({}, {
       url: win.webContents.getURL(),
     }, query)
 
     parent.emit('log', 'getting cookie: ' + JSON.stringify(details))
-    win.webContents.session.cookies.get(details, function (err, cookies) {
-      if (err) return parent.emit('cookie.get', err);
-      parent.emit('cookie.get', null, details.name ? cookies[0] : cookies)
+    win.webContents.session.cookies.get(details, function (error, cookies) {
+      if (error) return done(error);
+      done(null, details.name ? cookies[0] : cookies)
     })
   })
 
@@ -382,7 +383,7 @@ app.on('ready', function() {
    * Set cookies
    */
 
-  parent.on('cookie.set', function (cookies) {
+  parent.respondTo('cookie.set', function (cookies, done) {
     var pending = cookies.length
 
     for (var i = 0, cookie; cookie = cookies[i]; i++) {
@@ -391,9 +392,9 @@ app.on('ready', function() {
       }, cookie)
 
       parent.emit('log', 'setting cookie: ' + JSON.stringify(details))
-      win.webContents.session.cookies.set(details, function (err) {
-        if (err) parent.emit('cookie.set', err);
-        else if (!--pending) parent.emit('cookie.set')
+      win.webContents.session.cookies.set(details, function (error) {
+        if (error) done(error);
+        else if (!--pending) done();
       })
     }
   })
@@ -402,7 +403,7 @@ app.on('ready', function() {
    * Clear cookie
    */
 
-  parent.on('cookie.clear', function (cookies) {
+  parent.respondTo('cookie.clear', function (cookies, done) {
     var url = win.webContents.getURL()
     var pending = cookies.length
 
@@ -410,9 +411,9 @@ app.on('ready', function() {
 
     for (var i = 0, cookie; cookie = cookies[i]; i++){
       parent.emit('log', 'clearing cookie: ' + JSON.stringify(cookie))
-      win.webContents.session.cookies.remove(url, cookie, function (err) {
-          if (err) parent.emit('cookie.clear', err);
-          else if (!--pending) parent.emit('cookie.clear')
+      win.webContents.session.cookies.remove(url, cookie, function (error) {
+          if (error) done(error);
+          else if (!--pending) done();
       })
     }
   });
@@ -421,14 +422,14 @@ app.on('ready', function() {
    * Add custom functionality
    */
 
-  parent.on('action', function(name, fntext){
+  parent.respondTo('action', function(name, fntext, done){
     var fn = new Function('with(this){ parent.emit("log", "adding action for '+ name +'"); return ' + fntext + '}')
       .call({
         require: require,
         parent: parent
       });
-    fn(name, options, parent, win, renderer, function(err){
-      parent.emit('action', err);
+    fn(name, options, parent, win, renderer, function(error){
+      done(error);
      });
   });
 
@@ -436,19 +437,15 @@ app.on('ready', function() {
    * Continue
    */
 
-  parent.on('continue', function() {
+  parent.respondTo('continue', function(done) {
     if (!win.webContents.isLoading()) {
-      ready();
+      done();
     } else {
       parent.emit('log', 'navigating...');
       win.webContents.once('did-stop-loading', function() {
         parent.emit('log', 'navigated to: ' + win.webContents.getURL());
-        ready();
+        done();
       });
-    }
-
-    function ready () {
-      parent.emit('continue');
     }
   });
 
@@ -456,11 +453,11 @@ app.on('ready', function() {
    * Authentication
    */
 
-  parent.on('authentication', function(login, password) {
+  parent.respondTo('authentication', function(login, password, done) {
     win.webContents.on('login', function(webContents, request, authInfo, callback) {
         callback(login, password);
     });
-    parent.emit('authentication');
+    done();
   });
 
   /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -158,13 +158,13 @@ app.on('ready', function() {
    * javascript
    */
 
-  parent.on('javascript', function(src) {
+  parent.respondTo('javascript', function(src, done) {
     renderer.once('response', function(event, response) {
-      parent.emit('javascript', null, response);
+      done(null, response);
     });
 
     renderer.once('error', function(event, error) {
-      parent.emit('javascript', error);
+      done(error);
     });
 
     renderer.once('log', function(event, args) {
@@ -190,9 +190,9 @@ app.on('ready', function() {
     win.setSize(width, height);
   });
 
-  parent.on('useragent', function(useragent) {
+  parent.respondTo('useragent', function(useragent, done) {
     win.webContents.setUserAgent(useragent);
-    parent.emit('useragent');
+    done();
   });
 
   /**
@@ -356,9 +356,9 @@ app.on('ready', function() {
 
   parent.on('action', function(name, fntext){
     var fn = new Function('with(this){ parent.emit("log", "adding action for '+ name +'"); return ' + fntext + '}')
-      .call({ 
-        require: require, 
-        parent: parent 
+      .call({
+        require: require,
+        parent: parent
       });
     fn(name, options, parent, win, renderer, function(err){
       parent.emit('action', err);

--- a/test/index.js
+++ b/test/index.js
@@ -1476,7 +1476,31 @@ describe('Nightmare', function () {
         function() {
           done();
         });
-    })
+    });
+
+    it('should log a warning when replacing a responder', function*() {
+      Nightmare.action('uhoh',
+        function(_, __, parent, ___, ____, done) {
+          parent.respondTo('test', function(done) {
+            done();
+          });
+          done();
+        },
+        function(done) {
+          this.child.call('test', done);
+        });
+
+      var logged = false;
+      yield Nightmare()
+        .on('nightmare:ipc:debug', function(message) {
+          if (message.toLowerCase().indexOf('replacing') > -1) {
+            logged = true;
+          }
+        })
+        .goto('about:blank')
+        .end();
+      logged.should.be.true;
+    });
   });
 });
 


### PR DESCRIPTION
This addresses one aspect of #493. It should make IPC between the user’s process and the Electron process a) “safe” in that simultaneous calls can’t cause incorrect results and b) simpler. It’s based on discussion with @rosshinkley in issue #493.

The main idea here is that Nightmare’s IPC objects gain two methods, each to be used in opposite processes:

- `ipc.respondTo(name, responder)` Registers a function that can respond to calls from another process. The `name` is a handle by which other processes call it. The responder takes any number of arguments, where the last one is a callback. This callback should be called when the responder’s work is complete. Any arguments will be passed back to the caller in the other process. In addition, the callback has a method named `progress` that can be called to emit `data` events in the other process.

    ```js
    ipc.respondTo('cookies.get', function(query, done) {
      webContents.session.cookies.get(query, function(error, cookies) {
        if (error) { return done(error); }
        done(null, query.name ? cookies[0] : cookies);
      });
    });
    ```

- `ipc.call(name, [arg, [arg, [...]]], [callback])` Calls a responder with the given `name` in another process. Any arguments between the `name` and `callback` are passed as arguments to the responder. The callback will be called when the responder’s work is finished. In addition, this returns an event emitter than can be used to handle `data` events indicating progress from the responder or a single `end` event, which will be called with the same arguments as and immediately prior to `callback`.

    ```js
    ipc.call('cookies.get', {name: 'my-cookie'}, function(error, cookie) {
      if (error) { return console.error('UHOH!', error); }
      console.log('OM NOM NOM I GOT ME A COOKIE!', cookie);
    });
    ```

Under the hood this is accomplished by having three special IPC messages:

- `CALL` indicates that a responder should be called. Sent from the parent, to the child. It has at least 2 arguments:
    1. A unique ID identifying the call. This is used to ensure responses don’t get tied up with other calls to the same responder.
    2. The name of the responder to call
    3. Arguments to pass to the responder.

- `CALL_DATA_{ID}` indicates progress data related to a call is being sent. Sent from the child to the parent. The ID in the name is the unique ID that was sent with the initial call above.

- `CALL_RESULT_{ID}` indicates that this is the final result of the call. Sent from the child to the parent. The ID in the name is the unique ID that was sent with the initial call above.

The above set of messages can be used in either direction, but they are probably only relevant now in terms of calls from the parent to the child. Maybe worth noting: a very similar (but more heavily built out and robust) mechanism is used internally in Electron’s `remote` module. This one is more minimal and light-weight, but sacrifices a lot of nice features that one has (support for circular references, complex types like dates, functions, promises, errors, and placeholder objects instead of string names).

## Notes and open questions

1. This doesn’t convert all calls yet. It just does `evaluate_now` and `useragent` as demo cases. A later commit will have to do the rest.

2. In implementing this, I noticed that we can wind up with multiple IPC objects for a single process. It doesn’t actively cause problems, but depending on the order things are registered in, it could, so I made sure there could only be one IPC instance per process.

3. This implementation differs slightly from the initial proposal in #493—it is intended to be backwards-compatible (so it doesn’t break plugins). I’m not sure if that a virtue or unnecessary, since plugins that can run in the Electron process are pretty new. The method names are also slightly different; I thought these were clearer.

4. The progress capability is neat, but it incurs a lot of additional complexity and I’m not sure how much real value it adds. No existing actions use anything like it. The situations where it would be useful might be just as well handled with more judicious debug messages, error throwing, or simple events. We could easily remove the progress support and add it again later.
    - If we keep it, should be a stream instead of a simple emitter? Like the progress capability itself, its benefits are primarily theoretical and it probably comes with a more complex implementation.

5. This implementation sits atop the existing `ipc.emit()` and `ipc.on()` methods. That means the special `CALL*` messages can be pretty easily observed. I’m not sure that’s a big deal, but we could call the appropriate methods on the `process` instead to make intercepting things harder.

6. My initial implementation relied heavily on the spread operator, which made things much simpler. However, spread isn’t available in Node v4.x without the `--harmony` flag (it’s 👍 in v5.x), so I removed it in favor of lots of `apply()` calls.
    - `--harmony` is still mentioned in the README (only down at the bottom), but not actually required in practice on Node 4+. I think it’s good that it’s not required.
    - In hindsight, a lot of the `apply()` noise (not all) could be avoided by just sending arguments as an array through IPC instead of spreading them into the message arguments.

7. Some action implementations in the Electron process will get more complex (only slightly) because of this. Several actions are fire-and-forget, but in this implementation, they *have* to call a callback. Because arguments are so dynamic in Nightmare, I can’t think of a good way to detect whether an action (on the Electron side) actually uses the callback. Probably not a big deal, but I just wanted to call it out.

8. You only get to have one responder for a given name. I think that’s reasonable (what would you do with more??), but not sure if it’s worth adding some logging or throw errors if `respondTo` is called with the same `name` more than once.

9. There’s no way to unregister a responder. I’m not sure we need it, but maybe?

I’d love feedback from anybody on this. Ideally this is a safe, backwards-compatible change (see (3) above), but it’s still a major (and deep) API change. We should be more 👍 than ¯\\\_(ツ)\_/¯ in order to accept it.