### PR TITLE
Make `goto` reject w/ a helpful message when `url` is not provided

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -144,6 +144,10 @@ app.on('ready', function() {
    */
 
   parent.respondTo('goto', function(url, headers, done) {
+    if (!url || typeof url !== 'string') {
+      return done('goto: `url` must be a non-empty string');
+    }
+
     var extraHeaders = '';
     for (var key in headers) {
       extraHeaders += key + ': ' + headers[key] + '\n';

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe('Nightmare', function () {
 
     versions.electron.should.be.ok;
     versions.chrome.should.be.ok;
-   
+
     Nightmare.version.should.be.ok;
     yield nightmare.end();
   });
@@ -114,6 +114,24 @@ describe('Nightmare', function () {
     it('should return data about the response', function*() {
       var data = yield nightmare.goto(fixture('navigation'));
       data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
+    });
+
+    it('should reject with a useful message when no URL', function() {
+      return nightmare.goto(undefined).then(
+        function() {throw new Error('goto(undefined) didn’t cause an error');},
+        function(error) {
+          error.should.include('url');
+        }
+      );
+    });
+
+    it('should reject with a useful message for an empty URL', function() {
+      return nightmare.goto('').then(
+        function() {throw new Error('goto(undefined) didn’t cause an error');},
+        function(error) {
+          error.should.include('url');
+        }
+      );
     });
 
     it('should click on a link and then go back', function*() {


### PR DESCRIPTION
Fixes #642.

Ultimately, I think it would be better to reject with an instance of `TypeError` (with the same message), but that requires properly serializing and deserializing errors over IPC, which is a non-trivial task (would love to hear your thoughts on this, @rosshinkley). I wanted to get the immediate problem solved first.