### PR TITLE
Add 'Referer' header support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 test/tmp
 test/DevTools Extensions
+.idea

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -262,7 +262,7 @@ app.on('ready', function() {
         win.webContents.on('did-get-response-details', handleDetails);
         win.webContents.on('dom-ready', handleDomReady);
         win.webContents.on('did-finish-load', handleFinish);
-        win.webContents.loadURL(loadUrlOptions);
+        win.webContents.loadURL(url, loadUrlOptions);
 
         // javascript: URLs *may* trigger page loads; wait a bit to see
         if (protocol === 'javascript:') {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -165,7 +165,7 @@ app.on('ready', function() {
 
     var httpReferrer = '';
     var extraHeaders = '';
-    for (var key in headers) if (headers.hasOwnProperty(key)) {
+    for (var key in headers) {
       if (key.toLowerCase() == 'referer') {
         httpReferrer = headers[key];
         continue;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -163,15 +163,18 @@ app.on('ready', function() {
       return done('goto: `url` must be a non-empty string');
     }
 
-    var loadUrlOptions = { extraHeaders: '' };
+    var httpReferrer = '';
+    var extraHeaders = '';
     for (var key in headers) if (headers.hasOwnProperty(key)) {
       if (key.toLowerCase() == 'referer') {
-        loadUrlOptions.httpReferrer = headers[key];
+        httpReferrer = headers[key];
         continue;
       }
 
-      loadUrlOptions.extraHeaders += key + ': ' + headers[key] + '\n';
+      extraHeaders += key + ': ' + headers[key] + '\n';
     }
+    var loadUrlOptions = { extraHeaders: extraHeaders };
+    httpReferrer && (loadUrlOptions.httpReferrer = httpReferrer);
 
     if (win.webContents.getURL() == url) {
       done();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -163,10 +163,20 @@ app.on('ready', function() {
       return done('goto: `url` must be a non-empty string');
     }
 
+    var loadUrlOptions = {};
     var extraHeaders = '';
-    for (var key in headers) {
-      extraHeaders += key + ': ' + headers[key] + '\n';
+    var httpReferrer = '';
+    for (var key in headers) if (headers.hasOwnProperty(key)) {
+      switch (key.toLowerCase()) {
+        case 'referer':
+          httpReferrer = headers[key];
+          break;
+        default:
+          extraHeaders += key + ': ' + headers[key] + '\n';
+      }
     }
+    extraHeaders && (loadUrlOptions.extraHeaders = extraHeaders);
+    httpReferrer && (loadUrlOptions.httpReferrer = httpReferrer);
 
     if (win.webContents.getURL() == url) {
       done();
@@ -254,9 +264,7 @@ app.on('ready', function() {
         win.webContents.on('did-get-response-details', handleDetails);
         win.webContents.on('dom-ready', handleDomReady);
         win.webContents.on('did-finish-load', handleFinish);
-        win.webContents.loadURL(url, {
-          extraHeaders: extraHeaders
-        });
+        win.webContents.loadURL(url, loadUrlOptions);
 
         // javascript: URLs *may* trigger page loads; wait a bit to see
         if (protocol === 'javascript:') {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -163,20 +163,15 @@ app.on('ready', function() {
       return done('goto: `url` must be a non-empty string');
     }
 
-    var loadUrlOptions = {};
-    var extraHeaders = '';
-    var httpReferrer = '';
+    var loadUrlOptions = { extraHeaders: '' };
     for (var key in headers) if (headers.hasOwnProperty(key)) {
-      switch (key.toLowerCase()) {
-        case 'referer':
-          httpReferrer = headers[key];
-          break;
-        default:
-          extraHeaders += key + ': ' + headers[key] + '\n';
+      if (key.toLowerCase() == 'referer') {
+        loadUrlOptions.httpReferrer = headers[key];
+        continue;
       }
+
+      loadUrlOptions.extraHeaders += key + ': ' + headers[key] + '\n';
     }
-    extraHeaders && (loadUrlOptions.extraHeaders = extraHeaders);
-    httpReferrer && (loadUrlOptions.httpReferrer = httpReferrer);
 
     if (win.webContents.getURL() == url) {
       done();
@@ -264,7 +259,7 @@ app.on('ready', function() {
         win.webContents.on('did-get-response-details', handleDetails);
         win.webContents.on('dom-ready', handleDomReady);
         win.webContents.on('did-finish-load', handleFinish);
-        win.webContents.loadURL(url, loadUrlOptions);
+        win.webContents.loadURL(loadUrlOptions);
 
         // javascript: URLs *may* trigger page loads; wait a bit to see
         if (protocol === 'javascript:') {

--- a/test/index.js
+++ b/test/index.js
@@ -977,8 +977,7 @@ describe('Nightmare', function () {
 
       cookies.length.should.equal(0);
     })
-  })
-
+  });
 
   describe('rendering', function () {
     var nightmare;
@@ -1143,6 +1142,32 @@ describe('Nightmare', function () {
       buf.length.should.be.at.least(1000);
       isBuffer.should.be.true;
     });
+  });
+
+  describe('referer', function() {
+    var nightmare;
+
+    beforeEach(function() {
+      nightmare = Nightmare({webPreferences: {partition: 'test-partition'}});
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should return referer from headers', function*() {
+      var referer = 'http://my-referer.tld/';
+      var returnedReferer = yield nightmare
+        .goto(fixture('referer'), {
+          'Referer': referer
+        })
+        .evaluate(function () {
+          return document.body.innerText;
+        })
+        ;
+
+      referer.should.be.equal(returnedReferer.trim());
+    })
   });
 
   describe('events', function () {

--- a/test/server.js
+++ b/test/server.js
@@ -74,6 +74,14 @@ app.get('/do-not-respond', function(req, res) {
 app.get('/wait', function(req, res) {});
 
 /**
+ * Return 'Referer' header if presented
+ */
+
+app.get('/referer', function(req, res) {
+  res.send((typeof req.headers.referer != 'undefined') ? req.headers.referer : '');
+});
+
+/**
  * Serve the fixtures directory as static files.
  */
 


### PR DESCRIPTION
Hi guys!
How about "Referer" header?

Usage:
```javascript
const url = 'https://www.whatismybrowser.com/detect/what-http-headers-is-my-browser-sending';
var nightmare = new Nightmare();
yield nightmare
  .viewport(1920, 1080)
  .goto(url, {
    'Referer': 'http://my-referer.tld/'
  })
  .wait('body')
  .screenshot(path.join(__dirname, 'referer.png'))
  .end()
;
```

Result:
![headers](https://habrastorage.org/files/4ca/d21/34a/4cad2134ae524cc6b1a581ed9eeef0c2.png)
