### PR TITLE
Fail explicitly and with better messaging for wrong runner arguments

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -29,19 +29,21 @@ process.on('uncaughtException', function(e) {
  * Update the app paths
  */
 
-if (process.argv.length > 2) {
-  var processArgs = JSON.parse(process.argv[2]);
-  var paths = processArgs.paths;
-  if (paths) {
-    for (var i in paths) {
-      app.setPath(i, paths[i]);
-    }
+if (process.argv.length < 3) {
+  throw new Error(`Too few runner arguments: ${JSON.stringify(process.argv)}`);
+}
+
+var processArgs = JSON.parse(process.argv[2]);
+var paths = processArgs.paths;
+if (paths) {
+  for (var i in paths) {
+    app.setPath(i, paths[i]);
   }
-  var switches = processArgs.switches;
-  if (switches) {
-    for (var i in switches) {
-      app.commandLine.appendSwitch(i, switches[i]);
-    }
+}
+var switches = processArgs.switches;
+if (switches) {
+  for (var i in switches) {
+    app.commandLine.appendSwitch(i, switches[i]);
   }
 }
 


### PR DESCRIPTION
Given notes on https://github.com/segmentio/nightmare/issues/602#issuecomment-215139708 and #607, it seems prudent to add a more explicit failure case for starting the Electron process with incorrect arguments.

*We should never hit this error,* but obviously it’s possible somehow. This at least helps make it more explicit what happened instead of getting some crazy error about trying to access the `dock` property. When people *do* hit it, it also might give some tiny bit of insight into exactly what happened.