### PR TITLE
Listen explicitly for provisional load failures in `goto`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 dependencies:
   pre:
     - sudo apt-get update; sudo apt-get install libnotify-bin
+    - nvm install 4; nvm install 5; nvm install 6
 test:
   override:
     - nvm use 4 && npm test

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -237,6 +237,7 @@ app.on('ready', function() {
       function cleanup(error, data) {
         clearTimeout(timer);
         win.webContents.removeListener('did-fail-load', handleFailure);
+        win.webContents.removeListener('did-fail-provisional-load', handleFailure);
         win.webContents.removeListener('did-get-response-details', handleDetails);
         win.webContents.removeListener('dom-ready', handleDomReady);
         win.webContents.removeListener('did-finish-load', handleFinish);
@@ -266,6 +267,7 @@ app.on('ready', function() {
         }
 
         win.webContents.on('did-fail-load', handleFailure);
+        win.webContents.on('did-fail-provisional-load', handleFailure);
         win.webContents.on('did-get-response-details', handleDetails);
         win.webContents.on('dom-ready', handleDomReady);
         win.webContents.on('did-finish-load', handleFinish);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -595,6 +595,8 @@ app.on('ready', function() {
 
 function forward(name) {
   return function (event) {
-    parent.emit.apply(parent, [name, event].concat(sliced(arguments, 1)));
+    // NOTE: the raw Electron event used to be forwarded here, but we now send
+    // an empty event in its place -- the raw event is not JSON serializable.
+    parent.emit.apply(parent, [name, {}].concat(sliced(arguments, 1)));
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1916,17 +1916,24 @@ function withDeprecationTracking(constructor) {
  */
 var _action = Nightmare.action;
 var _pluginNames = [];
+var _existingNamespaces = Nightmare.namespaces.slice();
+var _existingChildActions = Object.assign({}, Nightmare.childActions);
 Nightmare.action = function (name) {
   _pluginNames.push(name);
   return _action.apply(this, arguments);
 };
+// NOTE: this is somewhat fragile since there's no public API for removing
+// plugins. If you touch `Nightmare.action`, please be sure to update this.
 Nightmare.resetActions = function () {
   _pluginNames.splice(0, _pluginNames.length).forEach((name) => {
     delete this.prototype[name];
   });
   this.namespaces.splice(0, this.namespaces.length);
+  this.namespaces.push.apply(this.namespaces, _existingNamespaces);
   Object.keys(this.childActions).forEach((name) => {
-    delete this.childActions[name];
+    if (!_existingChildActions[name]) {
+      delete this.childActions[name];
+    }
   });
 };
 

--- a/test/server.js
+++ b/test/server.js
@@ -60,6 +60,13 @@ app.get('/redirect', function (req, res) {
 });
 
 /**
+ * Start the response but do not end the request
+ */
+app.get('/not-modified', function(req, res) {
+  res.sendStatus(304);
+});
+
+/**
  * Simply hang up on the connection for testing interrupted page loads
  */
 


### PR DESCRIPTION
This fixes #740. We used to only listed for `did-fail-load` events to signal failure because they were always emitted in any kind of failure. In Electron v1.2.6, some kinds of provisional failures stopped emitting `did-fail-load`, so we now also need to listen for `did-fail-provisional-load`.