### PR TITLE
Speed up `.type()` event

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -374,13 +374,8 @@ app.on('ready', function() {
         keyCode: ch
       });
 
-      // HACK to prevent async keyboard events from
-      // being played out of order. The timeout is
-      // somewhat arbitrary. I want to achieve a
-      // nice balance between speed and correctness
-      // if you find that this value it too low,
-      // please open an issue.
-      setTimeout(type, 100);
+      // defer function into next event loop
+      setTimeout(type, 0);
     }
 
     // start


### PR DESCRIPTION
closes https://github.com/segmentio/nightmare/issues/469

I've tested my tests with `0` timeout on the `.type()` function and can't report any keystrokes being emitted in the wrong order. 

Using the `setTimeout(fn, 0);` hack to defer the event to the next event loop of JavaScript should be just fine. 

I was tempted to make this timeout a configurable variable to aid debugging without making test suites run longer than necessary, but I did not want to introduce a breaking change. 