### PR TITLE
Add jpeg support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -440,13 +440,8 @@ Similar to `.on()`, but captures page events with the callback one time.
 Removes a given listener callback for an event.
 
 #### .screenshot([path][, clip])
-Screenshot is an alias of `toPNG`
+Takes a screenshot of the current page. Useful for debugging. The output can be a `png` or a `jpg/jpeg` according to the file extension.The default mime type is `png`. All arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data.  If `compression` is provided, it will compress to the specified compression. Otherwise it will default to `90`.  Note that compression is only available with `jpg/jpeg`. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
-#### .toPng([path][, clip])
-Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
-
-#### .toJpeg([path][,compression, clip])
-Takes a screenshot of the current page. Useful for debugging. The output is always a `jpg`. All the arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `compression` is provided, it will compress to the specified compression. Otherwise it will default to `90`. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
 #### .html(path, saveType)
 Save the current page as html as files to disk at the given path. Save type options are [here](https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback).

--- a/Readme.md
+++ b/Readme.md
@@ -442,6 +442,12 @@ Removes a given listener callback for an event.
 #### .screenshot([path][, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
+#### .toPng([path][, clip])
+Is an alias of screenshot
+
+#### .toJpeg([path][,compression, clip])
+Takes a screenshot of the current page. Useful for debugging. The output is always a `jpg`. All the arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `compression` is provided, it will compress to the specified compression. Otherwise it will default to `90`. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
+
 #### .html(path, saveType)
 Save the current page as html as files to disk at the given path. Save type options are [here](https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback).
 
@@ -701,7 +707,7 @@ var Nightmare = require('nightmare');
 
 nightmare = Nightmare(); // non persistent paritition by default
 yield nightmare
