### PR TITLE
patching javascript action to remove extra listeners

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -248,17 +248,23 @@ app.on('ready', function() {
    */
 
   parent.respondTo('javascript', function(src, done) {
-    renderer.once('response', function(event, response) {
+    var response = (event, response) => {
+      renderer.removeListener('error', error);
+      renderer.removeListener('log', log);
       done(null, response);
-    });
+    };
 
-    renderer.once('error', function(event, error) {
+    var error = (event, error) => {
+      renderer.removeListener('log', log);
+      renderer.removeListener('response', response);
       done(error);
-    });
+    };
 
-    renderer.once('log', function(event, args) {
-      parent.emit.apply(parent, ['log'].concat(args));
-    });
+    var log = (event, args) => parent.emit.apply(parent, ['log'].concat(args));
+
+    renderer.once('response', response);
+    renderer.once('error', error);
+    renderer.on('log', log);
 
     win.webContents.executeJavaScript(src);
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -244,7 +244,7 @@ app.on('ready', function() {
   });
 
   /**
-   * javascript
+   * javascript 
    */
 
   parent.respondTo('javascript', function(src, done) {


### PR DESCRIPTION
Fixes #350:  Ensures extra event listeners are removed when done/error is called, also allows for >1 log event per `javascript` call.

All credit should go to @s0m3on3 for the original fix.

(Also, I _thought_ this had already been submitted, but I can't find the original.)