### PR TITLE
Updated link to electron documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -446,7 +446,7 @@ Takes a screenshot of the current page. Useful for debugging. The output is alwa
 Save the current page as html as files to disk at the given path. Save type options are [here](https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback).
 
 #### .pdf(path, options)
-Saves a PDF to the specified `path`. Options are [here](https://github.com/atom/electron/blob/v0.35.2/docs/api/web-contents.md#webcontentsprinttopdfoptions-callback).
+Saves a PDF to the specified `path`. Options are [here](https://github.com/electron/electron/blob/v1.4.4/docs/api/web-contents.md#contentsprinttopdfoptions-callback).
 
 #### .title()
 Returns the title of the current page.


### PR DESCRIPTION
I have updated the link to the electron documentation to match the version that is specified in [package.json](https://github.com/segmentio/nightmare/blob/master/package.json) file.

This is relevant since the electron 1.4.4 documentation describes the option of specifying a custom page size when generating PDF-files.