### PR TITLE
Remove workaround for older version of electron

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -587,10 +587,6 @@ app.on('ready', function() {
 
 function forward(name) {
   return function (event) {
-    // trying to send the event's `sender` can crash electron, so strip it
-    // https://github.com/electron/electron/issues/5180
-    var safeEvent = Object.assign({}, event);
-    delete safeEvent.sender;
-    parent.emit.apply(parent, [name, safeEvent].concat(sliced(arguments, 1)));
+    parent.emit.apply(parent, [name, event].concat(sliced(arguments, 1)));
   };
 }


### PR DESCRIPTION
The fix for this bug in Electron was released with version 0.37.7 and we currently depend on `^0.37.7` so this should be safe to remove.