### PR TITLE
making the `.type()` interval an option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -188,6 +188,15 @@ var nightmare = Nightmare({
 });
 ```
 
+##### typeInterval (default: 100ms)
+How long to wait between keystrokes when using `.type()`.
+
+```js
+var nightmare = Nightmare({
+  typeInterval: 20
+});
+```
+
 #### .engineVersions()
 Gets the versions for Electron and Chromium.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -29,7 +29,8 @@ var keys = Object.keys;
 const DEFAULT_GOTO_TIMEOUT = 30 * 1000;
 // Standard timeout for wait(ms)
 const DEFAULT_WAIT_TIMEOUT = 30 * 1000;
-
+// Timeout between keystrokes for `.type()`
+const DEFAULT_TYPE_INTERVAL = 100;
 /**
  * Export `Nightmare`
  */
@@ -61,6 +62,8 @@ function Nightmare(options) {
   var self = this;
   self.optionWaitTimeout = options.waitTimeout || DEFAULT_WAIT_TIMEOUT;
   self.optionGotoTimeout = options.gotoTimeout || DEFAULT_GOTO_TIMEOUT;
+
+  options.typeInterval = options.typeInterval || DEFAULT_TYPE_INTERVAL;
 
   var electron_path = options.electronPath || default_electron_path
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -37,7 +37,6 @@ const DEFAULT_POLL_INTERVAL = 250;
 // max retry for authentication
 const MAX_AUTH_RETRIES = 3;
 
->>>>>>> 7193030dfde6d69cbf1ca514667aa23c2d02f78c
 /**
  * Export `Nightmare`
  */

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -388,7 +388,7 @@ app.on('ready', function() {
       });
 
       // defer function into next event loop
-      setTimeout(type, 0);
+      setTimeout(type, options.typeInterval);
     }
 
     // start


### PR DESCRIPTION
Backs out #677 in favor of making the type interval an option.