-  .evaluate(function () { 
+  .evaluate(function () {
     window.localStorage.setItem('testing', 'This will not be persisted');
   })
   .end();

--- a/Readme.md
+++ b/Readme.md
@@ -440,10 +440,10 @@ Similar to `.on()`, but captures page events with the callback one time.
 Removes a given listener callback for an event.
 
 #### .screenshot([path][, clip])
-Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
+Screenshot is an alias of `toPNG`
 
 #### .toPng([path][, clip])
-Is an alias of screenshot
+Takes a screenshot of the current page. Useful for debugging. The output is always a `png`. Both arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.
 
 #### .toJpeg([path][,compression, clip])
 Takes a screenshot of the current page. Useful for debugging. The output is always a `jpg`. All the arguments are optional. If `path` is provided, it saves the image to the disk. Otherwise it returns a `Buffer` of the image data. If `compression` is provided, it will compress to the specified compression. Otherwise it will default to `90`. If `clip` is provided (as [documented here](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#wincapturepagerect-callback)), the image will be clipped to the rectangle.

--- a/example_render.js
+++ b/example_render.js
@@ -5,17 +5,30 @@ nightmare = new Nightmare({ show: false, frame:false });
    nightmare
    .goto('https://github.com')
    .viewport(1200,800)
-   .toPNG('png_default.png')
-   .toJPEG('jpeg_default.jpg')
-   .toJPEG('jpeg_compress.jpg',5)
-   .toJPEG('jpeg_compress_clip.jpg',5,{
+   .screenshot(3)
+   .screenshot('png_default.png')
+   .screenshot('png_clip.png',{
+     x: 50,
+     y: 50,
+     width: 100,
+     height: 100
+   })
+   .screenshot('bmp_default.bmp',{
+     x: 50,
+     y: 50,
+     width: 100,
+     height: 100
+   })
+   .screenshot('jpeg_default.jpg')
+   .screenshot('jpeg_compress.jpg',5)
+   .screenshot('jpeg_compress_clip.jpg',5,{
      x: 50,
      y: 50,
      width: 100,
      height: 100
    })
    //string object function
-   .toJPEG('jpeg_clip_default.jpg',{
+   .screenshot('jpeg_clip_default.jpg',{
      x: 50,
      y: 50,
      width: 100,

--- a/example_render.js
+++ b/example_render.js
@@ -5,17 +5,17 @@ nightmare = new Nightmare({ show: false, frame:false });
    nightmare
    .goto('https://github.com')
    .viewport(1200,800)
-   .toPng('png_default.png')
-   .toJpeg('jpeg_default.jpg')
-   .toJpeg('jpeg_compress.jpg',5)
-   .toJpeg('jpeg_compress_clip.jpg',5,{
+   .toPNG('png_default.png')
+   .toJPEG('jpeg_default.jpg')
+   .toJPEG('jpeg_compress.jpg',5)
+   .toJPEG('jpeg_compress_clip.jpg',5,{
      x: 50,
      y: 50,
      width: 100,
      height: 100
    })
    //string object function
-   .toJpeg('jpeg_clip_default.jpg',{
+   .toJPEG('jpeg_clip_default.jpg',{
      x: 50,
      y: 50,
      width: 100,

--- a/example_render.js
+++ b/example_render.js
@@ -1,41 +1,28 @@
 var Nightmare = require('.');
-
-nightmare = new Nightmare({ show: false, frame:false });
-// nightmare = new Nightmare();
-   nightmare
-   .goto('https://github.com')
-   .viewport(1200,800)
-   .screenshot(3)
-   .screenshot('png_default.png')
-   .screenshot('png_clip.png',{
-     x: 50,
-     y: 50,
-     width: 100,
-     height: 100
-   })
-   .screenshot('bmp_default.bmp',{
-     x: 50,
-     y: 50,
-     width: 100,
-     height: 100
-   })
-   .screenshot('jpeg_default.jpg')
-   .screenshot('jpeg_compress.jpg',5)
-   .screenshot('jpeg_compress_clip.jpg',5,{
-     x: 50,
-     y: 50,
-     width: 100,
-     height: 100
-   })
-   //string object function
-   .screenshot('jpeg_clip_default.jpg',{
-     x: 50,
-     y: 50,
-     width: 100,
-     height: 100
-   })
-   .run(function(err, nightmare) {
-       console.log('and we are done!');
-       // run() appropriately tears down the nightmare instance
-   })
-   .end();
+nightmare = new Nightmare({
+    show: false,
+    frame: false
+});
+nightmare
+    .goto('https://github.com')
+    .viewport(1200, 800)
+    .screenshot('png_default.png')
+    .screenshot('png_clip.png', {
+        x: 50,
+        y: 50,
+        width: 100,
+        height: 100
+    })
+    .screenshot('jpeg_default.jpg')
+    .screenshot('jpeg_compress.jpg', 5)
+    .screenshot('jpeg_compress_clip.jpg', 5, {
+        x: 50,
+        y: 50,
+        width: 100,
+        height: 100
+    })
+    .run(function(err, nightmare) {
+        console.log('and we are done!');
+        // run() appropriately tears down the nightmare instance
+    })
+    .end();

--- a/example_render.js
+++ b/example_render.js
@@ -1,0 +1,28 @@
+var Nightmare = require('.');
+
+nightmare = new Nightmare({ show: false, frame:false });
+// nightmare = new Nightmare();
+   nightmare
+   .goto('https://github.com')
+   .viewport(1200,800)
+   .toPng('png_default.png')
+   .toJpeg('jpeg_default.jpg')
+   .toJpeg('jpeg_compress.jpg',5)
+   .toJpeg('jpeg_compress_clip.jpg',5,{
+     x: 50,
+     y: 50,
+     width: 100,
+     height: 100
+   })
+   //string object function
+   .toJpeg('jpeg_clip_default.jpg',{
+     x: 50,
+     y: 50,
+     width: 100,
+     height: 100
+   })
+   .run(function(err, nightmare) {
+       console.log('and we are done!');
+       // run() appropriately tears down the nightmare instance
+   })
+   .end();

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -577,14 +577,15 @@ exports.scrollTo = function (y, x, done) {
 
 /**
  * Take a screenshot.
+ * screenshot() is an alias of toPNG()
  *
  * @param {String} path
  * @param {Object} clip
  * @param {Function} done
  */
-exports.screenshot = exports.toPng
+exports.screenshot = exports.toPNG
 = function (path, clip, done) {
-  debug('.toPng()');
+  debug('.toPNG()');
   if (typeof path === 'function') {
     done = path;
     clip = undefined;
@@ -594,9 +595,9 @@ exports.screenshot = exports.toPng
     clip = (typeof path === 'string') ? undefined : path;
     path = (typeof path === 'string') ? path : undefined;
   }
-  this.child.call('screenshot', path, clip, function (error, img) {
+  this.child.call('toPNG', path, clip, function (error, img) {
     var buf = new Buffer(img.data);
-    debug('.toPng() captured with length %s', buf.length);
+    debug('.toPNG() captured with length %s', buf.length);
     path ? fs.writeFile(path, buf, done) : done(null, buf);
   });
 };
@@ -610,8 +611,8 @@ exports.screenshot = exports.toPng
  * @param {Function} done
  */
 
-exports.toJpeg = function (path,compression, clip, done) {
-  debug('.toJpeg()');
+exports.toJPEG = function (path,compression, clip, done) {
+  debug('.toJPEG()');
   if (typeof path === 'function') {
     done = path;
     clip = undefined;
@@ -633,9 +634,9 @@ exports.toJpeg = function (path,compression, clip, done) {
       path = (typeof path === 'string') ? path : undefined
     }
   }
-  this.child.call('toJpeg', path, compression, clip, function (error, img) {
+  this.child.call('toJPEG', path, compression, clip, function (error, img) {
     var buf = new Buffer(img.data);
-    debug('.toJpeg() captured with length %s', buf.length);
+    debug('.toJPEG() captured with length %s', buf.length);
     path ? fs.writeFile(path, buf, done) : done(null, buf);
   });
 };

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -9,7 +9,7 @@ var isArray = Array.isArray;
 var once = require('once');
 var fs = require('fs');
 var keys = Object.keys;
-var jpegCompression = 90;
+
 /**
  * Get the version info for Nightmare, Electron and Chromium.
  * @param {Function} done
@@ -585,21 +585,20 @@ exports.scrollTo = function (y, x, done) {
  * @param {Object} clip
  * @param {Function} done
  */
-exports.screenshot = function (path,compression, clip, done) {
+
+exports.screenshot = function (path, compression, clip, done) {
   debug('.screenshot()');
   if (typeof path === 'function') {
     done = path;
     clip = undefined;
     compression = undefined;
     path = undefined;
-  } else
-  if (typeof compression === 'function') {
+  } else if (typeof compression === 'function') {
     done = compression;
     clip = (typeof path) === 'object' ? path : undefined;
     compression = (typeof path === 'number') ? path : undefined;
     path = (typeof path === 'string') ? path : undefined;
-  } else
-  if (typeof clip === 'function') {
+  } else if (typeof clip === 'function') {
     done = clip;
     clip = undefined;
     if (typeof compression === 'object'){
@@ -608,8 +607,6 @@ exports.screenshot = function (path,compression, clip, done) {
       path = (typeof path === 'string') ? path : undefined
     }
   }
-  // lets have jpeg buffers too!
-  var isJPEGBuffer = ((typeof path === 'undefined') &&  (typeof compression === 'number')) ? true : false
   this.child.call('screenshot', path, compression, clip, function (error, img) {
     var buf = new Buffer(img.data);
     debug('.screenshot() captured with length %s', buf.length);

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -9,7 +9,7 @@ var isArray = Array.isArray;
 var once = require('once');
 var fs = require('fs');
 var keys = Object.keys;
-
+var jpegCompression = 90;
 /**
  * Get the version info for Nightmare, Electron and Chromium.
  * @param {Function} done
@@ -582,9 +582,9 @@ exports.scrollTo = function (y, x, done) {
  * @param {Object} clip
  * @param {Function} done
  */
-
-exports.screenshot = function (path, clip, done) {
-  debug('.screenshot()');
+exports.screenshot = exports.toPng
+= function (path, clip, done) {
+  debug('.toPng()');
   if (typeof path === 'function') {
     done = path;
     clip = undefined;
@@ -596,7 +596,46 @@ exports.screenshot = function (path, clip, done) {
   }
   this.child.call('screenshot', path, clip, function (error, img) {
     var buf = new Buffer(img.data);
-    debug('.screenshot() captured with length %s', buf.length);
+    debug('.toPng() captured with length %s', buf.length);
+    path ? fs.writeFile(path, buf, done) : done(null, buf);
+  });
+};
+
+/**
+ * Take a Jpeg screenshot.
+ *
+ * @param {String} path
+ * @param {Number} compression
+ * @param {Object} clip
+ * @param {Function} done
+ */
+
+exports.toJpeg = function (path,compression, clip, done) {
+  debug('.toJpeg()');
+  if (typeof path === 'function') {
+    done = path;
+    clip = undefined;
+    compression = jpegCompression;
+    path = undefined;
+  } else
+  if (typeof compression === 'function') {
+    done = compression;
+    clip = (typeof path) === 'object' ? path : undefined;
+    compression = (typeof path) === 'number' ? path : jpegCompression;
+    path = (typeof path === 'string') ? path : undefined;
+  } else
+  if (typeof clip === 'function') {
+    done = clip;
+    clip = undefined;
+    if (typeof compression === 'object'){
+      clip = compression;
+      compression = (typeof path === 'string') ? jpegCompression : path
+      path = (typeof path === 'string') ? path : undefined
+    }
+  }
+  this.child.call('toJpeg', path, compression, clip, function (error, img) {
+    var buf = new Buffer(img.data);
+    debug('.toJpeg() captured with length %s', buf.length);
     path ? fs.writeFile(path, buf, done) : done(null, buf);
   });
 };

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -592,7 +592,7 @@ exports.screenshot = exports.toPNG
     path = undefined;
   } else if (typeof clip === 'function') {
     done = clip;
-    clip = (typeof path === 'string') ? undefined : path;
+    clip = (typeof path === 'object') ? path : undefined;
     path = (typeof path === 'string') ? path : undefined;
   }
   this.child.call('toPNG', path, clip, function (error, img) {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -590,13 +590,13 @@ exports.screenshot = function (path,compression, clip, done) {
   if (typeof path === 'function') {
     done = path;
     clip = undefined;
-    compression = jpegCompression;
+    compression = undefined;
     path = undefined;
   } else
   if (typeof compression === 'function') {
     done = compression;
     clip = (typeof path) === 'object' ? path : undefined;
-    compression = (typeof path === 'number') ? path : jpegCompression;
+    compression = (typeof path === 'number') ? path : undefined;
     path = (typeof path === 'string') ? path : undefined;
   } else
   if (typeof clip === 'function') {
@@ -604,12 +604,12 @@ exports.screenshot = function (path,compression, clip, done) {
     clip = undefined;
     if (typeof compression === 'object'){
       clip = compression;
-      compression = (typeof path === 'string') ? jpegCompression : path
+      compression = (typeof path === 'string') ? undefined : path
       path = (typeof path === 'string') ? path : undefined
     }
   }
-  /* lets have jpeg buffers too! */
-  // var isJPEGBuffer = (typeof path === 'undefined') &&  (typeof compression === 'number') ? true : false
+  // lets have jpeg buffers too!
+  var isJPEGBuffer = ((typeof path === 'undefined') &&  (typeof compression === 'number')) ? true : false
   this.child.call('screenshot', path, compression, clip, function (error, img) {
     var buf = new Buffer(img.data);
     debug('.screenshot() captured with length %s', buf.length);

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -583,8 +583,7 @@ exports.scrollTo = function (y, x, done) {
  * @param {Object} clip
  * @param {Function} done
  */
-exports.screenshot = exports.toPNG
-= function (path, clip, done) {
+exports.screenshot = exports.toPNG = function (path, clip, done) {
   debug('.toPNG()');
   if (typeof path === 'function') {
     done = path;

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -575,43 +575,18 @@ exports.scrollTo = function (y, x, done) {
   }, done, y, x);
 };
 
-/**
- * Take a screenshot.
- * screenshot() is an alias of toPNG()
- *
- * @param {String} path
- * @param {Object} clip
- * @param {Function} done
- */
-exports.screenshot = exports.toPNG = function (path, clip, done) {
-  debug('.toPNG()');
-  if (typeof path === 'function') {
-    done = path;
-    clip = undefined;
-    path = undefined;
-  } else if (typeof clip === 'function') {
-    done = clip;
-    clip = (typeof path === 'object') ? path : undefined;
-    path = (typeof path === 'string') ? path : undefined;
-  }
-  this.child.call('toPNG', path, clip, function (error, img) {
-    var buf = new Buffer(img.data);
-    debug('.toPNG() captured with length %s', buf.length);
-    path ? fs.writeFile(path, buf, done) : done(null, buf);
-  });
-};
+
 
 /**
- * Take a Jpeg screenshot.
+ * Take a screenshot.
  *
  * @param {String} path
  * @param {Number} compression
  * @param {Object} clip
  * @param {Function} done
  */
-
-exports.toJPEG = function (path,compression, clip, done) {
-  debug('.toJPEG()');
+exports.screenshot = function (path,compression, clip, done) {
+  debug('.screenshot()');
   if (typeof path === 'function') {
     done = path;
     clip = undefined;
@@ -621,7 +596,7 @@ exports.toJPEG = function (path,compression, clip, done) {
   if (typeof compression === 'function') {
     done = compression;
     clip = (typeof path) === 'object' ? path : undefined;
-    compression = (typeof path) === 'number' ? path : jpegCompression;
+    compression = (typeof path === 'number') ? path : jpegCompression;
     path = (typeof path === 'string') ? path : undefined;
   } else
   if (typeof clip === 'function') {
@@ -633,9 +608,11 @@ exports.toJPEG = function (path,compression, clip, done) {
       path = (typeof path === 'string') ? path : undefined
     }
   }
-  this.child.call('toJPEG', path, compression, clip, function (error, img) {
+  /* lets have jpeg buffers too! */
+  // var isJPEGBuffer = (typeof path === 'undefined') &&  (typeof compression === 'number') ? true : false
+  this.child.call('screenshot', path, compression, clip, function (error, img) {
     var buf = new Buffer(img.data);
-    debug('.toJPEG() captured with length %s', buf.length);
+    debug('.screenshot() captured with length %s', buf.length);
     path ? fs.writeFile(path, buf, done) : done(null, buf);
   });
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -411,13 +411,29 @@ app.on('ready', function() {
   })
 
   /**
-   * screenshot
+   * screenshot png
    */
 
-  parent.respondTo('screenshot', function(path, clip, done) {
-    // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
+var toPng = function(path, clip, done) {
+  // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
+  var args = [function handleCapture (img) {
+    done(null, img.toPng());
+  }];
+  if (clip) args.unshift(clip);
+  frameManager.requestFrame(function() {
+    win.capturePage.apply(win, args);
+  });
+};
+  parent.respondTo('screenshot', toPng);
+  parent.respondTo('toPng', toPng);
+
+  /**
+   * screenshot jpeg
+   */
+
+  parent.respondTo('toJpeg', function(path, compression, clip, done) {
     var args = [function handleCapture (img) {
-      done(null, img.toPng());
+      done(null, img.toJpeg(compression));
     }];
     if (clip) args.unshift(clip);
     frameManager.requestFrame(function() {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -415,16 +415,14 @@ app.on('ready', function() {
    */
 
   parent.respondTo('screenshot', function(path, compression, clip, done) {
-    parent.emit('log', path, compression, ext);
     var args;
     var ext = 'png';
-    if ((typeof path === 'undefined') && (typeof compression === 'number')){
+    if ((path === null) && (typeof compression === 'number')){
       ext = 'jpeg';
     } else if (typeof path === 'string'){
       ext = path.split('.').pop();
     }
-    compression = compression ? compression : 90
-    parent.emit('log', path, compression, ext);
+    compression = compression ? compression : 90;
     switch (ext) {
       case "jpg":
       case "jpeg":

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -415,15 +415,16 @@ app.on('ready', function() {
    */
 
   parent.respondTo('screenshot', function(path, compression, clip, done) {
-    var ext = "png";
-    if (typeof path === 'string') {
-      ext = path.split('.').pop();
-    } else if (typeof path === 'undefined') {
-      ext = "png";
-    }
-    compression = 90;
     parent.emit('log', path, compression, ext);
-    var args = [];
+    var args;
+    var ext = 'png';
+    if ((typeof path === 'undefined') && (typeof compression === 'number')){
+      ext = 'jpeg';
+    } else if (typeof path === 'string'){
+      ext = path.split('.').pop();
+    }
+    compression = compression ? compression : 90
+    parent.emit('log', path, compression, ext);
     switch (ext) {
       case "jpg":
       case "jpeg":

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -411,27 +411,32 @@ app.on('ready', function() {
   })
 
   /**
-   * screenshot png
-   */
-parent.respondTo('toPNG', function(path, clip, done) {
-  // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
-  var args = [function handleCapture (img) {
-    done(null, img.toPng());
-  }];
-  if (clip) args.unshift(clip);
-  frameManager.requestFrame(function() {
-    win.capturePage.apply(win, args);
-  });
-});
-
-  /**
-   * screenshot jpeg
+   * screenshot
    */
 
-  parent.respondTo('toJPEG', function(path, compression, clip, done) {
-    var args = [function handleCapture (img) {
-      done(null, img.toJpeg(compression));
-    }];
+  parent.respondTo('screenshot', function(path, compression, clip, done) {
+    var ext = "png";
+    if (typeof path === 'string') {
+      ext = path.split('.').pop();
+    } else if (typeof path === 'undefined') {
+      ext = "png";
+    }
+    compression = 90;
+    parent.emit('log', path, compression, ext);
+    var args = [];
+    switch (ext) {
+      case "jpg":
+      case "jpeg":
+      args = [function handleCapture (img) {
+        done(null, img.toJpeg(compression));
+      }];
+      break;
+      case "png":
+      default:
+      args = [function handleCapture (img) {
+        done(null, img.toPNG());
+      }];
+    }
     if (clip) args.unshift(clip);
     frameManager.requestFrame(function() {
       win.capturePage.apply(win, args);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -413,8 +413,7 @@ app.on('ready', function() {
   /**
    * screenshot png
    */
-
-var toPng = function(path, clip, done) {
+parent.respondTo('toPNG', function(path, clip, done) {
   // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
   var args = [function handleCapture (img) {
     done(null, img.toPng());
@@ -423,15 +422,13 @@ var toPng = function(path, clip, done) {
   frameManager.requestFrame(function() {
     win.capturePage.apply(win, args);
   });
-};
-  parent.respondTo('screenshot', toPng);
-  parent.respondTo('toPng', toPng);
+});
 
   /**
    * screenshot jpeg
    */
 
-  parent.respondTo('toJpeg', function(path, compression, clip, done) {
+  parent.respondTo('toJPEG', function(path, compression, clip, done) {
     var args = [function handleCapture (img) {
       done(null, img.toJpeg(compression));
     }];

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "multer": "1.1.0",
     "pngjs": "^2.2.0",
     "serve-static": "^1.10.0",
-    "split": "^1.0.0"
+    "split": "^1.0.0",
+    "file-type": "^4.0.0",
+    "read-chunk": "^2.0.0"
   },
   "engines": {
     "node":">=4.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -1393,7 +1393,7 @@ describe('Nightmare', function () {
       var stats = fs.statSync(tmp_dir+'/test.jpg');
       Buffer.isBuffer(image).should.be.true;
       var mime = fileType(image).mime;
-      mime.should.equal("image/jpeg");
+      mime.should.equal('image/jpeg');
       image.length.should.be.at.least(1000);
     });
     it('should take a clipped jpeg screenshot', function*() {
@@ -1436,9 +1436,9 @@ describe('Nightmare', function () {
         });
       Buffer.isBuffer(image).should.be.true;
       var statsClipped = fs.statSync(tmp_dir+'/test-clipped.jpg');
-      image.length.should.be.eql(statsClipped.size);
+      image.length.should.be.equal(statsClipped.size);
       var mime = fileType(image).mime;
-      mime.should.equal("image/jpeg");
+      mime.should.equal('image/jpeg');
       image.length.should.be.at.least(300);
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1372,6 +1372,66 @@ describe('Nightmare', function () {
       yield nightmare.end();
     });
 
+    /* screenshot jpeg */
+    it('should take a jpeg screenshot', function*() {
+      yield nightmare
+        .goto('https://github.com/')
+        .toJpeg(tmp_dir+'/test.jpg');
+      var stats = fs.statSync(tmp_dir+'/test.jpg');
+      stats.size.should.be.at.least(1000);
+    });
+
+    it('should buffer a jpeg screenshot', function*() {
+      var image = yield nightmare
+        .goto('https://github.com')
+        .toJpeg();
+      Buffer.isBuffer(image).should.be.true;
+      image.length.should.be.at.least(1000);
+    });
+    it('should take a clipped jpeg screenshot', function*() {
+      yield nightmare
+        .goto('https://github.com/')
+        .toJpeg(tmp_dir+'/test-clipped.jpg',5, {
+          x: 200,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      var stats = fs.statSync(tmp_dir+'/test.jpg');
+      var statsClipped = fs.statSync(tmp_dir+'/test-clipped.jpg');
+      statsClipped.size.should.be.at.least(300);
+      stats.size.should.be.at.least(10*statsClipped.size);
+    });
+    it('should take a clipped jpeg screenshot with default compression', function*() {
+      yield nightmare
+        .goto('https://github.com/')
+        .toJpeg(tmp_dir+'/test-clipped.jpg', {
+          x: 200,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      var stats = fs.statSync(tmp_dir+'/test.jpg');
+      var statsClipped = fs.statSync(tmp_dir+'/test-clipped.jpg');
+      statsClipped.size.should.be.at.least(300);
+      stats.size.should.be.at.least(10*statsClipped.size);
+    });
+
+    it('should buffer a clipped jpeg screenshot', function*() {
+      var image = yield nightmare
+        .goto('https://github.com')
+        .toJpeg({
+          x: 200,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      Buffer.isBuffer(image).should.be.true;
+      image.length.should.be.at.least(300);
+    });
+
+/* screenshot png */
+
     it('should take a screenshot', function*() {
       yield nightmare
         .goto('https://github.com/')

--- a/test/index.js
+++ b/test/index.js
@@ -1376,7 +1376,7 @@ describe('Nightmare', function () {
     it('should take a jpeg screenshot', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .toJpeg(tmp_dir+'/test.jpg');
+        .toJPEG(tmp_dir+'/test.jpg');
       var stats = fs.statSync(tmp_dir+'/test.jpg');
       stats.size.should.be.at.least(1000);
     });
@@ -1384,14 +1384,14 @@ describe('Nightmare', function () {
     it('should buffer a jpeg screenshot', function*() {
       var image = yield nightmare
         .goto('https://github.com')
-        .toJpeg();
+        .toJPEG();
       Buffer.isBuffer(image).should.be.true;
       image.length.should.be.at.least(1000);
     });
     it('should take a clipped jpeg screenshot', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .toJpeg(tmp_dir+'/test-clipped.jpg',5, {
+        .toJPEG(tmp_dir+'/test-clipped.jpg',5, {
           x: 200,
           y: 100,
           width: 100,
@@ -1405,7 +1405,7 @@ describe('Nightmare', function () {
     it('should take a clipped jpeg screenshot with default compression', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .toJpeg(tmp_dir+'/test-clipped.jpg', {
+        .toJPEG(tmp_dir+'/test-clipped.jpg', {
           x: 200,
           y: 100,
           width: 100,
@@ -1420,7 +1420,7 @@ describe('Nightmare', function () {
     it('should buffer a clipped jpeg screenshot', function*() {
       var image = yield nightmare
         .goto('https://github.com')
-        .toJpeg({
+        .toJPEG({
           x: 200,
           y: 100,
           width: 100,

--- a/test/index.js
+++ b/test/index.js
@@ -1384,7 +1384,7 @@ describe('Nightmare', function () {
     it('should buffer a jpeg screenshot', function*() {
       var image = yield nightmare
         .goto('https://github.com')
-        .screenshot();
+        .screenshot(90);
       Buffer.isBuffer(image).should.be.true;
       image.length.should.be.at.least(1000);
     });
@@ -1420,7 +1420,7 @@ describe('Nightmare', function () {
     it('should buffer a clipped jpeg screenshot', function*() {
       var image = yield nightmare
         .goto('https://github.com')
-        .screenshot({
+        .screenshot(90,{
           x: 200,
           y: 100,
           width: 100,
@@ -1479,7 +1479,7 @@ describe('Nightmare', function () {
     it('should create a png screenshot when the extension is unknown ', function*() {
       var image = yield nightmare
         .goto('https://github.com')
-        .screenshot(tmp_dir+"/test.xyz").wait(500);
+        .screenshot(tmp_dir+"/test.xyz").wait(1000);
         var stats = fs.statSync(tmp_dir+'/test.png');
         var statsUnknown = fs.statSync(tmp_dir+'/test.xyz');
         statsUnknown.size.should.be.at.least(1000);

--- a/test/index.js
+++ b/test/index.js
@@ -1380,9 +1380,9 @@ describe('Nightmare', function () {
         .goto('https://github.com/')
         .screenshot(tmp_dir+'/test.jpg');
       var stats = fs.statSync(tmp_dir+'/test.jpg');
-      var fileHeader = readChunk.sync(tmp_dir+'/test.jpg',0,4100);
-      var mime = fileType(fileHeader).mime;
-      mime.should.be.eql('image/jpeg');
+      var fileChunk = readChunk.sync(tmp_dir+'/test.jpg',0,4100);
+      var mime = fileType(fileChunk).mime;
+      mime.should.equal('image/jpeg');
       stats.size.should.be.at.least(1000);
     });
 
@@ -1393,7 +1393,7 @@ describe('Nightmare', function () {
       var stats = fs.statSync(tmp_dir+'/test.jpg');
       Buffer.isBuffer(image).should.be.true;
       var mime = fileType(image).mime;
-      mime.should.be.equal("image/jpeg");
+      mime.should.equal("image/jpeg");
       image.length.should.be.at.least(1000);
     });
     it('should take a clipped jpeg screenshot', function*() {
@@ -1438,7 +1438,7 @@ describe('Nightmare', function () {
       var statsClipped = fs.statSync(tmp_dir+'/test-clipped.jpg');
       image.length.should.be.eql(statsClipped.size);
       var mime = fileType(image).mime;
-      mime.should.be.equal("image/jpeg");
+      mime.should.equal("image/jpeg");
       image.length.should.be.at.least(300);
     });
 
@@ -1492,22 +1492,22 @@ describe('Nightmare', function () {
       var image = yield nightmare
         .goto('https://github.com')
         .screenshot(tmp_dir+"/test.xyz");
-        var statsUnknown = fs.statSync(tmp_dir+'/test.xyz');
+      var statsUnknown = fs.statSync(tmp_dir+'/test.xyz');
       statsUnknown.size.should.be.at.least(1000);
-        fileHandler= readChunk.sync(tmp_dir+'/test.xyz',0,4100);
-        mime = fileType(fileHandler).mime;
-        mime.should.be.equal('image/png');
+      fileChunk= readChunk.sync(tmp_dir+'/test.xyz',0,4100);
+      mime = fileType(fileChunk).mime;
+      mime.should.equal('image/png');
     });
 
     it('should create a png screenshot when there is no extension', function*() {
       var image = yield nightmare
         .goto('https://github.com')
         .screenshot(tmp_dir+"/testNoExt");
-        var statsUnknown = fs.statSync(tmp_dir+'/test.xyz');
+      var statsUnknown = fs.statSync(tmp_dir+'/testNoExt');
       statsUnknown.size.should.be.at.least(1000);
-        fileHandler= readChunk.sync(tmp_dir+'/testNoExt',0,4100);
-        mime = fileType(fileHandler).mime;
-        mime.should.be.equal('image/png');
+      fileHandler= readChunk.sync(tmp_dir+'/testNoExt',0,4100);
+      mime = fileType(fileHandler).mime;
+      mime.should.equal('image/png');
     });
 
     // repeat this test 3 times, since the concern here is non-determinism in

--- a/test/index.js
+++ b/test/index.js
@@ -1376,7 +1376,7 @@ describe('Nightmare', function () {
     it('should take a jpeg screenshot', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .toJPEG(tmp_dir+'/test.jpg');
+        .screenshot(tmp_dir+'/test.jpg');
       var stats = fs.statSync(tmp_dir+'/test.jpg');
       stats.size.should.be.at.least(1000);
     });
@@ -1384,14 +1384,14 @@ describe('Nightmare', function () {
     it('should buffer a jpeg screenshot', function*() {
       var image = yield nightmare
         .goto('https://github.com')
-        .toJPEG();
+        .screenshot();
       Buffer.isBuffer(image).should.be.true;
       image.length.should.be.at.least(1000);
     });
     it('should take a clipped jpeg screenshot', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .toJPEG(tmp_dir+'/test-clipped.jpg',5, {
+        .screenshot(tmp_dir+'/test-clipped.jpg',5, {
           x: 200,
           y: 100,
           width: 100,
@@ -1405,7 +1405,7 @@ describe('Nightmare', function () {
     it('should take a clipped jpeg screenshot with default compression', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .toJPEG(tmp_dir+'/test-clipped.jpg', {
+        .screenshot(tmp_dir+'/test-clipped.jpg', {
           x: 200,
           y: 100,
           width: 100,
@@ -1420,7 +1420,7 @@ describe('Nightmare', function () {
     it('should buffer a clipped jpeg screenshot', function*() {
       var image = yield nightmare
         .goto('https://github.com')
-        .toJPEG({
+        .screenshot({
           x: 200,
           y: 100,
           width: 100,
@@ -1474,6 +1474,16 @@ describe('Nightmare', function () {
         });
       Buffer.isBuffer(image).should.be.true;
       image.length.should.be.at.least(300);
+    });
+
+    it('should create a png screenshot when the extension is unknown ', function*() {
+      var image = yield nightmare
+        .goto('https://github.com')
+        .screenshot(tmp_dir+"/test.xyz").wait(500);
+        var stats = fs.statSync(tmp_dir+'/test.png');
+        var statsUnknown = fs.statSync(tmp_dir+'/test.xyz');
+        statsUnknown.size.should.be.at.least(1000);
+        statsUnknown.size.should.be.equal(stats.size);
     });
 
     // repeat this test 3 times, since the concern here is non-determinism in


### PR DESCRIPTION
Hi, ive added support for a toJPEG() to nightmare since electron supports it too.
for consistency ive added a toPNG(), while the current `screenshot()` is an alias of it.

runner.js:
added toJPEG

Action.js
* added toJPEG
* alias screenshot with toPNG
* Theres another change on the `toPNG` where if clip is a function, i check if the path is an object instead of checking if its a string when i am assigning to a clip, so if i accidentally pass a number like a do to a `toJPEG` for the compression the value will get ignored.

Thank you