### PR TITLE
Use debugger highlighting for triggering frames to render (improves screenshots)

### DIFF
--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -61,7 +61,9 @@ function FrameManager(window) {
        many milliseconds, run the callback anyway. In this case, The
        callback's first argument, an image buffer, will be `null`.
    */
-  this.requestFrame = function(callback, timeout = 1000) {
+  this.requestFrame = function(callback, timeout) {
+    timeout = (timeout == undefined) ? 1000 : timeout;
+    
     if (callback) {
       this.once('data', callback);
     }
@@ -85,9 +87,9 @@ function FrameManager(window) {
       }
       
       if (timeout) {
-        frameRequestTimeout = setTimeout(() => {
+        frameRequestTimeout = setTimeout(function() {
           parent.emit('log', `FrameManager timing out after ${timeout} ms with no new rendered frames`);
-          this.emit('data', null)
+          self.emit('data', null)
         }, timeout);
       }
 

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -98,6 +98,7 @@ function FrameManager(window) {
       window.webContents.debugger.sendCommand(
         'DOM.highlightRect', HIGHLIGHT_STYLE, function(error) {
           window.webContents.debugger.sendCommand('DOM.hideHighlight');
+          window.webContents.debugger.detach();
         });
     }
   };

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -3,6 +3,13 @@ const EventEmitter = require('events');
 const util = require('util');
 
 const RENDER_ELEMENT_ID = '__NIGHTMARE_RENDER__';
+const HIGHLIGHT_STYLE = {
+  x: 0,
+  y: 0,
+  width: 1,
+  height: 1,
+  color: {r: 0, g: 0, b: 0, a: 0.1}
+};
 
 module.exports = FrameManager;
 
@@ -53,33 +60,33 @@ function FrameManager(window) {
     if (callback) {
       this.once('data', callback);
     }
+    
     if (!requestedFrame) {
-      parent.emit('log', 'altering page to force rendering');
       requestedFrame = true;
-      window.webContents.executeJavaScript(
-        '(' + triggerRender + ')("' + RENDER_ELEMENT_ID + '")');
+      
+      // Force the browser to render new content by using the debugger to
+      // highlight a portion of the page. This way, we can guarantee a change
+      // that both requires rendering a frame and does not actually affect
+      // the content of the page.
+      if (!window.webContents.debugger.isAttached()) {
+        try {
+          window.webContents.debugger.attach();
+        }
+        catch (error) {
+          parent.emit('log', `Failed to attach to debugger for frame subscriptions: ${error}`);
+          self.emit('data', null);
+        }
+      }
+
+      parent.emit('log', 'Highlighting page to trigger rendering.');
+      window.webContents.debugger.sendCommand('DOM.enable')
+      window.webContents.debugger.sendCommand(
+        'DOM.highlightRect', HIGHLIGHT_STYLE, function(error) {
+          window.webContents.debugger.sendCommand('DOM.hideHighlight');
+        });
     }
   };
 };
 
 util.inherits(FrameManager, EventEmitter);
 
-// this runs in the render process and alters the render tree, forcing Chromium
-// to draw a new frame.
-var triggerRender = (function (id) {
-  var renderElement = document.getElementById(id);
-  if (renderElement) {
-    renderElement.remove();
-  }
-  else {
-    renderElement = document.createElement('div');
-    renderElement.id = id;
-    renderElement.setAttribute('style',
-      'position: absolute;' +
-      'left: 0;' +
-      'top: 0;' +
-      'width: 1px;' +
-      'height: 1px;');
-    document.documentElement.appendChild(renderElement);
-  }
-}).toString();

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -25,6 +25,7 @@ function FrameManager(window) {
   EventEmitter.call(this);
   var subscribed = false;
   var requestedFrame = false;
+  var frameRequestTimeout;
   var self = this;
 
   this.on('newListener', subscribe);
@@ -47,6 +48,7 @@ function FrameManager(window) {
 
   function receiveFrame(buffer) {
     requestedFrame = false;
+    clearTimeout(frameRequestTimeout);
     self.emit('data', buffer);
   }
 
@@ -54,9 +56,12 @@ function FrameManager(window) {
    * In addition to listening for events, calling `requestFrame` will ensure
    * that a frame is queued up to render (instead of just waiting for the next
    * time the browser chooses to draw a frame).
-   * @param  {Function} [callback] Called when the frame is rendered.
+   * @param {Function} [callback] Called when the frame is rendered.
+   * @param {Number} [timeout=1000] If no frame has been rendered after this
+       many milliseconds, run the callback anyway. In this case, The
+       callback's first argument, an image buffer, will be `null`.
    */
-  this.requestFrame = function(callback) {
+  this.requestFrame = function(callback, timeout = 1000) {
     if (callback) {
       this.once('data', callback);
     }
@@ -74,8 +79,16 @@ function FrameManager(window) {
         }
         catch (error) {
           parent.emit('log', `Failed to attach to debugger for frame subscriptions: ${error}`);
-          self.emit('data', null);
+          this.emit('data', null);
+          return;
         }
+      }
+      
+      if (timeout) {
+        frameRequestTimeout = setTimeout(() => {
+          parent.emit('log', `FrameManager timing out after ${timeout} ms with no new rendered frames`);
+          this.emit('data', null)
+        }, timeout);
       }
 
       parent.emit('log', 'Highlighting page to trigger rendering.');


### PR DESCRIPTION
Since the initial implementation of `FrameManager`, Electron has added an API for Chromium's remote debugging protocol, which can visually highlight a portion of the page. This change uses that functionality to force a new frame to be rendered, which is much more reliable than the way Nightmare currently tries to force new frames to render by fiddling around with the DOM (see people experiencing problems with this in #555, #736, #809). It also has the benefit of not doing anything page content can observe, ensuring that any JS or CSS won't modify the page in response to Nightmare's attempt to take a screenshot.

This also adds a timeout. We should never hit it when using the debugger, but I figure it’s better to be safe than sorry here, especially after the hangs people have been experiencing.

In future versions of the remote debugging protocol, it will be possible to directly capture an image of the page, but that feature is still experimental (so it could be removed) and Electron does not yet support it anyhow. Something to keep in mind for future changes, though.

This is an alternative solution to the one in 53dee8a2ad88ea656d2b48504dbe66ff5287d0ab (currently on the `screenshot-with-offscreen-rendering` branch). That method (using Electron's new "offscreen" rendering mode) is *much* faster than this and vastly simplifies the code, but has more ways it can fail and has other side effects. If that approach looks better, I can submit it as a PR. We can also look into combining the two if the side effects are acceptable.