### PR TITLE
Stop sending electron event data in forwarded events.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 dependencies:
   pre:
     - sudo apt-get update; sudo apt-get install libnotify-bin
+    - nvm install 4; nvm install 5; nvm install 6
 test:
   override:
     - nvm use 4 && npm test

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -595,6 +595,8 @@ app.on('ready', function() {
 
 function forward(name) {
   return function (event) {
-    parent.emit.apply(parent, [name, event].concat(sliced(arguments, 1)));
+    // NOTE: the raw Electron event used to be forwarded here, but we now send
+    // an empty event in its place -- the raw event is not JSON serializable.
+    parent.emit.apply(parent, [name, {}].concat(sliced(arguments, 1)));
   };
 }


### PR DESCRIPTION
Builds for #746 were failing in CI—it turns out this is because JSON serialization is failing from circular references. This is not the first time we’ve seen exceptions on serializing the raw event data, so I’m opting for just removing it altogether here. There’s very little meaningful information that actually comes with them to begin with.