### PR TITLE
Upgrade to Electron 0.37.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron-prebuilt": "^0.37.6",
+    "electron-prebuilt": "^0.37.7",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",


### PR DESCRIPTION
Contains upstream fixes for #375, #563, #572. For the dev tools issues, I think we should still take #576, but this does obviate it on a technical level.