### PR TITLE
asynchronous evaluate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -134,6 +134,14 @@ var nightmare = Nightmare({
   loadTimeout: 1000 // in ms
 });
 ```
+##### executionTimeout (default: 30s)
+The maxiumum amount of time to wait for an `.evaluate()` statement to complete.
+
+```js
+var nightmare = Nightmare({
+  executionTimeout: 1000 // in ms
+});
+```
 
 ##### paths
 The default system paths that Electron knows about. Here's a list of available paths: https://github.com/atom/electron/blob/master/docs/api/app.md#appgetpathname
@@ -311,6 +319,35 @@ nightmare
     // now we're executing inside the browser scope.
     return document.querySelector(selector).innerText;
    }, selector) // <-- that's how you pass parameters from Node scope to browser scope
+  .then(function(text) {
+    // ...
+  })
+```
+
+Callbacks are supported as a part of evaluate.  If the arguments passed are one fewer than the arguments expected for the evaluated function, the evaluation will be passed a callback as the last parameter to the function.  For example:
+
+```js
+var selector = 'h1';
+nightmare
+  .evaluate(function (selector, done) {
+    // now we're executing inside the browser scope.
+    setTimeout(() => done(null, document.querySelector(selector).innerText), 2000);
+   }, selector)
+  .then(function(text) {
+    // ...
+  })
+```
+Note that callbacks support only one value argument.  Ultimately, the callback will get wrapped in a native Promise and only be able to resolve a single value.
+
+Promises are also supported as a part of evaluate.  If the return value of the function has a `then` member, `.evaluate()` assumes it is waiting for a promise.  For example:
+
+```js
+var selector = 'h1';
+nightmare
+  .evaluate(function (selector, done) {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(document.querySelector(selector).innerText), 2000);
+   }, selector)
   .then(function(text) {
     // ...
   })

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -336,10 +336,10 @@ exports.wait = function () {
     }
   }
   else if (typeof arg === 'string') {
-    var timeout = null; 
-    if (typeof args[1] === 'number') { 
+    var timeout = null;
+    if (typeof args[1] === 'number') {
       timeout = args[1];
-    } 
+    }
     debug('.wait() for '+arg+' element'+(timeout ? ' or '+timeout+'msec' : ''));
     waitelem.apply({ timeout: timeout }, [this, arg, done]);
   }
@@ -389,27 +389,43 @@ function waitelem (self, selector, done) {
  * @param {Function} done
  */
 
-function waitfn() { 
-  var timeout = this.timeout || null;
-  var waitMsPassed = 0;
+function waitfn() {
+  var softTimeout = this.timeout || null;
+  var executionTimer;
+  var softTimeoutTimer;
+  var self = arguments[0];
+  
+  var args = sliced(arguments);
+  var done = args[args.length-1];
+  
+  var timeoutTimer = setTimeout(function(){
+    clearTimeout(executionTimer);
+    clearTimeout(softTimeoutTimer);
+    done(new Error(`.wait() timed out after ${self.options.waitTimeout}msec`));
+  }, self.options.waitTimeout);
   return tick.apply(this, arguments)
 
   function tick (self, fn/**, arg1, arg2..., done**/) {
-    var args = sliced(arguments);
-    var done = args[args.length-1];
+    if(softTimeout){
+      softTimeoutTimer = setTimeout(function(){
+        clearTimeout(executionTimer);
+        clearTimeout(timeoutTimer);
+        done();
+      }, softTimeout)
+    }
+
     var waitDone = function (err, result) {
       if (result) {
+        clearTimeout(timeoutTimer);
+        clearTimeout(softTimeoutTimer);
         return done();
-      }
-      else if (timeout && waitMsPassed > timeout) {
-        return done();
-      }
-      else if (self.options.waitTimeout && waitMsPassed > self.options.waitTimeout) {
-        return done(new Error('.wait() timed out after '+self.options.waitTimeout+'msec'));
+      } else if(err) {
+        clearTimeout(timeoutTimer);
+        clearTimeout(softTimeoutTimer);
+        return done(err);
       }
       else {
-        waitMsPassed += self.options.pollInterval;
-        setTimeout(function () {
+        executionTimer = setTimeout(function () {
           tick.apply(self, args);
         }, self.options.pollInterval);
       }
@@ -430,11 +446,19 @@ function waitfn() { 
 exports.evaluate = function (fn/**, arg1, arg2..., done**/) {
   var args = sliced(arguments);
   var done = args[args.length-1];
-  var newArgs = [fn, done].concat(args.slice(1,-1));
+  var self = this;
+  var newDone = function(){
+    clearTimeout(timeoutTimer);
+    done.apply(self, arguments);
+  };
+  var newArgs = [fn, newDone].concat(args.slice(1,-1));
   if (typeof fn !== 'function') {
     return done(new Error('.evaluate() fn should be a function'));
   }
   debug('.evaluate() fn on the page');
+  var timeoutTimer = setTimeout(function(){
+    done(new Error(`Evaluation timed out after ${self.options.executionTimeout}msec.  Are you calling done() or resolving your promises?`));
+  }, self.options.executionTimeout);
   this.evaluate_now.apply(this, newArgs);
 };
 

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -14,10 +14,34 @@ var execute = `
 (function javascript () {
   var ipc = __nightmare.ipc;
   try {
-    var response = ({{!src}})({{!args}})
-    ipc.send('response', response);
-  } catch (e) {
-    ipc.send('error', e.message);
+    var fn = ({{!src}}), 
+      response, 
+      args = JSON.parse('[{{!args}}]');
+
+    if(fn.length - 1 == args.length) {
+      args.push(((err, v) => {
+          if(err) {
+            ipc.send('error', err.message || err.toString());
+          }
+          ipc.send('response', v);
+        }));
+      fn.apply(null, args);
+    } 
+    else {
+      response = fn({{!args}})
+      if(response && response.then) {
+        response.then((v) => {
+          ipc.send('response', v);
+        })
+        .catch((err) => {
+          ipc.send('error', err)
+        });
+      } else {
+        ipc.send('response', response);
+      }
+    }
+  } catch (err) {
+    ipc.send('error', err.message);
   }
 })()
 `;

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -36,6 +36,8 @@ const DEFAULT_TYPE_INTERVAL = 100;
 const DEFAULT_POLL_INTERVAL = 250;
 // max retry for authentication
 const MAX_AUTH_RETRIES = 3;
+// max execution time for `.evaluate()`
+const DEFAULT_EXECUTION_TIMEOUT = 10 * 1000
 
 /**
  * Export `Nightmare`
@@ -72,6 +74,7 @@ function Nightmare(options) {
   options.pollInterval = options.pollInterval || DEFAULT_POLL_INTERVAL;
 
   options.typeInterval = options.typeInterval || DEFAULT_TYPE_INTERVAL;
+  options.executionTimeout = options.executionTimeout || DEFAULT_EXECUTION_TIMEOUT;
 
   var electron_path = options.electronPath || default_electron_path
 
@@ -349,7 +352,7 @@ Nightmare.prototype.run = function(fn) {
 Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var args = Array.prototype.slice.call(arguments).slice(2);
   var argsList = JSON.stringify(args).slice(1,-1);
-  var source = template.execute({ src: String(js_fn), args: argsList });
+  var source = template.execute({ src: String(js_fn), args: argsList});
 
   this.child.call('javascript', source, done);
   return this;

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -37,7 +37,7 @@ const DEFAULT_POLL_INTERVAL = 250;
 // max retry for authentication
 const MAX_AUTH_RETRIES = 3;
 // max execution time for `.evaluate()`
-const DEFAULT_EXECUTION_TIMEOUT = 10 * 1000
+const DEFAULT_EXECUTION_TIMEOUT = 30 * 1000
 
 /**
  * Export `Nightmare`

--- a/test/index.js
+++ b/test/index.js
@@ -709,7 +709,7 @@ describe('Nightmare', function () {
       });
 
       it('should allow for timeouts in asynchronous evaluation with a callback', function*() {
-        this.timeout(15000);
+        this.timeout(40000);
         yield nightmare
           .goto(fixture('evaluation'))
           .evaluate(function(done) {
@@ -752,7 +752,7 @@ describe('Nightmare', function () {
       });
 
       it('should allow for timeouts in asynchronous evaluation with a promise', function*() {
-        this.timeout(15000);
+        this.timeout(40000);
         yield nightmare
           .goto(fixture('evaluation'))
           .evaluate(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -188,7 +188,8 @@ describe('Nightmare', function () {
     beforeEach(function() {
       nightmare = Nightmare({
         webPreferences: {partition: 'test-partition' + Math.random()},
-        loadTimeout: 45 * 1000
+        loadTimeout: 45 * 1000,
+        waitTimeout: 5 * 1000,
       });
     });
 
@@ -308,6 +309,50 @@ describe('Nightmare', function () {
           var textB = document.querySelector('a.b').textContent;
           return (expectedA === textA && expectedB === textB);
         }, 'A', 'B');
+    });
+
+    describe('asynchronous wait', function(){
+      it('should wait until the evaluate fn with arguments returns true with a callback', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (expectedA, expectedB, done) {
+            setTimeout(() => {
+              var textA = document.querySelector('a.a').textContent;
+              var textB = document.querySelector('a.b').textContent;
+              done(null, expectedA === textA && expectedB === textB);
+            }, 2000);
+          }, 'A', 'B');
+      });
+
+      it('should wait until the evaluate fn with arguments returns true with a promise', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (expectedA, expectedB) {
+            return new Promise(function(resolve) {
+              setTimeout(() => {
+                var textA = document.querySelector('a.a').textContent;
+                var textB = document.querySelector('a.b').textContent;
+                resolve(expectedA === textA && expectedB === textB);
+              }, 2000);
+            });
+          }, 'A', 'B');
+      });
+
+      it('should reject timeout on wait', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (done) {
+            //never call done
+          }).should.be.rejected;
+      });
+
+      it('should run multiple times before timeout on wait', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (done) {
+            setTimeout(() => done(null, false), 500);
+          }).should.be.rejected;
+      });
     });
 
     it('should fail if navigation target is invalid', function() {
@@ -633,6 +678,89 @@ describe('Nightmare', function () {
         .goto(fixture('evaluation'))
         .evaluate('not_a_function')
         .should.be.rejected;
+    });
+
+    describe('asynchronous', function(){
+      it('should allow for asynchronous evaluation with a callback', function*() {
+        var asyncValue = yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(done) {
+            setTimeout(() => done(null, 'nightmare'), 1000);
+          });
+
+          asyncValue.should.equal('nightmare');
+      });
+      it('should allow for arguments with asynchronous evaluation with a callback', function*() {
+        var asyncValue = yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(str, done) {
+            setTimeout(() => done(null, str), 1000);
+          }, 'nightmare');
+
+          asyncValue.should.equal('nightmare');
+      });
+
+      it('should allow for errors in asynchronous evaluation with a callback', function*() {
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(done) {
+            setTimeout(() => done(new Error('nightmare')), 1000);
+          }).should.be.rejected;
+      });
+
+      it('should allow for timeouts in asynchronous evaluation with a callback', function*() {
+        this.timeout(15000);
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(done) {
+            //don't call done
+          }).should.be.rejected;
+      });
+
+      it('should allow for asynchronous evaluation with a promise', function*() {
+        var asyncValue =  yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function() {
+            return new Promise(resolve => {
+              setTimeout(() => resolve('nightmare'), 1000);
+            });
+          })
+
+          asyncValue.should.equal('nightmare');
+      });
+
+      it('should allow for arguments with asynchronous evaluation with a promise', function*() {
+        var asyncValue =  yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(str) {
+            return new Promise(resolve => {
+              setTimeout(() => resolve(str), 1000);
+            });
+          }, 'nightmare')
+
+          asyncValue.should.equal('nightmare');
+      });
+
+      it('should allow for errors in asynchronous evaluation with a promise', function*() {
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function() {
+            return new Promise((resolve, reject) => {
+              setTimeout(() => reject(new Error('nightmare')), 1000);
+            });
+          }).should.be.rejected;
+      });
+
+      it('should allow for timeouts in asynchronous evaluation with a promise', function*() {
+        this.timeout(15000);
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function() {
+            return new Promise((resolve, reject) => {
+              return 'nightmare';
+            });
+          }).should.be.rejected;
+      });
     });
   });
 


### PR DESCRIPTION
This PR is intended to let you run `.evaluate()`d functions that are asynchronous, either with callbacks or with promises.  For callbacks, if the `.evaluate()`d function's arity is one less than the passed in parameters, it'll assume the last argument to the function is the callback.  If the return value is a `then`able, it'll call `then()` to wait for promise fulfillment.  Otherwise, the call will behave synchronously as it does now.

This change is _potentially_ breaking as it does change behavior based on the arguments to `.evaluate()`.  Is this change worth the risk of possibly breaking implementations that already exist?

Related to #573 and closes #552.