### PR TITLE
update electron-prebuilt version

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,14 @@
+2.5.2 / 2016-06-20
+==================
+
+  * Fixes `Referer` header support
+  * Removes timeout between keystrokes when using `.type()`
+  * Checks instance existence when calling `.end()`
+  * Adds a link to `nightmare-examples`
+  * Changes `yield` to `.then()` in readme
+  * Swaps `did-finish-loading` for `did-stop-loading` when waiting for page transitions
+  * Adds optional `loadTimeout` for server responses that do not end
+
 2.5.1 / 2016-06-07
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightmare",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "license": "MIT",
   "main": "lib/nightmare.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron-prebuilt": "^1.2.1",
+    "electron-prebuilt": "^1.2.5",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",

--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,7 @@ describe('Nightmare', function () {
     });
   });
 
-  it.only('should end gracefully if the chain has not been started', function(done) {
+  it('should end gracefully if the chain has not been started', function(done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-created.js'));
 


### PR DESCRIPTION
Fixes #694, also removes an errant `.only()` in the test suite.