### PR TITLE
moves electron start to Nightmare queue

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -162,7 +162,7 @@ exports.type = function() {
   }
 
   debug('.type() %s into %s', text, selector);
-  var child = this.child;
+  var self = this;
 
   focusSelector.bind(this)(function() {
     var blurDone = blurSelector.bind(this, done, selector);
@@ -171,7 +171,7 @@ exports.type = function() {
         document.querySelector(selector).value = '';
       }, blurDone, selector);
     } else {
-      child.call('type', text, blurDone);
+      self.child.call('type', text, blurDone);
     }
   }, selector);
 };

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -294,7 +294,7 @@ Nightmare.prototype.run = function(fn) {
     var doneargs = arguments;
     self.running = false;
     if (self.ending) {
-      endInstance(self, () => fn.apply(self, doneargs));
+      return endInstance(self, () => fn.apply(self, doneargs));
     }
     return fn.apply(self, doneargs);
   }

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -180,6 +180,8 @@ function endInstance(instance, cb) {
     });
     instance.child.removeAllListeners();
     instance.proc.kill();
+  } else {
+    cb();
   }
 }
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -362,7 +362,10 @@ Nightmare.prototype.on = function(event, handler) {
  */
 
 Nightmare.prototype.once = function(event, handler) {
-  this.child.once(event, handler);
+  this.queue(function(done){
+    this.child.once(event, handler);
+    done();
+  })
   return this;
 };
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -68,29 +68,6 @@ function Nightmare(options) {
 
   electronArgs.dock = options.dock || false;
 
-  this.proc = proc.spawn(electron_path, [runner].concat(JSON.stringify(electronArgs)), {
-    stdio: [null, null, null, 'ipc']
-  });
-
-  this.proc.stdout.pipe(split2()).on('data', (data) => {
-    electronLog.stdout(data);
-  });
-
-  this.proc.stderr.pipe(split2()).on('data', (data) => {
-    electronLog.stderr(data);
-  });
-
-  this.proc.on('close', function(code) {
-    var help = {
-      127: 'command not found - you may not have electron installed correctly',
-      126: 'permission problem or command is not an executable - you may not have all the necessary dependencies for electron',
-      1: 'general error - you may need xvfb',
-      0: 'success!'
-    };
-
-    debug('electron child process exited with code ' + code + ': ' + help[code]);
-  });
-
   attachToProcess(this);
 
   // initial state
@@ -101,6 +78,69 @@ function Nightmare(options) {
   this._queue = [];
   this._headers = {};
   this.options = options;
+
+  debug('queuing process start');
+  this.queue((done) => {
+
+    this.proc = proc.spawn(electron_path, [runner].concat(JSON.stringify(electronArgs)), {
+      stdio: [null, null, null, 'ipc']
+    });
+
+    this.proc.stdout.pipe(split2()).on('data', (data) => {
+      electronLog.stdout(data);
+    });
+
+    this.proc.stderr.pipe(split2()).on('data', (data) => {
+      electronLog.stderr(data);
+    });
+
+    this.proc.on('close', (code) => {
+      if(!self.ended){
+        handleExit(code, self, noop);
+      }
+    });
+
+    this.child = child(this.proc);
+    // propagate console.log(...) through
+    this.child.on('log', function() {
+      log.apply(log, arguments);
+    });
+
+    this.child.on('uncaughtException', function(stack) {
+      console.error('Nightmare runner error:\n\n%s\n', '\t' + stack.replace(/\n/g, '\n\t'));
+      endInstance(self, noop);
+      process.exit(1);
+    });
+
+    this.child.on('page', function(type) {
+      log.apply(null, ['page-' + type].concat(sliced(arguments, 1)));
+    });
+
+    // propogate events through to debugging
+    this.child.on('did-finish-load', function () { log('did-finish-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('did-fail-load', function () { log('did-fail-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('did-fail-provisional-load', function () { log('did-fail-provisional-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('did-frame-finish-load', function () { log('did-frame-finish-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('did-start-loading', function () { log('did-start-loading', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('did-stop-loading', function () { log('did-stop-loading', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('did-get-response-details', function () { log('did-get-response-details', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('did-get-redirect-request', function () { log('did-get-redirect-request', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('dom-ready', function () { log('dom-ready', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('page-favicon-updated', function () { log('page-favicon-updated', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('new-window', function () { log('new-window', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('will-navigate', function () { log('will-navigate', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('crashed', function () { log('crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('plugin-crashed', function () { log('plugin-crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
+    this.child.on('destroyed', function () { log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments))); });
+
+    this.child.once('ready', (versions) => {
+      this.engineVersions = versions;
+      this.child.call('browser-initialize', options, function() {
+        self.state = 'ready';
+        done();
+      });
+    });
+  });
 
   // initialize namespaces
   Nightmare.namespaces.forEach(function (name) {
@@ -116,54 +156,29 @@ function Nightmare(options) {
       this.child.call('action', key, String(Nightmare.childActions[key]), done);
     });
   }, this);
-
-  this.child = child(this.proc);
-  this.child.once('ready', function() {
-    self.child.call('browser-initialize', options, function() {
-      self.state = 'ready';
-    });
-  });
-
-  // propagate console.log(...) through
-  this.child.on('log', function() {
-    log.apply(log, arguments);
-  });
-
-  this.child.on('uncaughtException', function(stack) {
-    console.error('Nightmare runner error:\n\n%s\n', '\t' + stack.replace(/\n/g, '\n\t'));
-    endInstance(self);
-    process.exit(1);
-  });
-
-  this.child.on('page', function(type) {
-    log.apply(null, ['page-' + type].concat(sliced(arguments, 1)));
-  });
-
-  // proporate events through to debugging
-  this.child.on('did-finish-load', function () { log('did-finish-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('did-fail-load', function () { log('did-fail-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('did-fail-provisional-load', function () { log('did-fail-provisional-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('did-frame-finish-load', function () { log('did-frame-finish-load', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('did-start-loading', function () { log('did-start-loading', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('did-stop-loading', function () { log('did-stop-loading', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('did-get-response-details', function () { log('did-get-response-details', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('did-get-redirect-request', function () { log('did-get-redirect-request', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('dom-ready', function () { log('dom-ready', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('page-favicon-updated', function () { log('page-favicon-updated', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('new-window', function () { log('new-window', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('will-navigate', function () { log('will-navigate', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('crashed', function () { log('crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('plugin-crashed', function () { log('plugin-crashed', JSON.stringify(Array.prototype.slice.call(arguments))); });
-  this.child.on('destroyed', function () { log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments))); });
 }
 
-function endInstance(instance) {
+function handleExit(code, instance, cb){
+  var help = {
+    127: 'command not found - you may not have electron installed correctly',
+    126: 'permission problem or command is not an executable - you may not have all the necessary dependencies for electron',
+    1: 'general error - you may need xvfb',
+    0: 'success!'
+  };
+
+  debug('electron child process exited with code ' + code + ': ' + help[code]);
+  instance.proc.removeAllListeners();
+  cb();
+};
+
+function endInstance(instance, cb) {
   instance.ended = true;
   detachFromProcess(instance);
   if (instance.proc.connected) {
+    instance.proc.on('close', (code) => {
+      handleExit(code, instance, cb);
+    });
     instance.child.removeAllListeners();
-    instance.proc.removeAllListeners();
-    instance.proc.disconnect();
     instance.proc.kill();
   }
 }
@@ -172,7 +187,7 @@ function endInstance(instance) {
  * Attach any instance-specific process-level events.
  */
 function attachToProcess(instance) {
-  instance._endNow = endInstance.bind(null, instance);
+  instance._endNow = endInstance.bind(null, instance, noop);
   process.setMaxListeners(Infinity);
   process.on('exit', instance._endNow);
   process.on('SIGINT', instance._endNow);
@@ -209,20 +224,6 @@ Nightmare.childActions = {};
 Nightmare.version = require(path.resolve(__dirname, '..', 'package.json')).version;
 
 /**
- * ready
- */
-
-Nightmare.prototype.ready = function(fn) {
-  var self = this;
-  if (this.state == 'ready') return fn();
-  this.child.once('ready', function(versions){
-    self.engineVersions = versions;
-    return fn();
-  });
-  return this;
-};
-
-/**
  * Override headers for all HTTP requests
  */
 
@@ -242,7 +243,7 @@ Nightmare.prototype.header = function(header, value) {
 
 Nightmare.prototype.goto = function(url, headers) {
   debug('queueing action "goto" for %s', url);
-  var child = this.child;
+  var self = this;
 
   headers = headers || {};
   for (var key in this._headers) {
@@ -250,7 +251,7 @@ Nightmare.prototype.goto = function(url, headers) {
   }
 
   this.queue(function(fn) {
-    child.call('goto', url, headers, fn);
+    self.child.call('goto', url, headers, fn);
   });
   return this;
 };
@@ -261,8 +262,7 @@ Nightmare.prototype.goto = function(url, headers) {
 
 Nightmare.prototype.run = function(fn) {
   debug('running')
-  var ready = [this.ready.bind(this)];
-  var steps = [ready].concat(this.queue());
+  var steps = this.queue();
   this.running = true;
   this._queue = [];
   var self = this;
@@ -283,17 +283,20 @@ Nightmare.prototype.run = function(fn) {
 
   function after (err, res) {
     var args = sliced(arguments);
-    self.child.call('continue', function() {
+    if(self.child){
+      self.child.call('continue', () => next.apply(self, args));
+    } else {
       next.apply(self, args);
-    });
+    }
   }
 
   function done () {
+    var doneargs = arguments;
     self.running = false;
     if (self.ending) {
-      endInstance(self);
+      endInstance(self, () => fn.apply(self, doneargs));
     }
-    return fn.apply(self, arguments);
+    return fn.apply(self, doneargs);
   }
 
   return this;
@@ -344,7 +347,10 @@ Nightmare.prototype.end = function(done) {
  */
 
 Nightmare.prototype.on = function(event, handler) {
-  this.child.on(event, handler);
+  this.queue(function(done){
+    this.child.on(event, handler);
+    done();
+  });
   return this;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -112,6 +112,14 @@ describe('Nightmare', function () {
       });
   });
 
+  it('should allow ending more than once', function(done){
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('navigation'))
+      .end()
+      .then(() => nightmare.end())
+      .then(() => done());
+  });
+
   describe('navigation', function () {
     var nightmare;
 


### PR DESCRIPTION
This is a pass at moving the Nightmare start to the queue.  This removes the need for `.ready()`.  Also, this changeset makes the ending of an instance asynchronous.  (This props up downstream usability for #502 and possibly #598.)