### PR TITLE
clear all cookies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -385,9 +385,9 @@ Available properties are documented here:  https://github.com/atom/electron/blob
 
 Set multiple cookies at once. `cookies` is an array of `cookie` objects. Take a look at the `.cookies.set(cookie)` documentation above for a better idea of what `cookie` should look like.
 
-#### .cookies.clear(name)
+#### .cookies.clear([name])
 
-Clear a cookie for the current domain.
+Clear a cookie for the current domain.  If `name` is not specified, all cookies for the current domain will be cleared.
 
 ```js
 yield nightmare

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -426,18 +426,32 @@ app.on('ready', function() {
    */
 
   parent.respondTo('cookie.clear', function (cookies, done) {
-    var url = win.webContents.getURL()
-    var pending = cookies.length
+    var url = win.webContents.getURL();
+    var getCookies = (cb) => cb(null, cookies);
 
-    parent.emit('log', 'listing params', cookies);
-
-    for (var i = 0, cookie; cookie = cookies[i]; i++){
-      parent.emit('log', 'clearing cookie: ' + JSON.stringify(cookie))
-      win.webContents.session.cookies.remove(url, cookie, function (error) {
-          if (error) done(error);
-          else if (!--pending) done();
-      })
+    if(cookies.length == 0){
+      getCookies = (cb) => win.webContents.session.cookies.get({url: url}, (error, cookies) => {
+        cb(error, cookies.map((cookie) => cookie.name));
+      });
     }
+
+    getCookies((error, cookies) => {
+      var pending = cookies.length;
+      //if no cookies, return
+      if(pending == 0){
+        return done();
+      }
+      parent.emit('log', 'listing params', cookies);
+
+      //for each cookie name in cookies,
+      for (var i = 0, cookie; cookie = cookies[i]; i++){
+        //remove the cookie from the url
+        win.webContents.session.cookies.remove(url, cookie, function (error) {
+            if (error) done(error);
+            else if (!--pending) done();
+        })
+      }
+    });
   });
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -868,6 +868,29 @@ describe('Nightmare', function () {
       var cookies = yield cookies.get({ path: '/cookie' });
 
       cookies.length.should.equal(0);
+    });
+
+    it('.set([cookie]) & .clear() & .get()', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ])
+
+      yield cookies.clear();
+
+      var cookies = yield cookies.get();
+
+      cookies.length.should.equal(0);
     })
   })
 


### PR DESCRIPTION
Fixes two problems: one, if the name is not specified, clear all cookies for the current domain (#202); and two, return if there are no cookies specified to clear.  (This is a nascent bug that would cause Nightmare to hang indefinitely.)

I didn't change the cookie methods to look at an optional domain as I _think_ that's a bit outside the scope of this PR.  Should that be opened up in a separate issue, or should I include that here?

FWIW, the required changes:

* change `assign` to use `defaults` in `get ` and `set`
* alter `clear` to accept strings _or_ cookie objects with a a default URL to the current URL