### PR TITLE
Remove `process` event listeners when a Nightmare instance ends

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -78,25 +78,7 @@ function Nightmare(options) {
     debug('electron child process exited with code ' + code + ': ' + help[code]);
   });
 
-  process.setMaxListeners(Infinity);
-  process.on('uncaughtException', function(err) {
-    console.error(err.stack);
-    endInstance(self);
-    // This allows any user defined 'uncaughtException' handlers
-    // to run before exiting
-    process.nextTick(function() {
-        process.exit(1);
-    });
-  });
-
-  // if the process nightmare is running in dies, make sure to kill electron
-  var endSelf = endInstance.bind(null, self);
-  process.on('exit', endSelf);
-  process.on('SIGINT', endSelf);
-  process.on('SIGTERM', endSelf);
-  process.on('SIGQUIT', endSelf);
-  process.on('SIGHUP', endSelf);
-  process.on('SIGBREAK', endSelf);
+  attachToProcess(this);
 
   // initial state
   this.state = 'initial';
@@ -165,11 +147,37 @@ function Nightmare(options) {
 }
 
 function endInstance(instance) {
+  instance.ended = true;
+  detachFromProcess(instance);
   if (instance.proc.connected) {
+    instance.child.removeAllListeners();
+    instance.proc.removeAllListeners();
     instance.proc.disconnect();
     instance.proc.kill();
-    instance.ended = true;
   }
+}
+
+/**
+ * Attach any instance-specific process-level events.
+ */
+function attachToProcess(instance) {
+  instance._endNow = endInstance.bind(null, instance);
+  process.setMaxListeners(Infinity);
+  process.on('exit', instance._endNow);
+  process.on('SIGINT', instance._endNow);
+  process.on('SIGTERM', instance._endNow);
+  process.on('SIGQUIT', instance._endNow);
+  process.on('SIGHUP', instance._endNow);
+  process.on('SIGBREAK', instance._endNow);
+}
+
+function detachFromProcess(instance) {
+  process.removeListener('exit', instance._endNow);
+  process.removeListener('SIGINT', instance._endNow);
+  process.removeListener('SIGTERM', instance._endNow);
+  process.removeListener('SIGQUIT', instance._endNow);
+  process.removeListener('SIGHUP', instance._endNow);
+  process.removeListener('SIGBREAK', instance._endNow);
 }
 
 /**


### PR DESCRIPTION
This is one of several issues @fr- noted in #282. It is also important because the registered listener could cause the Nightmare instance to be retained even if there are no other references to it, which means instances can never be garbage collected.

This also removes the uncaught exception listener on the parent process, as mentioned in https://github.com/segmentio/nightmare/issues/586#issuecomment-212681749.

Finally, ensure the instance gets marked as ended even if the child process connection has already died (e.g. it crashed).

Other notes:

- This adds a “private” variable to nightmare instances named `_endNow`. I’d like not to do that, but nightmare already stores several private variables this way and I didn’t want to either totally rearrange the code by bringing `run` inside a closure or introduce a whole new pattern of using `WeakMap` to store references to private data.

- This still installs lots of listeners (the primary issue at hand in #282). It slightly reduces the trouble by cleaning up listeners when an instance is done with, but it’s not perfect. Another approach would be to have a central registry of instances that handles telling each of them to end when relevant process events happen, which would mean we only add one listener per event instead of one per event per instance. If we move to a single electron process model, we’ll probably have to have that central registry to do other things anyway.