### PR TITLE
Fix usage of deprecated Electron APIs

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,5 +1,5 @@
 window.__nightmare = {};
-__nightmare.ipc = require('ipc');
+__nightmare.ipc = require('electron').ipcRenderer;
 __nightmare.sliced = require('sliced');
 
 // Listen for error events

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -289,7 +289,7 @@ app.on('ready', function() {
       landscape: false
     });
 
-    win.printToPDF(options, function (err, data) {
+    win.webContents.printToPDF(options, function (err, data) {
       if (err) return parent.emit('pdf', arguments);
       parent.emit('pdf', null , data);
     });
@@ -356,9 +356,9 @@ app.on('ready', function() {
 
   parent.on('action', function(name, fntext){
     var fn = new Function('with(this){ parent.emit("log", "adding action for '+ name +'"); return ' + fntext + '}')
-      .call({ 
-        require: require, 
-        parent: parent 
+      .call({
+        require: require,
+        parent: parent
       });
     fn(name, options, parent, win, renderer, function(err){
       parent.emit('action', err);

--- a/test/index.js
+++ b/test/index.js
@@ -1002,7 +1002,7 @@ describe('Nightmare', function () {
     });
 
     it('should set viewport', function*() {
-      var size = { width: 400, height: 300, 'use-content-size': true };
+      var size = { width: 400, height: 300, useContentSize: true };
       nightmare = Nightmare(size);
       var result = yield nightmare
         .goto(fixture('options'))
@@ -1245,7 +1245,7 @@ describe('Nightmare', function () {
           this.child.emit('checkDevTools');
         });
       nightmare = Nightmare({show:true, openDevTools:true});
-      
+
     });
 
     afterEach(function*(){


### PR DESCRIPTION
We were using a few deprecated Electron APIs in various spots. Best to fix that before they disappear entirely and break! Happily, they were all just renamings or moves to other locations, so this was very straightforward.

Noticed while looking at #421.