### PR TITLE
Add catch function to nightmare instance

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -377,6 +377,14 @@ Nightmare.prototype.then = function(fulfill, reject) {
 };
 
 /**
+ * catch
+ */
+
+Nightmare.prototype.catch = function(reject) {
+  return this.then(undefined, reject);
+};
+
+/**
  * use
  */
 

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe('Nightmare', function () {
 
     versions.electron.should.be.ok;
     versions.chrome.should.be.ok;
-   
+
     Nightmare.version.should.be.ok;
     yield nightmare.end();
   });
@@ -94,6 +94,19 @@ describe('Nightmare', function () {
 
       child.once('exit', function(code) {
         code.should.not.equal(0);
+        done();
+      });
+  });
+
+  it('should provide a .catch function', function(done) {
+    var nightmare = Nightmare();
+
+    nightmare
+      .goto('about:blank')
+      .evaluate(function() {
+        throw new Error('Test');
+      })
+      .catch(function(err) {
         done();
       });
   });


### PR DESCRIPTION
It felt very awkward to be able to use `.then`, but not `.catch` directly, leading me to write code like this:

```js
browser.evaluate(checkErrors).then(x => x).catch(err => {
  // ...
})
```

This pr will allow me to skip the `.then(x => x)` part and just use `catch` directly, making it work even more as a normal promise.

```js
browser.evaluate(checkErrors).catch(err => {
  // ...
})
```