### PR TITLE
open server connection load timeout

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -120,6 +120,15 @@ var nightmare = Nightmare({
 });
 ```
 
+##### loadTimeout (default: infinite)
+This will force Nightmare to move on if a page transition caused by an action (eg, `.click()`) didn't finish within the set timeframe.  If `loadTimeout` is shorter than `gotoTimeout`, the exceptions thrown by `gotoTimeout` will be suppressed.
+
+```js
+var nightmare = Nightmare({
+  loadTimeout: 1000 // in ms
+});
+```
+
 ##### paths
 The default system paths that Electron knows about. Here's a list of available paths: https://github.com/atom/electron/blob/master/docs/api/app.md#appgetpathname
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -25,6 +25,11 @@ var split2 = require('split2');
 var noop = function() {};
 var keys = Object.keys;
 
+// Standard timeout for loading URLs
+const DEFAULT_GOTO_TIMEOUT = 30 * 1000;
+// Standard timeout for wait(ms)
+const DEFAULT_WAIT_TIMEOUT = 30 * 1000;
+
 /**
  * Export `Nightmare`
  */
@@ -54,8 +59,8 @@ function Nightmare(options) {
   options = options || {};
   var electronArgs = {};
   var self = this;
-  self.optionWaitTimeout = options.waitTimeout || 30000;
-  self.optionGotoTimeout = options.gotoTimeout;
+  self.optionWaitTimeout = options.waitTimeout || DEFAULT_WAIT_TIMEOUT;
+  self.optionGotoTimeout = options.gotoTimeout || DEFAULT_GOTO_TIMEOUT;
 
   var electron_path = options.electronPath || default_electron_path
 
@@ -65,6 +70,11 @@ function Nightmare(options) {
 
   if (options.switches) {
     electronArgs.switches = options.switches;
+  }
+
+  electronArgs.loadTimeout = options.loadTimeout;
+  if(options.loadTimeout && options.gotoTimeout && options.loadTimeout < self.optionGotoTimeout){
+    debug(`WARNING:  load timeout of ${options.loadTimeout} is shorter than goto timeout of ${self.optionGotoTimeout}`);
   }
 
   electronArgs.dock = options.dock || false;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -17,8 +17,6 @@ var FrameManager = require('./frame-manager');
 
 // URL protocols that don't need to be checked for validity
 const KNOWN_PROTOCOLS = ['http', 'https', 'file', 'about', 'javascript'];
-// Standard timeout for loading URLs
-const DEFAULT_GOTO_TIMEOUT = 30 * 1000;
 // Property for tracking whether a window is ready for interaction
 const IS_READY = Symbol('isReady');
 
@@ -137,14 +135,24 @@ app.on('ready', function() {
     win.webContents.on('plugin-crashed', forward('plugin-crashed'));
     win.webContents.on('destroyed', forward('destroyed'));
 
+    var loadwatch;
+
     win.webContents.on('did-start-loading', function() {
       if (win.webContents.isLoadingMainFrame()) {
+        if(options.loadTimeout){
+          loadwatch = setTimeout(function(){
+            win.webContents.stop();
+          }, options.loadTimeout);
+        }
         setIsReady(false);
       }
     });
-    win.webContents.on('did-finish-load', function() {
+    
+    win.webContents.on('did-stop-loading', function(){
+      clearTimeout(loadwatch);
       setIsReady(true);
     });
+
     setIsReady(true);
 
     done();
@@ -173,7 +181,6 @@ app.on('ready', function() {
     } else {
       var responseData = {};
       var domLoaded = false;
-      timeout = timeout || DEFAULT_GOTO_TIMEOUT;
 
       var timer = setTimeout(function() {
         // If the DOM loaded before timing out, consider the load successful.

--- a/test/fixtures/navigation/index.html
+++ b/test/fixtures/navigation/index.html
@@ -7,5 +7,6 @@
     <a class="a" href="a.html">A</a>
     <a class="b" href="b.html">B</a>
     <a class="c" href="c.html" id="escaping:test">C</a>
+    <a id='never-ends' href='/never-ends'>does not end</a>
   </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -161,7 +161,8 @@ describe('Nightmare', function () {
 
     beforeEach(function() {
       nightmare = Nightmare({
-        webPreferences: {partition: 'test-partition' + Math.random()}
+        webPreferences: {partition: 'test-partition' + Math.random()},
+        loadTimeout: 45 * 1000
       });
     });
 
@@ -463,6 +464,16 @@ describe('Nightmare', function () {
           .then(function() {
             return nightmare.goto(fixture('navigation'));
           });
+      });
+
+      it('should allow for timeouts for non-goto loads', function*() { // ###
+        this.timeout(40000);
+        var nightmare = Nightmare({loadTimeout: 30000});
+        yield nightmare
+          .goto(fixture('navigation'))
+          .click('#never-ends');
+
+        yield nightmare.end();
       });
     });
   });

--- a/test/server.js
+++ b/test/server.js
@@ -72,14 +72,7 @@ app.get('/do-not-respond', function(req, res) {
  */
 app.get('/never-ends', function(req, res) {
   res.set('Content-Type', 'text/html');
-  var i = 0;
-  var fn = function(){
-    setTimeout(function() {
-      res.write(`${i++}<br>`);
-      fn();
-    }, 1000);
-  };
-  fn();
+  res.write(`<strong>this page will not stop</strong>`);
 });
 
 /**

--- a/test/server.js
+++ b/test/server.js
@@ -68,6 +68,21 @@ app.get('/do-not-respond', function(req, res) {
 });
 
 /**
+ * Start the response but do not end the request
+ */
+app.get('/never-ends', function(req, res) {
+  res.set('Content-Type', 'text/html');
+  var i = 0;
+  var fn = function(){
+    setTimeout(function() {
+      res.write(`${i++}<br>`);
+      fn();
+    }, 1000);
+  };
+  fn();
+});
+
+/**
  * Wait forever and never respond
  */
 


### PR DESCRIPTION
Fixes #689.

- moves timeout defaults to parent process
- adds a non-ending route to the test server
- uses `did-stop-loading` instead of `did-finish-loading` as the former
is called regardless of load success or not
- adds an optional page transition timeout called `loadTimeout` that
forces the `webContents` to stop after a given time.