### PR TITLE
Add testing for deprecated API usage in Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mocha-generators": "^1.2.0",
     "multer": "1.1.0",
     "pngjs": "^2.2.0",
-    "serve-static": "^1.10.0"
+    "serve-static": "^1.10.0",
+    "split": "^1.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,7 @@ var rimraf = require('rimraf');
 var child_process = require('child_process');
 var PNG = require('pngjs').PNG;
 var should = chai.should();
+var split = require('split');
 
 /**
  * Temporary directory
@@ -37,6 +38,11 @@ var base = 'http://localhost:7500/';
 describe('Nightmare', function () {
   before(function (done) {
     server.listen(7500, done);
+    Nightmare = withDeprecationTracking(Nightmare);
+  });
+
+  after(function() {
+    Nightmare.assertNoDeprecations();
   });
 
   it('should be constructable', function*() {
@@ -1245,7 +1251,7 @@ describe('Nightmare', function () {
           this.child.emit('checkDevTools');
         });
       nightmare = Nightmare({show:true, openDevTools:true});
-      
+
     });
 
     afterEach(function*(){
@@ -1272,6 +1278,34 @@ describe('Nightmare', function () {
 
 function fixture(path) {
   return url.resolve(base, path);
+}
+
+/**
+ * Track deprecation warnings.
+ */
+
+function withDeprecationTracking(constructor) {
+  var newConstructor = function() {
+    var instance = constructor.apply(this, arguments);
+    instance.proc.stderr.pipe(split()).on('data', (line) => {
+      if (line.indexOf('deprecated') > -1) {
+        newConstructor.__deprecations.add(line);
+      }
+    });
+    return instance;
+  };
+  newConstructor.__deprecations = new Set();
+  newConstructor.assertNoDeprecations = function() {
+    var deprecations = Nightmare.__deprecations;
+    if (deprecations.size) {
+      var plural = deprecations.size === 1 ? '' : 's';
+      throw new Error(
+        `Used ${deprecations.size} deprecated Electron API${plural}:
+        ${Array.from(deprecations).join('\n        ')}`);
+    }
+  }
+  Object.setPrototypeOf(newConstructor, constructor);
+  return newConstructor;
 }
 
 /**


### PR DESCRIPTION
Running across #581 made me think it would be a good idea to get automatic warning of deprecated API usage. This causes the test suite to fail at the end if any deprecated APIs are used.

The implementation basically wraps the Nightmare constructor used in tests and watches Electron’s `stderr` for deprecation warnings, then throws an exception at the end if there were any.