### PR TITLE
Initial support for XPath

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -58,7 +58,7 @@ function xpathLookup(xpath) {
         if (e instanceof DOMException) {
             return undefined;
         } else {
-            throw new Error(e.message + " ('" + xpath + "')");
+            throw e;
         }
     }
 }
@@ -76,7 +76,7 @@ function cssLookup(selector) {
         if (e instanceof DOMException) {
             return undefined;
         } else {
-            throw new Error(e.message + " ('" + selector + "')");
+            throw e;
         }
     }
 }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -11,41 +11,6 @@ var fs = require('fs');
 var keys = Object.keys;
 
 /**
- * Get the version info for Nightmare, Electron and Chromium.
- * @param {Function} done
- */
-exports.engineVersions = function(done) {
-    debug('.engineVersions()');
-    done(null, this.engineVersions);
-};
-
-/**
- * Get the title of the page.
- *
- * @param {Function} done
- */
-
-exports.title = function(done) {
-    debug('.title() getting it');
-    this.evaluate_now(function() {
-        return document.title;
-    }, done);
-};
-
-/**
- * Get the url of the page.
- *
- * @param {Function} done
- */
-
-exports.url = function(done) {
-    debug('.url() getting it');
-    this.evaluate_now(function() {
-        return document.location.href;
-    }, done);
-};
-
-/**
  * Helper function to query an element by XPath.
  *
  * @param {String} xpath
@@ -82,6 +47,41 @@ function cssLookup(selector) {
 }
 
 /**
+ * Get the version info for Nightmare, Electron and Chromium.
+ * @param {Function} done
+ */
+exports.engineVersions = function(done) {
+    debug('.engineVersions()');
+    done(null, this.engineVersions);
+};
+
+/**
+ * Get the title of the page.
+ *
+ * @param {Function} done
+ */
+
+exports.title = function(done) {
+    debug('.title() getting it');
+    this.evaluate_now(function() {
+        return document.title;
+    }, done);
+};
+
+/**
+ * Get the url of the page.
+ *
+ * @param {Function} done
+ */
+
+exports.url = function(done) {
+    debug('.url() getting it');
+    this.evaluate_now(function() {
+        return document.location.href;
+    }, done);
+};
+
+/**
  * Determine if a selector is visible on a page.
  *
  * @param {String} selector
@@ -92,7 +92,9 @@ exports.visible = function(selector, done) {
     debug('.visible() for ' + selector);
     this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
         return elem ? (elem.offsetWidth > 0 && elem.offsetHeight > 0) : false;
     }, done, selector);
 };
@@ -108,7 +110,9 @@ exports.exists = function(selector, done) {
     debug('.exists() for ' + selector);
     this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
         return elem !== null;
     }, done, selector);
 };
@@ -125,7 +129,9 @@ exports.click = function(selector, done) {
     this.evaluate_now(function(selector) {
         document.activeElement.blur();
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
         if (!elem) {
             throw new Error('Unable to find element by selector: ' + selector);
         }
@@ -146,9 +152,12 @@ exports.mousedown = function(selector, done) {
     debug('.mousedown() on ' + selector);
     this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
-        if (!elem)
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
+        if (!elem) {
             throw new Error('Unable to find element by selector: ' + selector);
+        }
         var event = document.createEvent('MouseEvent');
         event.initEvent('mousedown', true, true);
         elem.dispatchEvent(event);
@@ -166,7 +175,9 @@ exports.mouseover = function(selector, done) {
     debug('.mouseover() on ' + selector);
     this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
         if (!elem) {
             throw new Error('Unable to find element by selector: ' + selector);
         }
@@ -184,7 +195,12 @@ exports.mouseover = function(selector, done) {
 var focusSelector = function(done, selector) {
     return this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
+        if (!elem) {
+            throw new Error('Unable to find element by selector: ' + selector);
+        }
         elem.focus();
     }, done.bind(this), selector);
 };
@@ -192,7 +208,12 @@ var focusSelector = function(done, selector) {
 var blurSelector = function(done, selector) {
     return this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
+        if (!elem) {
+            throw new Error('Unable to find element by selector: ' + selector);
+        }
         elem.blur();
     }, done.bind(this), selector);
 };
@@ -223,7 +244,9 @@ exports.type = function() {
         if ((text || '') == '') {
             this.evaluate_now(function(selector) {
                 var elem = cssLookup(selector);
-                if (!elem) elem = xpathLookup(selector);
+                if (!elem) {
+                    elem = xpathLookup(selector);
+                }
                 elem.value = '';
             }, blurDone, selector);
         } else {
@@ -254,7 +277,9 @@ exports.insert = function(selector, text, done) {
         if ((text || '') == '') {
             this.evaluate_now(function(selector) {
                 var elem = cssLookup(selector);
-                if (!elem) elem = xpathLookup(selector);
+                if (!elem) {
+                    elem = xpathLookup(selector);
+                }
                 elem.value = '';
             }, blurDone, selector);
         } else {
@@ -274,7 +299,12 @@ exports.check = function(selector, done) {
     debug('.check() ' + selector);
     this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
+        if (!elem) {
+            throw new Error('Unable to find element by selector: ' + selector);
+        }
         var event = document.createEvent('HTMLEvents');
         elem.checked = true;
         event.initEvent('change', true, true);
@@ -293,7 +323,12 @@ exports.uncheck = function(selector, done) {
     debug('.uncheck() ' + selector);
     this.evaluate_now(function(selector) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
+        if (!elem) {
+            throw new Error('Unable to find element by selector: ' + selector);
+        }
         var event = document.createEvent('HTMLEvents');
         elem.checked = null;
         event.initEvent('change', true, true);
@@ -315,7 +350,12 @@ exports.select = function(selector, option, done) {
     debug('.select() ' + selector);
     this.evaluate_now(function(selector, option) {
         var elem = cssLookup(selector);
-        if (!elem) elem = xpathLookup(selector);
+        if (!elem) {
+            elem = xpathLookup(selector);
+        }
+        if (!elem) {
+            throw new Error('Unable to find element by selector: ' + selector);
+        }
         var event = document.createEvent('HTMLEvents');
         elem.value = option;
         event.initEvent('change', true, true);

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -415,7 +415,7 @@ function waitelem(self, selector, done) {
         "        elem = document.querySelector('" + jsesc(selector) + "');" +
         "    } else {" +
         "       throw e;" +
-        "    }"
+        "    }" +
         " }" +
         " return (elem ? true : false);" +
         "};");

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -50,7 +50,7 @@ exports.url = function(done) {
  *
  * @param {String} xpath
  */
