### PR TITLE
Quit electron app gracefully instead of killing the process

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -208,8 +208,9 @@ function endInstance(instance, cb) {
     instance.proc.on('close', (code) => {
       handleExit(code, instance, cb);
     });
-    instance.child.removeAllListeners();
-    instance.proc.kill();
+    instance.child.call('quit', () =>{
+      instance.child.removeAllListeners();
+    });
   } else {
     debug('electron child process not started yet, skipping kill.');
     cb();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -596,6 +596,15 @@ app.on('ready', function() {
     done();
   });
 
+ /**
+   * Kill the electron app
+   */
+
+  parent.respondTo('quit', function(done) {
+    app.quit(); 
+    done();
+  });
+
   /**
    * Send "ready" event to the parent process
    */


### PR DESCRIPTION
Still not sure what exactly is causing the problem but it seams when you kill() the process is not giving time to electron.app to quit gracefully and that is not allowing the cookies/session to be saved. 

More info can be found here: [Quit gracefully when Ctrl-C is pressed in console #5273](https://github.com/electron/electron/issues/5273)

Fixes bug:
[Nightmare persist partition on windows bug #755](https://github.com/segmentio/nightmare/issues/755) 

Probable fix for:
[Always fail to set cookie #531](https://github.com/segmentio/nightmare/issues/531) 
[sharing a session between different machines? #398](https://github.com/segmentio/nightmare/issues/398)
[Sessions are not persisting in Ubuntu #536](https://github.com/segmentio/nightmare/issues/536)
