### PR TITLE
Give better error messages when element isn't found

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -87,6 +87,9 @@ exports.click = function(selector, done) {
   this.evaluate_now(function (selector) {
     document.activeElement.blur();
     var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
     var event = document.createEvent('MouseEvent');
     event.initEvent('click', true, true);
     element.dispatchEvent(event);
@@ -104,6 +107,9 @@ exports.mousedown = function(selector, done) {
   debug('.mousedown() on ' + selector);
   this.evaluate_now(function (selector) {
     var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
     var event = document.createEvent('MouseEvent');
     event.initEvent('mousedown', true, true);
     element.dispatchEvent(event);
@@ -121,6 +127,9 @@ exports.mouseover = function(selector, done) {
   debug('.mouseover() on ' + selector);
   this.evaluate_now(function (selector) {
     var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
     var event = document.createEvent('MouseEvent');
     event.initMouseEvent('mouseover', true, true);
     element.dispatchEvent(event);

--- a/test/index.js
+++ b/test/index.js
@@ -112,6 +112,42 @@ describe('Nightmare', function () {
       });
   });
 
+  it('should provide useful errors for .click', function(done) {
+    var nightmare = Nightmare();
+
+    nightmare
+      .goto('about:blank')
+      .click('a.not-here')
+      .catch(function (error) {
+        error.should.include('a.not-here');
+        done();
+      });
+  });
+
+  it('should provide useful errors for .mousedown', function(done) {
+    var nightmare = Nightmare();
+
+    nightmare
+      .goto('about:blank')
+      .mousedown('a.not-here')
+      .catch(function (error) {
+        error.should.include('a.not-here');
+        done();
+      });
+  });
+
+  it('should provide useful errors for .mouseover', function(done) {
+    var nightmare = Nightmare();
+
+    nightmare
+      .goto('about:blank')
+      .mouseover('a.not-here')
+      .catch(function (error) {
+        error.should.include('a.not-here');
+        done();
+      });
+  });
+
   describe('navigation', function () {
     var nightmare;
 


### PR DESCRIPTION
Gives more helpful errors when using `.click`, `.mousedown` or `.mouseover`, and the selector cannot be found.

e.g. when running `.click('a.not-here')` and the element cannot be found, it will give back the error "Unable to find element by selector: a.not-here" instead of the previous "Cannot read property 'dispatchEvent' of null".