### PR TITLE
error on bad authentication

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -188,6 +188,14 @@ var nightmare = Nightmare({
 });
 ```
 
+##### maxAuthRetries
+Defines the number of times to retry an authentication when set up with `.authenticate()`.  Defaults to 3.
+```js
+var nightmare = Nightmare({
+  maxAuthRetries: 3
+});
+```
+
 #### .engineVersions()
 Gets the versions for Electron and Chromium.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -29,6 +29,8 @@ var keys = Object.keys;
 const DEFAULT_GOTO_TIMEOUT = 30 * 1000;
 // Standard timeout for wait(ms)
 const DEFAULT_WAIT_TIMEOUT = 30 * 1000;
+// max retry for authentication
+const MAX_AUTH_RETRIES = 3;
 
 /**
  * Export `Nightmare`
@@ -71,6 +73,7 @@ function Nightmare(options) {
   if (options.switches) {
     electronArgs.switches = options.switches;
   }
+  options.maxAuthRetries = options.maxAuthRetries || MAX_AUTH_RETRIES;
 
   electronArgs.loadTimeout = options.loadTimeout;
   if(options.loadTimeout && options.gotoTimeout && options.loadTimeout < self.optionGotoTimeout){
@@ -112,6 +115,12 @@ function Nightmare(options) {
     });
 
     this.child = child(this.proc);
+
+    this.child.once('die', function(err){
+      debug('dying: ' + err);
+      self.die = err;
+    });
+
     // propagate console.log(...) through
     this.child.on('log', function() {
       log.apply(log, arguments);
@@ -296,7 +305,9 @@ Nightmare.prototype.run = function(fn) {
   }
 
   function after (err, res) {
+    err = err || self.die;
     var args = sliced(arguments);
+
     if(self.child){
       self.child.call('continue', () => next.apply(self, args));
     } else {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -555,8 +555,21 @@ app.on('ready', function() {
    */
 
   parent.respondTo('authentication', function(login, password, done) {
+    var currentUrl;
+    var tries = 0;
     win.webContents.on('login', function(webContents, request, authInfo, callback) {
+      tries++;
+      parent.emit('log', `authenticating against ${request.url}, try #${tries}`);
+      if(currentUrl != request.url) {
+        currentUrl = request.url;
+        tries = 1;
+      }
+
+      if(tries >= options.maxAuthRetries){
+        parent.emit('die', 'problem authenticating, check your credentials');
+      } else {
         callback(login, password);
+      }
     });
     done();
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -554,10 +554,15 @@ app.on('ready', function() {
    * Authentication
    */
 
+  var loginListener;
   parent.respondTo('authentication', function(login, password, done) {
     var currentUrl;
     var tries = 0;
-    win.webContents.on('login', function(webContents, request, authInfo, callback) {
+    if(loginListener){
+      win.webContents.removeListener('login', loginListener);
+    }
+
+    loginListener = function(webContents, request, authInfo, callback) {
       tries++;
       parent.emit('log', `authenticating against ${request.url}, try #${tries}`);
       if(currentUrl != request.url) {
@@ -570,7 +575,9 @@ app.on('ready', function() {
       } else {
         callback(login, password);
       }
-    });
+    }
+    win.webContents.on('login', loginListener);
+
     done();
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1441,6 +1441,19 @@ describe('Nightmare', function () {
         .should.be.rejected;
     });
 
+    it.only('should be able to update authentication', function*(){
+      nightmare = Nightmare();
+      var data = yield nightmare
+        .authentication('my', 'auth')
+        .goto(fixture('auth'))
+        .authentication('my2', 'auth2')
+        .goto(fixture('auth2'))
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      data.should.eql({ name: 'my2', pass: 'auth2' });
+    });
+
     it('should set viewport', function*() {
       var size = { width: 400, height: 300, useContentSize: true };
       nightmare = Nightmare(size);

--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,7 @@ describe('Nightmare', function () {
     });
   });
 
-  it.only('should end gracefully if the chain has not been started', function(done) {
+  it('should end gracefully if the chain has not been started', function(done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-created.js'));
 
@@ -1431,6 +1431,14 @@ describe('Nightmare', function () {
           return JSON.parse(document.querySelector('pre').innerHTML);
         });
       data.should.eql({ name: 'my', pass: 'auth' });
+    });
+
+    it('should fail on authentication failure', function*() {
+      nightmare = Nightmare();
+      var data = yield nightmare
+        .authentication('my', 'wrong')
+        .goto(fixture('auth'))
+        .should.be.rejected;
     });
 
     it('should set viewport', function*() {

--- a/test/index.js
+++ b/test/index.js
@@ -1441,7 +1441,7 @@ describe('Nightmare', function () {
         .should.be.rejected;
     });
 
-    it.only('should be able to update authentication', function*(){
+    it('should be able to update authentication', function*(){
       nightmare = Nightmare();
       var data = yield nightmare
         .authentication('my', 'auth')

--- a/test/server.js
+++ b/test/server.js
@@ -38,6 +38,10 @@ app.get('/auth', basicAuth('my', 'auth'), function (req, res) {
   res.send(auth(req));
 });
 
+app.get('/auth2', basicAuth('my2', 'auth2'), function (req, res) {
+  res.send(auth(req));
+});
+
 /**
  * Echo HTTP Headers for testing assertions.
  */


### PR DESCRIPTION
Fix #696.

Changes:

1. Adds error when authentication fails
1. Adds the ability to end a Nightmare chain from an event that happens out-of-band using the `die` event
1. Allows for credentials to be reset mid-stream.