### PR TITLE
Alter default behavior to non-persistent partition

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -678,6 +678,34 @@ __nightmare.ipc = require('electron').ipcRenderer;
 
 To benefit of all of nightmare's feedback from the browser, you can instead copy the contents of nightmare's [preload script](lib/preload.js).
 
+#### Storage Persistence between nightmare instances
+
+By default nightmare will create an in-memory partition for each instance. This means that any localStorage or cookies or any other form of persistent state will be destroyed when nightmare is ended. If you would like to persist state between instances you can use the [webPreferences.partition](http://electron.atom.io/docs/api/browser-window/#new-browserwindowoptions) api in electron.
+
+```js
+var Nightmare = require('nightmare');
+
+nightmare = Nightmare(); // non persistent paritition by default
+yield nightmare
+  .evaluate(function () { 
+    window.localStorage.setItem('testing', 'This will not be persisted');
+  })
+  .end();
+
+nightmare = Nightmare({
+  webPreferences: {
+    partition: 'persist: testing'
+  }
+});
+yield nightmare
+  .evaluate(function () {
+    window.localStorage.setItem('testing', 'This is persisted for other instances with the same paritition name');
+  })
+  .end();
+```
+
+If you specify a `null` paritition then it will use the electron default behavior (persistent) or any string that starts with `'persist:'` will persist under that partition name, any other string will result in in-memory only storage.
+
 ## Usage
 #### Installation
 Nightmare is a Node.js module, so you'll need to [have Node.js installed](http://nodejs.org/). Then you just need to `npm install` the module:

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -40,6 +40,8 @@ const MAX_AUTH_RETRIES = 3;
 const DEFAULT_EXECUTION_TIMEOUT = 30 * 1000
 // Error message when halted
 const DEFAULT_HALT_MESSAGE = 'Nightmare Halted';
+// Non-persistent partition to use by defaults
+const DEFAULT_PARTITION = 'nightmare';
 
 /**
  * Export `Nightmare`
@@ -77,6 +79,12 @@ function Nightmare(options) {
 
   options.typeInterval = options.typeInterval || DEFAULT_TYPE_INTERVAL;
   options.executionTimeout = options.executionTimeout || DEFAULT_EXECUTION_TIMEOUT;
+  options.webPreferences = options.webPreferences || {};
+
+  // null is a valid value, which will result in the use of the electron default behavior, which is to persist storage.
+  // The default behavior for nightmare will be to use non-persistent storage.
+  // http://electron.atom.io/docs/api/browser-window/#new-browserwindowoptions
+  options.webPreferences.partition = options.webPreferences.partition !== undefined ? options.webPreferences.partition : DEFAULT_PARTITION;
 
   var electron_path = options.electronPath || default_electron_path
 


### PR DESCRIPTION
The current behavior uses electron default, which creates a partition
for storage which persists between instances. This makes sense for
electron but not necessarily for primary use cases of Nightmare.

This change sets the default partition to be a non-persistent partition
but allows a user to opt back into persistence with simple configuration options.

Fixes segmentio/nightmare#916

## 4 new passing tests, all others green
<img width="675" alt="screenshot 2016-12-05 16 59 20" src="https://cloud.githubusercontent.com/assets/10974/20906254/ba9ad368-bb0c-11e6-889e-4b83fe75aba2.png">

## Preview of wiki changes
![screenshot 2016-12-05 16 53 50](https://cloud.githubusercontent.com/assets/10974/20906235/a8c32604-bb0c-11e6-816f-ca387fbf1b04.png)

