### PR TITLE
piping electron stdout and stderr to debug calls

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -5,8 +5,8 @@
 var log = require('debug')('nightmare:log');
 var debug = require('debug')('nightmare');
 var electronLog = {
-  stdout: require('debug')('nightmare:electron:stdout'),
-  stderr: require('debug')('nightmare:electron:stderr')
+  stdout: require('debug')('electron:stdout'),
+  stderr: require('debug')('electron:stderr')
 };
 
 /**

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -21,6 +21,7 @@ var join = require('path').join;
 var sliced = require('sliced');
 var child = require('./ipc');
 var once = require('once');
+var split2 = require('split2');
 var noop = function() {};
 var keys = Object.keys;
 
@@ -71,12 +72,12 @@ function Nightmare(options) {
     stdio: [null, null, null, 'ipc']
   });
 
-  this.proc.stdout.on('data', (data) => {
-    electronLog.stdout(data.toString().trim());
+  this.proc.stdout.pipe(split2()).on('data', (data) => {
+    electronLog.stdout(data);
   });
 
-  this.proc.stderr.on('data', (data) => {
-    electronLog.stderr(data.toString().trim());
+  this.proc.stderr.pipe(split2()).on('data', (data) => {
+    electronLog.stderr(data);
   });
 
   this.proc.on('close', function(code) {

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -4,6 +4,10 @@
 
 var log = require('debug')('nightmare:log');
 var debug = require('debug')('nightmare');
+var electronLog = {
+  stdout: require('debug')('nightmare:electron:stdout'),
+  stderr: require('debug')('nightmare:electron:stderr')
+};
 
 /**
  * Module dependencies
@@ -65,6 +69,14 @@ function Nightmare(options) {
 
   this.proc = proc.spawn(electron_path, [runner].concat(JSON.stringify(electronArgs)), {
     stdio: [null, null, null, 'ipc']
+  });
+
+  this.proc.stdout.on('data', (data) => {
+    electronLog.stdout(data.toString().trim());
+  });
+
+  this.proc.stderr.on('data', (data) => {
+    electronLog.stderr(data.toString().trim());
   });
 
   this.proc.on('close', function(code) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "object-assign": "^4.0.1",
     "once": "^1.3.3",
     "rimraf": "^2.4.3",
-    "sliced": "1.0.1"
+    "sliced": "1.0.1",
+    "split2": "^2.0.1"
   },
   "devDependencies": {
     "basic-auth": "^1.0.3",


### PR DESCRIPTION
Fixes #421, at least in part.

Open questions: 

1. Should Nightmare override the environment variable for `ELECTRON_ENABLE_LOGGING`?
2. Should the `nightmare:` namespace be on the debug calls for Electron?