### PR TITLE
Don't dispatch event on non-existent option.

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -311,11 +311,13 @@ exports.uncheck = function(selector, done){
 exports.select = function(selector, option, done) {
   debug('.select() ' + selector);
   this.evaluate_now(function(selector, option) {
-    var element = document.querySelector(selector);
-    var event = document.createEvent('HTMLEvents');
-    element.value = option;
-    event.initEvent('change', true, true);
-    element.dispatchEvent(event);
+    if (document.querySelector(selector + ' option[value="' + option + '"]')) {
+      var element = document.querySelector(selector);
+      var event = document.createEvent('HTMLEvents');
+      element.value = option;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }
   }, done, selector, option);
 };
 


### PR DESCRIPTION
In certain cases in angular, if there is a select box with an event listener that has no options populated and an event if dispatched, it will trigger change detection within angular, which will throw errors and cause electron to crash/freeze.