### PR TITLE
code example corrections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -350,7 +350,7 @@ Promises are also supported as a part of evaluate.  If the return value of the f
 ```js
 var selector = 'h1';
 nightmare
-  .evaluate(function (selector, done) {
+  .evaluate(function (selector) {
       return new Promise((resolve, reject) => {
         setTimeout(() => resolve(document.querySelector(selector).innerText), 2000);
    })}, selector)

--- a/Readme.md
+++ b/Readme.md
@@ -353,7 +353,7 @@ nightmare
   .evaluate(function (selector, done) {
       return new Promise((resolve, reject) => {
         setTimeout(() => resolve(document.querySelector(selector).innerText), 2000);
-   }, selector)
+   })}, selector)
   .then(function(text) {
     // ...
   })


### PR DESCRIPTION
I found two missing characters within the code example for the newly added Promises within an evaluate section.

Also, I removed done because including an extra parameter when using evaluate Promises will cause it to not work as a Promise and instead as a callback.
