### PR TITLE
Bring back support for `javascript:` URLs

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -15,7 +15,7 @@ var fs = require('fs');
 var urlFormat = require('url');
 var FrameManager = require('./frame-manager');
 
-const KNOWN_PROTOCOLS = ['http', 'https', 'file', 'about'];
+const KNOWN_PROTOCOLS = ['http', 'https', 'file', 'about', 'javascript'];
 
 /**
  * Handle uncaught exceptions in the main electron process
@@ -192,15 +192,16 @@ app.on('ready', function() {
 
       // In most environments, loadURL handles this logic for us, but in some
       // it just hangs for unhandled protocols. Mitigate by checking ourselves.
-      function canLoadProtocol(url, callback) {
-        var protocol = (urlFormat.parse(url).protocol || '').replace(/:$/, '');
+      function canLoadProtocol(protocol, callback) {
+        protocol = (protocol || '').replace(/:$/, '');
         if (!protocol || KNOWN_PROTOCOLS.includes(protocol)) {
           return callback(true);
         }
         electron.protocol.isProtocolHandled(protocol, callback);
       }
 
-      canLoadProtocol(url, function(canLoad) {
+      var protocol = urlFormat.parse(url).protocol;
+      canLoadProtocol(protocol, function(canLoad) {
         if (canLoad) {
           win.webContents.on('did-fail-load', handleFailure);
           win.webContents.on('did-get-response-details', handleDetails);
@@ -208,6 +209,21 @@ app.on('ready', function() {
           win.webContents.loadURL(url, {
             extraHeaders: extraHeaders
           });
+
+          // javascript: URLs *may* trigger page loads; wait a bit to see
+          if (protocol === 'javascript:') {
+            setTimeout(function() {
+              if (!win.webContents.isLoading()) {
+                done(null, {
+                  url: url,
+                  code: 200,
+                  method: 'GET',
+                  referrer: win.webContents.getURL(),
+                  headers: {}
+                });
+              }
+            }, 10);
+          }
           return;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -298,6 +298,32 @@ describe('Nightmare', function () {
           done();
         });
     });
+
+    it('should support javascript URLs', function*() {
+      var gotoResult = yield nightmare
+        .goto(fixture('navigation'))
+        .goto('javascript:void(document.querySelector(".a").textContent="LINK");');
+      gotoResult.should.be.an('object');
+
+      var linkText = yield nightmare
+        .evaluate(function() {
+          return document.querySelector('.a').textContent;
+        });
+      linkText.should.equal('LINK');
+    });
+
+    it('should support javascript URLs that load pages', function*() {
+      var data = yield nightmare
+        .goto(fixture('navigation'))
+        .goto(`javascript:window.location='${fixture('navigation/a.html')}'`);
+      data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
+
+      var linkText = yield nightmare
+        .evaluate(function() {
+          return document.querySelector('.d').textContent;
+        });
+      linkText.should.equal('D');
+    });
   });
 
   describe('evaluation', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -317,6 +317,7 @@ describe('Nightmare', function () {
         .goto(fixture('navigation'))
         .goto(`javascript:window.location='${fixture('navigation/a.html')}'`);
       data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
+      data.url.should.equal(fixture('navigation/a.html'));
 
       var linkText = yield nightmare
         .evaluate(function() {


### PR DESCRIPTION
Fixes #590.

We used to support `javascript:` URLs, but lost that feature in #553. TBH, I’m slightly skeptical on bringing it back, *but* #553 got released in an extra-minor update, so it seems worth fixing since it actually broke some people.

Bonus: this supports page loading data for URLs like `javascript:window.location='http://google.com'`. It could be ever so slightly faster if we didn’t bother to support that. Seemed nice to have, though. ¯\\\_(ツ)\_/¯

Also worth noting: we don’t handle errors especially well this way. It’s not any worse than before, but I wonder if calling `goto('javascript:notAnActualFunction()')` should return error instead of success, which I think we could do by passing JS URLs through the evaluate code and then, if the result is not `undefined`, setting the URL. That’s complicated, though. (You *can* currently capture errors with the `page-error` event, but it’s hard to connect that with the URL.)