### PR TITLE
get version information synchronously

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -155,6 +155,11 @@ var nightmare = Nightmare({
   show: true
 });
 ```
+#### .version
+Returns the current version of Nightmare.
+
+#### .engineVersions
+A hash containing the versions of Chromium and Electron that Nightmare is currently using.
 
 #### .useragent(useragent)
 Set the `useragent` used by electron.

--- a/Readme.md
+++ b/Readme.md
@@ -93,6 +93,9 @@ package for Mocha, which enables the support for generators.
 #### Nightmare(options)
 Create a new instance that can navigate around the web. The available options are [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions), along with the following nightmare-specific options.
 
+#### Nightmare.version
+Returns the current version of Nightmare.
+
 ##### waitTimeout (default: 30s)
 This will throw an exception if the `.wait()` didn't return `true` within the set timeframe.
 
@@ -155,9 +158,6 @@ var nightmare = Nightmare({
   show: true
 });
 ```
-#### .version
-Returns the current version of Nightmare.
-
 #### .engineVersions
 A hash containing the versions of Chromium and Electron that Nightmare is currently using.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -44,6 +44,11 @@ var runner = path.join(__dirname, 'runner.js');
 var template = require('./javascript');
 
 /**
+ * Version
+ */
+Nightmare.version = require(path.resolve(__dirname, '..', 'package.json')).version;
+
+/**
  * Initialize `Nightmare`
  *
  * @param {Object} options
@@ -92,20 +97,11 @@ function Nightmare(options) {
   });
 
   Object.defineProperty(this, 'engineVersions', {
-    get: function() {
-      delete this.engineVersions; 
-      return this.engineVersions = JSON.parse(
-        proc.execSync(`${electron_path} ${runner} --engineVersions`, {
+    value:  JSON.parse(proc.execSync(`${electron_path} ${runner} --engineVersions`, {
           encoding:'utf-8',
           stdio: [null, null, null]
-        }));
-    },
+        }))
   });
-  this.version = require(path.resolve(__dirname, '..', 'package.json')).version;
-
-  debug(`Chromium version: ${this.engineVersions.chrome}`)
-  debug(`Electron version: ${this.engineVersions.electron}`)
-  debug(`Nightmare version: ${this.version}`)
 
   attachToProcess(this);
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -17,7 +17,7 @@ var default_electron_path = require('electron-prebuilt');
 var source = require('function-source');
 var proc = require('child_process');
 var actions = require('./actions');
-var join = require('path').join;
+var path = require('path');
 var sliced = require('sliced');
 var child = require('./ipc');
 var once = require('once');
@@ -35,7 +35,7 @@ module.exports = Nightmare;
  * runner script
  */
 
-var runner = join(__dirname, 'runner.js');
+var runner = path.join(__dirname, 'runner.js');
 
 /**
  * Template
@@ -90,6 +90,22 @@ function Nightmare(options) {
 
     debug('electron child process exited with code ' + code + ': ' + help[code]);
   });
+
+  Object.defineProperty(this, 'engineVersions', {
+    get :function() {
+      delete this.engineVersions; 
+      return this.engineVersions = JSON.parse(
+        proc.execSync(`${electron_path} ${runner} --engineVersions`, {
+          encoding:'utf-8',
+          stdio: [null, null, null]
+        }));
+    },
+  });
+  this.version = require(path.resolve(__dirname, '..', 'package.json')).version;
+
+  debug(`Chromium version: ${this.engineVersions.chrome}`)
+  debug(`Electron version: ${this.engineVersions.electron}`)
+  debug(`Nightmare version: ${this.version}`)
 
   attachToProcess(this);
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -92,7 +92,7 @@ function Nightmare(options) {
   });
 
   Object.defineProperty(this, 'engineVersions', {
-    get :function() {
+    get: function() {
       delete this.engineVersions; 
       return this.engineVersions = JSON.parse(
         proc.execSync(`${electron_path} ${runner} --engineVersions`, {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -30,6 +30,15 @@ process.on('uncaughtException', function(e) {
  */
 
 if (process.argv.length > 2) {
+  if(process.argv[2] == '--engineVersions'){
+    console.log(JSON.stringify({
+      electron: process.versions['electron'],
+      chrome: process.versions['chrome']
+    }));
+
+    return process.exit(0);
+  }
+  
   var processArgs = JSON.parse(process.argv[2]);
   var paths = processArgs.paths;
   if (paths) {

--- a/test/index.js
+++ b/test/index.js
@@ -54,12 +54,12 @@ describe('Nightmare', function () {
     yield nightmare.end();
   });
 
-  it('should have version information', function*() {
+  it.only('should have version information', function*() {
     var nightmare = Nightmare();
     nightmare.should.be.ok;
     nightmare.engineVersions.electron.should.be.ok;
     nightmare.engineVersions.chrome.should.be.ok;
-    nightmare.version.should.be.ok;
+    Nightmare.version.should.be.ok;
     yield nightmare.end();
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,15 @@ describe('Nightmare', function () {
     yield nightmare.end();
   });
 
+  it('should have version information', function*() {
+    var nightmare = Nightmare();
+    nightmare.should.be.ok;
+    nightmare.engineVersions.electron.should.be.ok;
+    nightmare.engineVersions.chrome.should.be.ok;
+    nightmare.version.should.be.ok;
+    yield nightmare.end();
+  });
+
   it('should kill its electron process when it is killed', function(done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-unended.js'));


### PR DESCRIPTION
Redo of #600 to fix #599.  This method allows for synchronous version retrieval.

The only thing I'm not _real_ crazy about is the debugging of the version information.  That seems to defeat the purpose of using a lazy getter that props up the cached version values.  Thoughts?