### PR TITLE
Make blur optional for type and insert

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -149,9 +149,23 @@ var focusSelector = function(done, selector) {
 
 var blurSelector = function(done, selector) {
   return this.evaluate_now(function(selector) {
-    document.querySelector(selector).blur();
+    //it is possible the element has been removed from the DOM
+    //between the action and the call to blur the element
+    var element = document.querySelector(selector);
+    if(element) {
+      element.blur()
+    }
   }, done.bind(this), selector);
 };
+
+/*
+var blurSelector = function(done, selector) {
+  return this.evaluate_now(function(selector) {
+    var element = document.querySelector(selector).blur();
+  }, done.bind(this), selector);
+}; 
+*/
+
 
 /**
  * Type into an element.
@@ -173,7 +187,12 @@ exports.type = function() {
   debug('.type() %s into %s', text, selector);
   var self = this;
 
-  focusSelector.bind(this)(function() {
+  focusSelector.bind(this)(function(err) {
+    if(err) {
+      debug('Unable to .type() into non-existent selector %s', selector);
+      return done(err);
+    }
+
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
       this.evaluate_now(function(selector) {
@@ -202,7 +221,12 @@ exports.insert = function(selector, text, done) {
   debug('.insert() %s into %s', text, selector);
   var child = this.child;
 
-  focusSelector.bind(this)(function() {
+  focusSelector.bind(this)(function(err) {
+    if(err) {
+      debug('Unable to .insert() into non-existent selector %s', selector);
+      return done(err);
+    }
+    
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
       this.evaluate_now(function(selector) {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -158,15 +158,6 @@ var blurSelector = function(done, selector) {
   }, done.bind(this), selector);
 };
 
-/*
-var blurSelector = function(done, selector) {
-  return this.evaluate_now(function(selector) {
-    var element = document.querySelector(selector).blur();
-  }, done.bind(this), selector);
-}; 
-*/
-
-
 /**
  * Type into an element.
  *

--- a/test/fixtures/manipulation/index.html
+++ b/test/fixtures/manipulation/index.html
@@ -8,6 +8,7 @@
     <form action="results.html">
       <input type="search" name="q">
       <input type="checkbox" name="advanced">
+      <input type='text' id='disappears'>
       <select name="options">
         <option value="a">A</option>
         <option value="b">B</option>
@@ -80,6 +81,14 @@
   <script>
   var h1 = document.getElementsByTagName("h1");
   var search = document.querySelector('input[type=search]')
+  var disappears = document.querySelector('#disappears');
+
+  disappears.addEventListener('keydown', function(e){
+    if(e.which == 69){
+      var form = document.querySelector('form');
+      form.removeChild(disappears);
+    }
+  });
 
   h1[0].addEventListener("mouseover", function(){
     this.style.background = "#66ff66";

--- a/test/index.js
+++ b/test/index.js
@@ -831,6 +831,13 @@ describe('Nightmare', function () {
       isBody.should.be.true;
     });
 
+    it('should not fail if selector no longer exists to blur after typing', function*() {
+      yield nightmare
+        .on('console', function(){ console.log(arguments)})
+        .goto(fixture('manipulation'))
+        .type('input#disappears', 'nightmare');
+    });
+
     it('should type and click', function*() {
       var title = yield nightmare
         .goto(fixture('manipulation'))


### PR DESCRIPTION
If the element being typed or inserted into is removed from the DOM before the blur call is made (which can happen if the element is removed on a key event), an exception is raised.  `blurSelector` now makes sure the element still exists before making the blur call.  Also added a debug message if the selector does not exist after focusing.

Partially fixes #762.