### PR TITLE
Adds .path() to get path exclusively, instead of full url

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -443,6 +443,9 @@ Returns the title of the current page.
 #### .url()
 Returns the url of the current page.
 
+#### .path()
+Returns the path name of the current page.
+
 ### Cookies
 
 #### .cookies.get(name)

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -46,6 +46,19 @@ exports.url = function(done) {
 };
 
 /**
+ * Get the path of the page.
+ *
+ * @param {Function} done
+ */
+
+exports.path = function(done) {
+  debug('.url() getting it');
+  this.evaluate_now(function() {
+    return document.location.pathname;
+  }, done);
+};
+
+/**
  * Determine if a selector is visible on a page.
  *
  * @param {String} selector

--- a/test/index.js
+++ b/test/index.js
@@ -656,6 +656,15 @@ describe('Nightmare', function () {
       url.should.have.string(fixture('evaluation'));
     });
 
+    it('should get the path', function*() {
+      var path = yield nightmare
+        .goto(fixture('evaluation'))
+        .path();
+      var formalUrl = fixture('evaluation') + '/';
+
+      formalUrl.should.have.string(path);
+    });
+
     it('should check if the selector exists', function*() {
       // existent element
       var exists = yield nightmare


### PR DESCRIPTION
Fixes #901 

In my understanding, all exported actions are bound to the nightmare object on instantiate. So this will work fine.

```js
yield nightmare.goto('https://some.tld/path/is/here').path(); // outputs /path/is/here
```