### PR TITLE
Repaired support for multiple timeouts in FrameManager

### DIFF
--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -44,6 +44,12 @@ function FrameManager(window) {
     }
   }
 
+  function cancelFrame() {
+    requestedFrame = false;
+    clearTimeout(frameRequestTimeout);
+    self.emit('data', null);
+  }
+
   function receiveFrame(buffer) {
     requestedFrame = false;
     clearTimeout(frameRequestTimeout);
@@ -79,8 +85,7 @@ function FrameManager(window) {
         }
         catch (error) {
           parent.emit('log', `Failed to attach to debugger for frame subscriptions: ${error}`);
-          requestedFrame = false;
-          this.emit('data', null);
+          cancelFrame();
           return;
         }
       }
@@ -88,8 +93,7 @@ function FrameManager(window) {
       if (timeout) {
         frameRequestTimeout = setTimeout(function() {
           parent.emit('log', `FrameManager timing out after ${timeout} ms with no new rendered frames`);
-          requestedFrame = false;
-          self.emit('data', null)
+          cancelFrame();
         }, timeout);
       }
 

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -79,6 +79,7 @@ function FrameManager(window) {
         }
         catch (error) {
           parent.emit('log', `Failed to attach to debugger for frame subscriptions: ${error}`);
+          requestedFrame = false;
           this.emit('data', null);
           return;
         }
@@ -87,6 +88,7 @@ function FrameManager(window) {
       if (timeout) {
         frameRequestTimeout = setTimeout(function() {
           parent.emit('log', `FrameManager timing out after ${timeout} ms with no new rendered frames`);
+          requestedFrame = false;
           self.emit('data', null)
         }, timeout);
       }

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -23,7 +23,6 @@ function FrameManager(window) {
   if (!(this instanceof FrameManager)) return new FrameManager(window);
 
   EventEmitter.call(this);
-  var subscribed = false;
   var requestedFrame = false;
   var frameRequestTimeout;
   var self = this;
@@ -42,7 +41,6 @@ function FrameManager(window) {
     if (!self.listenerCount('data')) {
       parent.emit('log', 'unsubscribing from browser window frames')
       window.webContents.endFrameSubscription();
-      subscribed = false;
     }
   }
 

--- a/lib/frame-manager.js
+++ b/lib/frame-manager.js
@@ -32,7 +32,7 @@ function FrameManager(window) {
   this.on('removeListener', unsubscribe);
 
   function subscribe(eventName) {
-    if (!subscribed && eventName === 'data') {
+    if (!self.listenerCount('data') && eventName === 'data') {
       parent.emit('log', 'subscribing to browser window frames');
       window.webContents.beginFrameSubscription(receiveFrame);
     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "split2": "^2.0.1"
   },
   "devDependencies": {
+    "async": "~2.1.4",
     "basic-auth": "^1.0.3",
     "basic-auth-connect": "^1.0.0",
     "chai": "^3.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -1463,6 +1463,31 @@ describe('Nightmare', function () {
       didSubscribe.should.be.false;
     });
 
+    it.only('should subscribe to frames when requested necessary', function(done) {
+      var didSubscribe = false;
+      var didUnsubscribe = false;
+      var FrameManager = require('../lib/frame-manager.js');
+      var fn;
+      var manager = FrameManager({
+        webContents: {
+          debugger: {
+            isAttached: function() { return true; },
+            sendCommand: function(command) { if (command === 'DOM.highlightRect') { fn('mock-data'); }}
+          },
+          beginFrameSubscription: function(_fn) { didSubscribe = true; fn = _fn; },
+          endFrameSubscription: function() { didUnsubscribe = true; },
+          executeJavaScript: function() {}
+        }
+      });
+      manager.requestFrame(function (data) {
+        console.log('uhhh', data);
+        didSubscribe.should.be.true;
+        didUnsubscribe.should.be.true;
+        data.should.equal('mock-data');
+        done();
+      });
+    });
+
     it('should load jquery correctly', function*() {
       var loaded = yield nightmare
         .goto(fixture('rendering'))

--- a/test/index.js
+++ b/test/index.js
@@ -1564,7 +1564,7 @@ describe('Nightmare', function () {
     });
 
     // DEV: We can have multiple timeouts if page is static
-    it.only('should support multiple series timing out frame subscriptions', function(done) {
+    it('should support multiple series timing out frame subscriptions', function(done) {
       var subscribeCount = 0;
       var unsubscribeCount = 0;
       var FrameManager = require('../lib/frame-manager.js');

--- a/test/index.js
+++ b/test/index.js
@@ -1525,7 +1525,7 @@ describe('Nightmare', function () {
       });
     });
 
-    it.only('should support multiple series frame subscriptions', function(done) {
+    it('should support multiple series frame subscriptions', function(done) {
       var subscribeCount = 0;
       var unsubscribeCount = 0;
       var FrameManager = require('../lib/frame-manager.js');

--- a/test/index.js
+++ b/test/index.js
@@ -1588,8 +1588,8 @@ describe('Nightmare', function () {
         }, 100);
       }, function handleResults (err, results) {
         if (err) { done(err); }
-        subscribeCount.should.equal(1);
-        unsubscribeCount.should.equal(1);
+        subscribeCount.should.equal(2);
+        unsubscribeCount.should.equal(2);
         should.equal(results[0], null);
         should.equal(results[1], null);
         done();


### PR DESCRIPTION
I'm a new user of Nightmare but found an issue when recording multiple screenshots on a static page (i.e. one with no frame updates). I was recording multiple screenshots in series at different viewport sizes.

- Nightmare was hanging indefinitely when hidden
- Nightmare was hanging when visible until I moved my mouse over the content (thus generating a new frame for the debugger)

After some sleuthing, it looks like FrameManager has some sneaky edge cases that needed deeper testing. In this PR:

- Fixed up double subscription issue due to still using `subscribed` boolean despite no longer being used
- Added `requestedFrame` resetting on `attach` error and `timeout` so future attach errors/timeouts can get the same `null` frame
- Added tests

**Notes:**

With respect to tests, I feel like I did a quick and dirty job. The `require` chunks aren't pulled out and I added `async` despite it not being used in the rest of the repo. I mostly wanted to get feedback on the PR and how y'all would like to handle the code setup instead of stressing myself out. I will gladly make any requested changes

Closes https://github.com/segmentio/nightmare/issues/555#issuecomment-324119322