### PR TITLE
Javascript: URLs should only wait if the *main* frame is loading.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -215,7 +215,7 @@ app.on('ready', function() {
           // javascript: URLs *may* trigger page loads; wait a bit to see
           if (protocol === 'javascript:') {
             setTimeout(function() {
-              if (!win.webContents.isLoading()) {
+              if (!win.webContents.isLoadingMainFrame()) {
                 done(null, {
                   url: url,
                   code: 200,


### PR DESCRIPTION
This fixes a potential bug where, if `goto('javascript:blahblahblah')` was called while a child frame was loading, the nightmare could wind up getting stuck, never moving on to the next action (because the `goto` machinery is only paying attention to events on the main frame).

[There's a related check for `isLoading()` in the `continue` action](https://github.com/segmentio/nightmare/blob/master/lib/runner.js#L459), but I figured that one was best to leave alone for now—if you want to take a screenshot, for example, you might want to make sure child frames have finished loading first. We could get a minor potential speed boost on pages with frames by changing it, though.