### PR TITLE
Run it.only, and add option to provide env vars to electron process

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -94,7 +94,8 @@ function Nightmare(options) {
   this.queue((done) => {
 
     this.proc = proc.spawn(electron_path, [runner].concat(JSON.stringify(electronArgs)), {
-      stdio: [null, null, null, 'ipc']
+      stdio: [null, null, null, 'ipc'],
+      env: options.env || process.env
     });
 
     this.proc.stdout.pipe(split2()).on('data', (data) => {

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -22,6 +22,7 @@ var sliced = require('sliced');
 var child = require('./ipc');
 var once = require('once');
 var split2 = require('split2');
+var defaults = require('defaults');
 var noop = function() {};
 var keys = Object.keys;
 
@@ -95,7 +96,7 @@ function Nightmare(options) {
 
     this.proc = proc.spawn(electron_path, [runner].concat(JSON.stringify(electronArgs)), {
       stdio: [null, null, null, 'ipc'],
-      env: options.env || process.env
+      env: defaults(options.env || {}, process.env)
     });
 
     this.proc.stdout.pipe(split2()).on('data', (data) => {

--- a/test/index.js
+++ b/test/index.js
@@ -1528,7 +1528,7 @@ describe('Nightmare', function () {
     it('should allow to use external Electron', function*() {
       nightmare = Nightmare({ electronPath: require('electron-prebuilt') });
       nightmare.should.be.ok;
-    })
+    });
   });
 
   describe('Nightmare.action(name, fn)', function() {
@@ -1630,6 +1630,32 @@ describe('Nightmare', function () {
       eventResults[0].should.equal('sample');
       eventResults[1].should.equal(3);
       eventResults[2].sample.should.equal('sample');
+    });
+
+    it('should allow env variables', function*() {
+      Nightmare.action('envtest',
+        function (name, options, parent, win, renderer, done) {
+          console.log(arguments);
+          parent.respondTo('envtest', function(done){
+            done(null, process.env);
+          });
+          done();
+        },
+        function(done) {
+          this.child.call('envtest', done);
+        }
+      );
+      nightmare = Nightmare({
+        env: {
+          TZ: 'UTC'
+        }
+      });
+      nightmare.should.be.ok;
+      var envTest = yield nightmare
+        .goto('about:bank')
+        .envtest();
+      envTest.should.be.ok;
+      envTest.should.have.property('TZ', 'UTC');
     });
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,7 @@ describe('Nightmare', function () {
     });
   });
 
-  it.only('should end gracefully if the chain has not been started', function(done) {
+  it('should end gracefully if the chain has not been started', function(done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-created.js'));
 
@@ -132,7 +132,7 @@ describe('Nightmare', function () {
       .then(() => nightmare.end())
       .then(() => done());
   });
-  
+
   it('should provide useful errors for .click', function(done) {
     var nightmare = Nightmare();
 
@@ -1348,7 +1348,7 @@ describe('Nightmare', function () {
         });
 
       nightmare.removeListener('page', handler);
-      
+
       yield nightmare
         .evaluate(function(){
           alert('alert two');

--- a/test/index.js
+++ b/test/index.js
@@ -1635,7 +1635,6 @@ describe('Nightmare', function () {
     it('should allow env variables', function*() {
       Nightmare.action('envtest',
         function (name, options, parent, win, renderer, done) {
-          console.log(arguments);
           parent.respondTo('envtest', function(done){
             done(null, process.env);
           });


### PR DESCRIPTION
Addresses issue #704, also removes "it.only" from unit tests (assuming that was unintentional).

I admit that I'm not sure what to write for a unit test here.  If you can give me some guidance, that would great.  Otherwise, existing tests pass, and a test run on my machine appears to use the TZ environment variable.  Thanks!