### PR TITLE
fixes for openDevTools option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -179,11 +179,20 @@ var nightmare = Nightmare({
 ```
 
 ##### openDevTools
-Optionally show the DevTools in the Electron window using `true`, or use an object hash containing `detatch` to show in a separate window. The hash gets passed to [`webContents.openDevTools()`](https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentsopendevtoolsoptions) to be handled.  This is also useful for testing purposes.  Note that this option is honored only if `show` is set to `true`.
+Optionally show the DevTools in the Electron window using `true`, or use an object hash containing `mode: 'detach'` to show in a separate window. The hash gets passed to [`contents.openDevTools()`](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#contentsopendevtoolsoptions) to be handled.  This is also useful for testing purposes.  Note that this option is honored only if `show` is set to `true`.
 
 ```js
 var nightmare = Nightmare({
   openDevTools: true,
+  show: true
+});
+```
+
+```js
+var nightmare = Nightmare({
+  openDevTools: {
+    mode: 'detach'
+  },
   show: true
 });
 ```


### PR DESCRIPTION
- fix link to contents.openDevTools function
- fix misspelling of 'detach'
- specify that 'detach' must be the value of the 'mode' property (see electron doc for confirmation)