### PR TITLE
Prevent unload dialogs (...from preventing .end())

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -8,6 +8,29 @@ window.addEventListener('error', function(e) {
 });
 
 (function(){
+  // prevent 'unload' and 'beforeunload' from being bound
+  var defaultAddEventListener = window.addEventListener;
+  window.addEventListener = function (type) {
+    if (type === 'unload' || type === 'beforeunload') {
+      return;
+    }
+    defaultAddEventListener.apply(window, arguments);
+  };
+
+  // prevent 'onunload' and 'onbeforeunload' from being set
+  Object.defineProperties(window, {
+    onunload: {
+      enumerable: true,
+      writable: false,
+      value: null
+    },
+    onbeforeunload: {
+      enumerable: true,
+      writable: false,
+      value: null
+    }
+  });
+
   // listen for console.log
   var defaultLog = console.log;
   console.log = function() {

--- a/test/fixtures/unload/add-event-listener.html
+++ b/test/fixtures/unload/add-event-listener.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Unload</title>
+    <script>
+      var unloadHandler = function (event) {
+        var confirmationMessage = 'Are you sure?';
+        event.returnValue = confirmationMessage;
+        return confirmationMessage;
+      };
+      window.addEventListener('unload', unloadHandler);
+      window.addEventListener('beforeunload', unloadHandler);
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/fixtures/unload/index.html
+++ b/test/fixtures/unload/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Unload</title>
+    <script>
+      window.onunload = window.onbeforeunload = function () {
+        return 'Are you sure?';
+      };
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -92,7 +92,7 @@ describe('Nightmare', function () {
   it('should gracefully handle electron being killed', function(done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-unended.js'));
-      
+
     child.once('message', function(electronPid) {
       process.kill(electronPid, 'SIGINT');
       child.once('exit', function(){
@@ -143,6 +143,20 @@ describe('Nightmare', function () {
     nightmare.goto(fixture('navigation'))
       .end()
       .then(() => nightmare.end())
+      .then(() => done());
+  });
+
+  it('should successfully end on pages setting onunload or onbeforeunload', function(done) {
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('unload'))
+      .end()
+      .then(() => done());
+  });
+
+  it('should successfully end on pages binding unload or beforeunload', function(done) {
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('unload/add-event-listener.html'))
+      .end()
       .then(() => done());
   });
 


### PR DESCRIPTION
Earlier today I ran into this issue: https://github.com/segmentio/nightmare/issues/824

I resolved it by creating a modified `preload.js` that prevents the browser from setting any `unload` or `beforeunload` handlers. This pull request includes my modified `preload.js` along with two tests that ensure that it works.
