### PR TITLE
Fix deprecated API usage in preload test (needed to support Electron 1.0+)

### DIFF
--- a/test/fixtures/preload/index.js
+++ b/test/fixtures/preload/index.js
@@ -1,3 +1,3 @@
 window.__nightmare = {};
-__nightmare.ipc = require('ipc');
+__nightmare.ipc = require('electron').ipcRenderer;
 window.preload = 'custom'


### PR DESCRIPTION
We fixed this in the actual preload script, but missed the test! This doesn’t upgrade Electron, but it is a prerequisite for upgrading. (The API is gone entirely in Electron 1.0)