-function xpathLookup(xpath) {
+var xpathLookup = function(xpath) {
     try {
         return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE);
     } catch (e) {
@@ -72,8 +72,8 @@ function xpathLookup(xpath) {
 exports.visible = function(selector, done) {
     debug('.visible() for ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
         else return false;
     }, done, selector);
@@ -89,8 +89,8 @@ exports.visible = function(selector, done) {
 exports.exists = function(selector, done) {
     debug('.exists() for ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         return elem !== null;
     }, done, selector);
 };
@@ -106,8 +106,8 @@ exports.click = function(selector, done) {
     debug('.click() on ' + selector);
     this.evaluate_now(function(selector) {
         document.activeElement.blur();
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         if (!elem) {
             throw new Error('Unable to find element by selector: ' + selector);
         }
@@ -127,8 +127,8 @@ exports.click = function(selector, done) {
 exports.mousedown = function(selector, done) {
     debug('.mousedown() on ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         if (!elem)
             throw new Error('Unable to find element by selector: ' + selector);
         var event = document.createEvent('MouseEvent');
@@ -147,8 +147,8 @@ exports.mousedown = function(selector, done) {
 exports.mouseover = function(selector, done) {
     debug('.mouseover() on ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = xpathSelector(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         if (!elem) {
             throw new Error('Unable to find element by selector: ' + selector);
         }
@@ -165,16 +165,16 @@ exports.mouseover = function(selector, done) {
 
 var focusSelector = function(done, selector) {
     return this.evaluate_now(function(selector) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         elem.focus();
     }, done.bind(this), selector);
 };
 
 var blurSelector = function(done, selector) {
     return this.evaluate_now(function(selector) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         elem.blur();
     }, done.bind(this), selector);
 };
@@ -204,8 +204,8 @@ exports.type = function() {
         var blurDone = blurSelector.bind(this, done, selector);
         if ((text || '') == '') {
             this.evaluate_now(function(selector) {
-                var elem = xpathLookup(selector);
-                if (!elem) elem = document.querySelector(selector);
+                var elem = document.querySelector(selector);
+                if (!elem) elem = xpathLookup(selector);
                 elem.value = '';
             }, blurDone, selector);
         } else {
@@ -235,8 +235,8 @@ exports.insert = function(selector, text, done) {
         var blurDone = blurSelector.bind(this, done, selector);
         if ((text || '') == '') {
             this.evaluate_now(function(selector) {
-                var elem = xpathLookup(selector);
-                if (!elem) elem = document.querySelector(selector);
+                var elem = document.querySelector(selector);
+                if (!elem) elem = xpathLookup(selector);
                 elem.value = '';
             }, blurDone, selector);
         } else {
@@ -255,8 +255,8 @@ exports.insert = function(selector, text, done) {
 exports.check = function(selector, done) {
     debug('.check() ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         var event = document.createEvent('HTMLEvents');
         elem.checked = true;
         event.initEvent('change', true, true);
@@ -274,8 +274,8 @@ exports.check = function(selector, done) {
 exports.uncheck = function(selector, done) {
     debug('.uncheck() ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         var event = document.createEvent('HTMLEvents');
         elem.checked = null;
         event.initEvent('change', true, true);
@@ -296,8 +296,8 @@ exports.uncheck = function(selector, done) {
 exports.select = function(selector, option, done) {
     debug('.select() ' + selector);
     this.evaluate_now(function(selector, option) {
-        var elem = xpathLookup(selector);
-        if (!elem) elem = document.querySelector(selector);
+        var elem = document.querySelector(selector);
+        if (!elem) elem = xpathLookup(selector);
         var event = document.createEvent('HTMLEvents');
         elem.value = option;
         event.initEvent('change', true, true);
@@ -407,12 +407,13 @@ function waitms(ms, done) {
 
 function waitelem(self, selector, done) {
     eval("var elementPresent = function() {" +
-        " var elem = null" +
+        " var elem = null;" +
         " try {" +
-        "   elem = document.evaluate('" + jsesc(selector) + "', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE);" +
+        "   elem = document.querySelector('" + jsesc(selector) + "');" +
+        "   if (!elem) elem = document.evaluate('" + jsesc(selector) + "', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE);" +
         " } catch (e) {" +
         "    if (e instanceof DOMException) {" +
-        "        elem = document.querySelector('" + jsesc(selector) + "');" +
+        "       elem = null;" +
         "    } else {" +
         "       throw e;" +
         "    }" +

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -105,16 +105,15 @@ exports.exists = function(selector, done) {
 exports.click = function(selector, done) {
     debug('.click() on ' + selector);
     this.evaluate_now(function(selector) {
-            document.activeElement.blur();
-            var elem = xpathLookup(selector);
-            if (!elem) elem = document.querySelector(selector);
-            if (!elem) {
-                throw new Error('Unable to find element by selector: ' + selector);
-            }
-            var event = document.createEvent('MouseEvent');
-            event.initEvent('click', true, true);
-            element.dispatchEvent(event);
+        document.activeElement.blur();
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        if (!elem) {
+            throw new Error('Unable to find element by selector: ' + selector);
         }
+        var event = document.createEvent('MouseEvent');
+        event.initEvent('click', true, true);
+        element.dispatchEvent(event);
     }, done, selector);
 };
 
@@ -128,12 +127,13 @@ exports.click = function(selector, done) {
 exports.mousedown = function(selector, done) {
     debug('.mousedown() on ' + selector);
     this.evaluate_now(function(selector) {
-            var elem = xpathLookup(selector);
-            if (!elem) elem = document.querySelector(selector);
-            if (!elem)
-                throw new Error('Unable to find element by selector: ' + selector);
-        }
-        var event = document.createEvent('MouseEvent'); event.initEvent('mousedown', true, true); element.dispatchEvent(event);
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        if (!elem)
+            throw new Error('Unable to find element by selector: ' + selector);
+        var event = document.createEvent('MouseEvent');
+        event.initEvent('mousedown', true, true);
+        element.dispatchEvent(event);
     }, done, selector);
 };
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -50,14 +50,33 @@ exports.url = function(done) {
  *
  * @param {String} xpath
  */
-var xpathLookup = function(xpath) {
+
+function xpathLookup(xpath) {
     try {
-        return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE);
+        return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE).singleValueNode;
     } catch (e) {
         if (e instanceof DOMException) {
-            return null;
+            return undefined;
         } else {
-            throw e;
+            throw new Error(e.message + " ('" + xpath + "')");
+        }
+    }
+}
+
+/**
+ * Helper function to query an element by CSS selector.
+ *
+ * @param {String} selector
+ */
+
+function cssLookup(selector) {
+    try {
+        return document.querySelector(selector);
+    } catch (e) {
+        if (e instanceof DOMException) {
+            return undefined;
+        } else {
+            throw new Error(e.message + " ('" + selector + "')");
         }
     }
 }
@@ -72,10 +91,9 @@ var xpathLookup = function(xpath) {
 exports.visible = function(selector, done) {
     debug('.visible() for ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
-        if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
-        else return false;
+        return elem ? (elem.offsetWidth > 0 && elem.offsetHeight > 0) : false;
     }, done, selector);
 };
 
@@ -89,7 +107,7 @@ exports.visible = function(selector, done) {
 exports.exists = function(selector, done) {
     debug('.exists() for ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         return elem !== null;
     }, done, selector);
@@ -106,14 +124,14 @@ exports.click = function(selector, done) {
     debug('.click() on ' + selector);
     this.evaluate_now(function(selector) {
         document.activeElement.blur();
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         if (!elem) {
             throw new Error('Unable to find element by selector: ' + selector);
         }
         var event = document.createEvent('MouseEvent');
         event.initEvent('click', true, true);
-        element.dispatchEvent(event);
+        elem.dispatchEvent(event);
     }, done, selector);
 };
 
@@ -127,13 +145,13 @@ exports.click = function(selector, done) {
 exports.mousedown = function(selector, done) {
     debug('.mousedown() on ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         if (!elem)
             throw new Error('Unable to find element by selector: ' + selector);
         var event = document.createEvent('MouseEvent');
         event.initEvent('mousedown', true, true);
-        element.dispatchEvent(event);
+        elem.dispatchEvent(event);
     }, done, selector);
 };
 
@@ -147,14 +165,14 @@ exports.mousedown = function(selector, done) {
 exports.mouseover = function(selector, done) {
     debug('.mouseover() on ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         if (!elem) {
             throw new Error('Unable to find element by selector: ' + selector);
         }
         var event = document.createEvent('MouseEvent');
         event.initMouseEvent('mouseover', true, true);
-        element.dispatchEvent(event);
+        elem.dispatchEvent(event);
     }, done, selector);
 };
 
@@ -165,7 +183,7 @@ exports.mouseover = function(selector, done) {
 
 var focusSelector = function(done, selector) {
     return this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         elem.focus();
     }, done.bind(this), selector);
@@ -173,7 +191,7 @@ var focusSelector = function(done, selector) {
 
 var blurSelector = function(done, selector) {
     return this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         elem.blur();
     }, done.bind(this), selector);
@@ -204,7 +222,7 @@ exports.type = function() {
         var blurDone = blurSelector.bind(this, done, selector);
         if ((text || '') == '') {
             this.evaluate_now(function(selector) {
-                var elem = document.querySelector(selector);
+                var elem = cssLookup(selector);
                 if (!elem) elem = xpathLookup(selector);
                 elem.value = '';
             }, blurDone, selector);
@@ -235,7 +253,7 @@ exports.insert = function(selector, text, done) {
         var blurDone = blurSelector.bind(this, done, selector);
         if ((text || '') == '') {
             this.evaluate_now(function(selector) {
-                var elem = document.querySelector(selector);
+                var elem = cssLookup(selector);
                 if (!elem) elem = xpathLookup(selector);
                 elem.value = '';
             }, blurDone, selector);
@@ -255,7 +273,7 @@ exports.insert = function(selector, text, done) {
 exports.check = function(selector, done) {
     debug('.check() ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         var event = document.createEvent('HTMLEvents');
         elem.checked = true;
@@ -274,7 +292,7 @@ exports.check = function(selector, done) {
 exports.uncheck = function(selector, done) {
     debug('.uncheck() ' + selector);
     this.evaluate_now(function(selector) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         var event = document.createEvent('HTMLEvents');
         elem.checked = null;
@@ -296,7 +314,7 @@ exports.uncheck = function(selector, done) {
 exports.select = function(selector, option, done) {
     debug('.select() ' + selector);
     this.evaluate_now(function(selector, option) {
-        var elem = document.querySelector(selector);
+        var elem = cssLookup(selector);
         if (!elem) elem = xpathLookup(selector);
         var event = document.createEvent('HTMLEvents');
         elem.value = option;
@@ -408,17 +426,31 @@ function waitms(ms, done) {
 function waitelem(self, selector, done) {
     eval("var elementPresent = function() {" +
         " var elem = null;" +
+        " var validCss = false;" +
         " try {" +
         "   elem = document.querySelector('" + jsesc(selector) + "');" +
-        "   if (!elem) elem = document.evaluate('" + jsesc(selector) + "', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE);" +
+        "   validCss = true;" +
+        "   if (!elem) elem = document.evaluate('" + jsesc(selector) + "', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE).singleValueNode;" +
         " } catch (e) {" +
-        "    if (e instanceof DOMException) {" +
-        "       elem = null;" +
+        "    if (!validCss) {" +
+        "      try {" +
+        "       elem = document.evaluate('" + jsesc(selector) + "', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE).singleValueNode;" +
+        "      } catch (e) {" +
+        "        if (e instanceof DOMException) {" +
+        "         elem = null;" +
+        "        } else {" +
+        "           throw e;" +
+        "        }" +
+        "      }" +
         "    } else {" +
-        "       throw e;" +
+        "       if (e instanceof DOMException) {" +
+        "          elem = null;" +
+        "       } else {" +
+        "          throw e;" +
+        "       }" +
         "    }" +
         " }" +
-        " return (elem ? true : false);" +
+        " return elem ? true : false;" +
         "};");
     waitfn.apply(this, [self, elementPresent, done]);
 }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -14,9 +14,9 @@ var keys = Object.keys;
  * Get the version info for Nightmare, Electron and Chromium.
  * @param {Function} done
  */
-exports.engineVersions = function(done){
-  debug('.engineVersions()');
-  done(null, this.engineVersions);
+exports.engineVersions = function(done) {
+    debug('.engineVersions()');
+    done(null, this.engineVersions);
 };
 
 /**
@@ -26,10 +26,10 @@ exports.engineVersions = function(done){
  */
 
 exports.title = function(done) {
-  debug('.title() getting it');
-  this.evaluate_now(function() {
-    return document.title;
-  }, done);
+    debug('.title() getting it');
+    this.evaluate_now(function() {
+        return document.title;
+    }, done);
 };
 
 /**
@@ -39,11 +39,28 @@ exports.title = function(done) {
  */
 
 exports.url = function(done) {
-  debug('.url() getting it');
-  this.evaluate_now(function() {
-    return document.location.href;
-  }, done);
+    debug('.url() getting it');
+    this.evaluate_now(function() {
+        return document.location.href;
+    }, done);
 };
+
+/**
+ * Helper function to query an element by XPath.
+ *
+ * @param {String} xpath
+ */
+function xpathLookup(xpath) {
+    try {
+        return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE);
+    } catch (e) {
+        if (e instanceof DOMException) {
+            return null;
+        } else {
+            throw e;
+        }
+    }
+}
 
 /**
  * Determine if a selector is visible on a page.
@@ -53,12 +70,13 @@ exports.url = function(done) {
  */
 
 exports.visible = function(selector, done) {
-  debug('.visible() for ' + selector);
-  this.evaluate_now(function(selector) {
-    var elem = document.querySelector(selector);
-    if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
-    else return false;
-  }, done, selector);
+    debug('.visible() for ' + selector);
+    this.evaluate_now(function(selector) {
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
+        else return false;
+    }, done, selector);
 };
 
 /**
@@ -69,10 +87,12 @@ exports.visible = function(selector, done) {
  */
 
 exports.exists = function(selector, done) {
-  debug('.exists() for ' + selector);
-  this.evaluate_now(function(selector) {
-    return (document.querySelector(selector)!==null);
-  }, done, selector);
+    debug('.exists() for ' + selector);
+    this.evaluate_now(function(selector) {
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        return elem !== null;
+    }, done, selector);
 };
 
 /**
@@ -83,17 +103,19 @@ exports.exists = function(selector, done) {
  */
 
 exports.click = function(selector, done) {
-  debug('.click() on ' + selector);
-  this.evaluate_now(function (selector) {
-    document.activeElement.blur();
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('click', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+    debug('.click() on ' + selector);
+    this.evaluate_now(function(selector) {
+            document.activeElement.blur();
+            var elem = xpathLookup(selector);
+            if (!elem) elem = document.querySelector(selector);
+            if (!elem) {
+                throw new Error('Unable to find element by selector: ' + selector);
+            }
+            var event = document.createEvent('MouseEvent');
+            event.initEvent('click', true, true);
+            element.dispatchEvent(event);
+        }
+    }, done, selector);
 };
 
 /**
@@ -104,16 +126,15 @@ exports.click = function(selector, done) {
  */
 
 exports.mousedown = function(selector, done) {
-  debug('.mousedown() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('mousedown', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+    debug('.mousedown() on ' + selector);
+    this.evaluate_now(function(selector) {
+            var elem = xpathLookup(selector);
+            if (!elem) elem = document.querySelector(selector);
+            if (!elem)
+                throw new Error('Unable to find element by selector: ' + selector);
+        }
+        var event = document.createEvent('MouseEvent'); event.initEvent('mousedown', true, true); element.dispatchEvent(event);
+    }, done, selector);
 };
 
 /**
@@ -124,16 +145,17 @@ exports.mousedown = function(selector, done) {
  */
 
 exports.mouseover = function(selector, done) {
-  debug('.mouseover() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initMouseEvent('mouseover', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+    debug('.mouseover() on ' + selector);
+    this.evaluate_now(function(selector) {
+        var elem = xpathSelector(selector);
+        if (!elem) elem = document.querySelector(selector);
+        if (!elem) {
+            throw new Error('Unable to find element by selector: ' + selector);
+        }
+        var event = document.createEvent('MouseEvent');
+        event.initMouseEvent('mouseover', true, true);
+        element.dispatchEvent(event);
+    }, done, selector);
 };
 
 /**
@@ -142,15 +164,19 @@ exports.mouseover = function(selector, done) {
  */
 
 var focusSelector = function(done, selector) {
-  return this.evaluate_now(function(selector) {
-    document.querySelector(selector).focus();
-  }, done.bind(this), selector);
+    return this.evaluate_now(function(selector) {
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        elem.focus();
+    }, done.bind(this), selector);
 };
 
 var blurSelector = function(done, selector) {
-  return this.evaluate_now(function(selector) {
-    document.querySelector(selector).blur();
-  }, done.bind(this), selector);
+    return this.evaluate_now(function(selector) {
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        elem.blur();
+    }, done.bind(this), selector);
 };
 
 /**
@@ -162,27 +188,30 @@ var blurSelector = function(done, selector) {
  */
 
 exports.type = function() {
-  var selector = arguments[0], text, done;
-  if(arguments.length == 2) {
-    done = arguments[1];
-  } else {
-    text = arguments[1];
-    done = arguments[2];
-  }
-
-  debug('.type() %s into %s', text, selector);
-  var self = this;
-
-  focusSelector.bind(this)(function() {
-    var blurDone = blurSelector.bind(this, done, selector);
-    if ((text || '') == '') {
-      this.evaluate_now(function(selector) {
-        document.querySelector(selector).value = '';
-      }, blurDone, selector);
+    var selector = arguments[0],
+        text, done;
+    if (arguments.length == 2) {
+        done = arguments[1];
     } else {
-      self.child.call('type', text, blurDone);
+        text = arguments[1];
+        done = arguments[2];
     }
-  }, selector);
+
+    debug('.type() %s into %s', text, selector);
+    var self = this;
+
+    focusSelector.bind(this)(function() {
+        var blurDone = blurSelector.bind(this, done, selector);
+        if ((text || '') == '') {
+            this.evaluate_now(function(selector) {
+                var elem = xpathLookup(selector);
+                if (!elem) elem = document.querySelector(selector);
+                elem.value = '';
+            }, blurDone, selector);
+        } else {
+            self.child.call('type', text, blurDone);
+        }
+    }, selector);
 };
 
 /**
@@ -194,24 +223,26 @@ exports.type = function() {
  */
 
 exports.insert = function(selector, text, done) {
-  if (arguments.length === 2) {
-    done = text
-    text = null
-  }
-
-  debug('.insert() %s into %s', text, selector);
-  var child = this.child;
-
-  focusSelector.bind(this)(function() {
-    var blurDone = blurSelector.bind(this, done, selector);
-    if ((text || '') == '') {
-      this.evaluate_now(function(selector) {
-        document.querySelector(selector).value = '';
-      }, blurDone, selector);
-    } else {
-      child.call('insert', text, blurDone);
+    if (arguments.length === 2) {
+        done = text
+        text = null
     }
-  }, selector);
+
+    debug('.insert() %s into %s', text, selector);
+    var child = this.child;
+
+    focusSelector.bind(this)(function() {
+        var blurDone = blurSelector.bind(this, done, selector);
+        if ((text || '') == '') {
+            this.evaluate_now(function(selector) {
+                var elem = xpathLookup(selector);
+                if (!elem) elem = document.querySelector(selector);
+                elem.value = '';
+            }, blurDone, selector);
+        } else {
+            child.call('insert', text, blurDone);
+        }
+    }, selector);
 }
 
 /**
@@ -222,14 +253,15 @@ exports.insert = function(selector, text, done) {
  */
 
 exports.check = function(selector, done) {
-  debug('.check() ' + selector);
-  this.evaluate_now(function(selector) {
-    var element = document.querySelector(selector);
-    var event = document.createEvent('HTMLEvents');
-    element.checked = true;
-    event.initEvent('change', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+    debug('.check() ' + selector);
+    this.evaluate_now(function(selector) {
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        var event = document.createEvent('HTMLEvents');
+        elem.checked = true;
+        event.initEvent('change', true, true);
+        elem.dispatchEvent(event);
+    }, done, selector);
 };
 
 /*
@@ -239,14 +271,15 @@ exports.check = function(selector, done) {
  * @param {Function} done
  */
 
-exports.uncheck = function(selector, done){
-  debug('.uncheck() ' + selector);
-  this.evaluate_now(function(selector) {
-      var element = document.querySelector(selector);
-      var event = document.createEvent('HTMLEvents');
-      element.checked = null;
-      event.initEvent('change', true, true);
-      element.dispatchEvent(event);
+exports.uncheck = function(selector, done) {
+    debug('.uncheck() ' + selector);
+    this.evaluate_now(function(selector) {
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        var event = document.createEvent('HTMLEvents');
+        elem.checked = null;
+        event.initEvent('change', true, true);
+        elem.dispatchEvent(event);
     }, done, selector);
 };
 
@@ -261,14 +294,15 @@ exports.uncheck = function(selector, done){
  */
 
 exports.select = function(selector, option, done) {
-  debug('.select() ' + selector);
-  this.evaluate_now(function(selector, option) {
-    var element = document.querySelector(selector);
-    var event = document.createEvent('HTMLEvents');
-    element.value = option;
-    event.initEvent('change', true, true);
-    element.dispatchEvent(event);
-  }, done, selector, option);
+    debug('.select() ' + selector);
+    this.evaluate_now(function(selector, option) {
+        var elem = xpathLookup(selector);
+        if (!elem) elem = document.querySelector(selector);
+        var event = document.createEvent('HTMLEvents');
+        elem.value = option;
+        event.initEvent('change', true, true);
+        elem.dispatchEvent(event);
+    }, done, selector, option);
 };
 
 /**
@@ -278,10 +312,10 @@ exports.select = function(selector, option, done) {
  */
 
 exports.back = function(done) {
-  debug('.back()');
-  this.evaluate_now(function() {
-    window.history.back();
-  }, done);
+    debug('.back()');
+    this.evaluate_now(function() {
+        window.history.back();
+    }, done);
 };
 
 /**
@@ -291,10 +325,10 @@ exports.back = function(done) {
  */
 
 exports.forward = function(done) {
-  debug('.forward()');
-  this.evaluate_now(function() {
-    window.history.forward();
-  }, done);
+    debug('.forward()');
+    this.evaluate_now(function() {
+        window.history.forward();
+    }, done);
 };
 
 /**
@@ -304,10 +338,10 @@ exports.forward = function(done) {
  */
 
 exports.refresh = function(done) {
-  debug('.refresh()');
-  this.evaluate_now(function() {
-    window.location.reload();
-  }, done);
+    debug('.refresh()');
+    this.evaluate_now(function() {
+        window.location.reload();
+    }, done);
 };
 
 /**
@@ -316,41 +350,40 @@ exports.refresh = function(done) {
  * @param {...} args
  */
 
-exports.wait = function () {
-  var args = sliced(arguments);
-  var done = args[args.length-1];
-  if (args.length < 2) {
-    debug('Not enough arguments for .wait()');
-    return done();
-  }
-
-  var arg = args[0];
-  if (typeof arg === 'number') {
-    debug('.wait() for ' + arg + 'ms');
-    if(arg < this.options.waitTimeout){
-      waitms(arg, done);
-    } else {
-      waitms(this.options.waitTimeout, function(){
-        done(new Error('.wait() timed out after '+this.options.waitTimeout+'msec'));
-      }.bind(this));
+exports.wait = function() {
+    var args = sliced(arguments);
+    var done = args[args.length - 1];
+    if (args.length < 2) {
+        debug('Not enough arguments for .wait()');
+        return done();
     }
-  }
-  else if (typeof arg === 'string') {
-    var timeout = null; 
-    if (typeof args[1] === 'number') { 
-      timeout = args[1];
-    } 
-    debug('.wait() for '+arg+' element'+(timeout ? ' or '+timeout+'msec' : ''));
-    waitelem.apply({ timeout: timeout }, [this, arg, done]);
-  }
-  else if (typeof arg === 'function') {
-    debug('.wait() for fn');
-    args.unshift(this);
-    waitfn.apply(this, args);
-  }
-  else {
-    done();
-  }
+
+    var arg = args[0];
+    if (typeof arg === 'number') {
+        debug('.wait() for ' + arg + 'ms');
+        if (arg < this.options.waitTimeout) {
+            waitms(arg, done);
+        } else {
+            waitms(this.options.waitTimeout, function() {
+                done(new Error('.wait() timed out after ' + this.options.waitTimeout + 'msec'));
+            }.bind(this));
+        }
+    } else if (typeof arg === 'string') {
+        var timeout = null; 
+        if (typeof args[1] === 'number') { 
+            timeout = args[1];
+        } 
+        debug('.wait() for ' + arg + ' element' + (timeout ? ' or ' + timeout + 'msec' : ''));
+        waitelem.apply({
+            timeout: timeout
+        }, [this, arg, done]);
+    } else if (typeof arg === 'function') {
+        debug('.wait() for fn');
+        args.unshift(this);
+        waitfn.apply(this, args);
+    } else {
+        done();
+    }
 };
 
 /**
@@ -360,8 +393,8 @@ exports.wait = function () {
  * @param {Function} done
  */
 
-function waitms (ms, done) {
-  setTimeout(done, ms);
+function waitms(ms, done) {
+    setTimeout(done, ms);
 }
 
 /**
@@ -372,12 +405,21 @@ function waitms (ms, done) {
  * @param {Function} done
  */
 
-function waitelem (self, selector, done) {
-  eval("var elementPresent = function() {"+
-      "  var element = document.querySelector('"+jsesc(selector)+"');"+
-      "  return (element ? true : false);" +
-      "};");
-  waitfn.apply(this, [self, elementPresent, done]);
+function waitelem(self, selector, done) {
+    eval("var elementPresent = function() {" +
+        " var elem = null" +
+        " try {" +
+        "   elem = document.evaluate('" + jsesc(selector) + "', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE);" +
+        " } catch (e) {" +
+        "    if (e instanceof DOMException) {" +
+        "        elem = document.querySelector('" + jsesc(selector) + "');" +
+        "    } else {" +
+        "       throw e;" +
+        "    }"
+        " }" +
+        " return (elem ? true : false);" +
+        "};");
+    waitfn.apply(this, [self, elementPresent, done]);
 }
 
 /**
@@ -390,33 +432,30 @@ function waitelem (self, selector, done) {
  */
 
 function waitfn() { 
-  var timeout = this.timeout || null;
-  var waitMsPassed = 0;
-  return tick.apply(this, arguments)
+    var timeout = this.timeout || null;
+    var waitMsPassed = 0;
+    return tick.apply(this, arguments)
 
-  function tick (self, fn/**, arg1, arg2..., done**/) {
-    var args = sliced(arguments);
-    var done = args[args.length-1];
-    var waitDone = function (err, result) {
-      if (result) {
-        return done();
-      }
-      else if (timeout && waitMsPassed > timeout) {
-        return done();
-      }
-      else if (self.options.waitTimeout && waitMsPassed > self.options.waitTimeout) {
-        return done(new Error('.wait() timed out after '+self.options.waitTimeout+'msec'));
-      }
-      else {
-        waitMsPassed += self.options.pollInterval;
-        setTimeout(function () {
-          tick.apply(self, args);
-        }, self.options.pollInterval);
-      }
-    };
-    var newArgs = [fn, waitDone].concat(args.slice(2,-1));
-    self.evaluate_now.apply(self, newArgs);
-  }
+    function tick(self, fn /**, arg1, arg2..., done**/ ) {
+        var args = sliced(arguments);
+        var done = args[args.length - 1];
+        var waitDone = function(err, result) {
+            if (result) {
+                return done();
+            } else if (timeout && waitMsPassed > timeout) {
+                return done();
+            } else if (self.options.waitTimeout && waitMsPassed > self.options.waitTimeout) {
+                return done(new Error('.wait() timed out after ' + self.options.waitTimeout + 'msec'));
+            } else {
+                waitMsPassed += self.options.pollInterval;
+                setTimeout(function() {
+                    tick.apply(self, args);
+                }, self.options.pollInterval);
+            }
+        };
+        var newArgs = [fn, waitDone].concat(args.slice(2, -1));
+        self.evaluate_now.apply(self, newArgs);
+    }
 }
 
 /**
@@ -427,15 +466,15 @@ function waitfn() { 
  * @param {Function} done
  */
 
-exports.evaluate = function (fn/**, arg1, arg2..., done**/) {
-  var args = sliced(arguments);
-  var done = args[args.length-1];
-  var newArgs = [fn, done].concat(args.slice(1,-1));
-  if (typeof fn !== 'function') {
-    return done(new Error('.evaluate() fn should be a function'));
-  }
-  debug('.evaluate() fn on the page');
-  this.evaluate_now.apply(this, newArgs);
+exports.evaluate = function(fn /**, arg1, arg2..., done**/ ) {
+    var args = sliced(arguments);
+    var done = args[args.length - 1];
+    var newArgs = [fn, done].concat(args.slice(1, -1));
+    if (typeof fn !== 'function') {
+        return done(new Error('.evaluate() fn should be a function'));
+    }
+    debug('.evaluate() fn on the page');
+    this.evaluate_now.apply(this, newArgs);
 };
 
 /**
@@ -446,20 +485,22 @@ exports.evaluate = function (fn/**, arg1, arg2..., done**/) {
  * @param {Function} done
  */
 
-exports.inject = function (type, file, done) {
-  debug('.inject()-ing a file');
-  if (type === 'js') {
-    var js = fs.readFileSync(file, { encoding: 'utf-8' });
-    this._inject(js, done);
-  }
-  else if (type === 'css') {
-    var css = fs.readFileSync(file, { encoding: 'utf-8' });
-    this.child.call('css', css, done);
-  }
-  else {
-    debug('unsupported file type in .inject()');
-    done();
-  }
+exports.inject = function(type, file, done) {
+    debug('.inject()-ing a file');
+    if (type === 'js') {
+        var js = fs.readFileSync(file, {
+            encoding: 'utf-8'
+        });
+        this._inject(js, done);
+    } else if (type === 'css') {
+        var css = fs.readFileSync(file, {
+            encoding: 'utf-8'
+        });
+        this.child.call('css', css, done);
+    } else {
+        debug('unsupported file type in .inject()');
+        done();
+    }
 };
 
 /**
@@ -470,9 +511,9 @@ exports.inject = function (type, file, done) {
  * @param {Function} done
  */
 
-exports.viewport = function (width, height, done) {
-  debug('.viewport()');
-  this.child.call('size', width, height, done);
+exports.viewport = function(width, height, done) {
+    debug('.viewport()');
+    this.child.call('size', width, height, done);
 };
 
 /**
@@ -483,8 +524,8 @@ exports.viewport = function (width, height, done) {
  */
 
 exports.useragent = function(useragent, done) {
-  debug('.useragent() to ' + useragent);
-  this.child.call('useragent', useragent, done);
+    debug('.useragent() to ' + useragent);
+    this.child.call('useragent', useragent, done);
 };
 
 /**
@@ -495,11 +536,11 @@ exports.useragent = function(useragent, done) {
  * @param {Function} done
  */
 
-exports.scrollTo = function (y, x, done) {
-  debug('.scrollTo()');
-  this.evaluate_now(function (y, x) {
-    window.scrollTo(x, y);
-  }, done, y, x);
+exports.scrollTo = function(y, x, done) {
+    debug('.scrollTo()');
+    this.evaluate_now(function(y, x) {
+        window.scrollTo(x, y);
+    }, done, y, x);
 };
 
 /**
@@ -510,22 +551,22 @@ exports.scrollTo = function (y, x, done) {
  * @param {Function} done
  */
 
-exports.screenshot = function (path, clip, done) {
-  debug('.screenshot()');
-  if (typeof path === 'function') {
-    done = path;
-    clip = undefined;
-    path = undefined;
-  } else if (typeof clip === 'function') {
-    done = clip;
-    clip = (typeof path === 'string') ? undefined : path;
-    path = (typeof path === 'string') ? path : undefined;
-  }
-  this.child.call('screenshot', path, clip, function (error, img) {
-    var buf = new Buffer(img.data);
-    debug('.screenshot() captured with length %s', buf.length);
-    path ? fs.writeFile(path, buf, done) : done(null, buf);
-  });
+exports.screenshot = function(path, clip, done) {
+    debug('.screenshot()');
+    if (typeof path === 'function') {
+        done = path;
+        clip = undefined;
+        path = undefined;
+    } else if (typeof clip === 'function') {
+        done = clip;
+        clip = (typeof path === 'string') ? undefined : path;
+        path = (typeof path === 'string') ? path : undefined;
+    }
+    this.child.call('screenshot', path, clip, function(error, img) {
+        var buf = new Buffer(img.data);
+        debug('.screenshot() captured with length %s', buf.length);
+        path ? fs.writeFile(path, buf, done) : done(null, buf);
+    });
 };
 
 /**
@@ -536,24 +577,24 @@ exports.screenshot = function (path, clip, done) {
  * @param {Function} done
  */
 
-exports.html = function (path, saveType, done) {
-  debug('.html()');
-  if (typeof path === 'function' && !saveType && !done) {
-    done = path;
-    saveType = undefined;
-    path = undefined;
-  } else if (typeof path === 'object' && typeof saveType === 'function' && !done) {
-    done = saveType;
-    saveType = path;
-    path = undefined;
-  } else if (typeof saveType === 'function' && !done) {
-    done = saveType;
-    saveType = undefined;
-  }
-  this.child.call('html', path, saveType, function (error) {
-    if (error) debug(error);
-    done(error);
-  });
+exports.html = function(path, saveType, done) {
+    debug('.html()');
+    if (typeof path === 'function' && !saveType && !done) {
+        done = path;
+        saveType = undefined;
+        path = undefined;
+    } else if (typeof path === 'object' && typeof saveType === 'function' && !done) {
+        done = saveType;
+        saveType = path;
+        path = undefined;
+    } else if (typeof saveType === 'function' && !done) {
+        done = saveType;
+        saveType = undefined;
+    }
+    this.child.call('html', path, saveType, function(error) {
+        if (error) debug(error);
+        done(error);
+    });
 }
 
 /**
@@ -563,26 +604,26 @@ exports.html = function (path, saveType, done) {
  * @param {Function} done
  */
 
-exports.pdf = function (path, options, done) {
-  debug('.pdf()');
-  if (typeof path === 'function' && !options && !done) {
-    done = path;
-    options = undefined;
-    path = undefined;
-  } else if (typeof path === 'object' && typeof options === 'function' && !done){
-    done = options;
-    options = path;
-    path = undefined;
-  } else if (typeof options === 'function' && !done) {
-    done = options;
-    options = undefined;
-  }
-  this.child.call('pdf', path, options, function (error, pdf) {
-    if (error) debug(error);
-    var buf = new Buffer(pdf.data);
-    debug('.pdf() captured with length %s', buf.length);
-    path ? fs.writeFile(path, buf, done) : done(null, buf);
-  });
+exports.pdf = function(path, options, done) {
+    debug('.pdf()');
+    if (typeof path === 'function' && !options && !done) {
+        done = path;
+        options = undefined;
+        path = undefined;
+    } else if (typeof path === 'object' && typeof options === 'function' && !done) {
+        done = options;
+        options = path;
+        path = undefined;
+    } else if (typeof options === 'function' && !done) {
+        done = options;
+        options = undefined;
+    }
+    this.child.call('pdf', path, options, function(error, pdf) {
+        if (error) debug(error);
+        var buf = new Buffer(pdf.data);
+        debug('.pdf() captured with length %s', buf.length);
+        path ? fs.writeFile(path, buf, done) : done(null, buf);
+    });
 };
 
 /**
@@ -599,84 +640,85 @@ exports.cookies = {};
  * Get a cookie
  */
 
-exports.cookies.get = function (name, done) {
-  debug('cookies.get()')
-  var query = {}
+exports.cookies.get = function(name, done) {
+    debug('cookies.get()')
+    var query = {}
 
-  switch (arguments.length) {
-    case 2:
-      query = typeof name === 'string'
-        ? { name: name }
-        : name
-      break;
-    case 1:
-      done = name
-      break;
-  }
+    switch (arguments.length) {
+        case 2:
+            query = typeof name === 'string' ? {
+                    name: name
+                } :
+                name
+            break;
+        case 1:
+            done = name
+            break;
+    }
 
-  this.child.call('cookie.get', query, done);
+    this.child.call('cookie.get', query, done);
 };
 
 /**
  * Set a cookie
  */
 
-exports.cookies.set = function (name, value, done) {
-  debug('cookies.set()')
-  var cookies = []
+exports.cookies.set = function(name, value, done) {
+    debug('cookies.set()')
+    var cookies = []
 
-  switch (arguments.length) {
-    case 3:
-      cookies.push({
-        name: name,
-        value: value
-      })
-      break;
-    case 2:
-      cookies = [].concat(name)
-      done = value
-      break;
-    case 1:
-      done = name
-      break;
-  }
+    switch (arguments.length) {
+        case 3:
+            cookies.push({
+                name: name,
+                value: value
+            })
+            break;
+        case 2:
+            cookies = [].concat(name)
+            done = value
+            break;
+        case 1:
+            done = name
+            break;
+    }
 
-  this.child.call('cookie.set', cookies, done);
+    this.child.call('cookie.set', cookies, done);
 };
 
 /**
  * Clear a cookie
  */
 
-exports.cookies.clear = function (name, done) {
-  debug('cookies.clear()')
-  var cookies = []
+exports.cookies.clear = function(name, done) {
+    debug('cookies.clear()')
+    var cookies = []
 
-  switch (arguments.length) {
-    case 2:
-      cookies = [].concat(name);
-      break;
-    case 1:
-      done = name;
-      break;
-  }
+    switch (arguments.length) {
+        case 2:
+            cookies = [].concat(name);
+            break;
+        case 1:
+            done = name;
+            break;
+    }
 
-  this.child.call('cookie.clear', cookies, done);
+    this.child.call('cookie.clear', cookies, done);
 };
 
 /**
  * Clear all cookies
  */
 
-exports.cookies.clearAll = function(done){
-  this.child.call('cookie.clearAll', done);
+exports.cookies.clearAll = function(done) {
+    this.child.call('cookie.clearAll', done);
 };
 
 /**
  * Authentication
  */
 
- exports.authentication = function (login, password, done) {
-   debug('.authentication()');
-   this.child.call('authentication', login, password, done);
- };
+exports.authentication = function(login, password, done) {
+    debug('.authentication()');
+    this.child.call('authentication', login, password, done);
+};


### PR DESCRIPTION
Adding `document.evaluate()` before regular `document.querySelector()` calls, transparently handling XPath expressions. 

Could be an initial implementation to target #775 

Thanks,
Gustavo
