### PR TITLE
Override nightmare `Promise` library

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,7 @@ Many thanks to [@matthewmueller](https://github.com/matthewmueller) and [@rosshi
   - [Extract from the page](#extract-from-the-page)
   - [Cookies](#cookies)
   - [Proxies](#proxies)
+  - [Promises](#promises)
   - [Extending Nightmare](#extending-nightmare)
 * [Usage](#usage)
 * [Debugging](#debugging)
@@ -585,6 +586,46 @@ regularNightmare
   .then(function(ip) { // This will log the your local IP
     console.log('local IP:', ip);
   });
+```
+
+### Promises
+
+By default, Nightmare uses default native ES6 promises. You can plug in your favorite [ES6-style promises library](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) like [bluebird](https://www.npmjs.com/package/bluebird) or [q](https://www.npmjs.com/package/q) for convenience!
+
+Here's an example:
+
+```js
+var Nightmare = require('nightmare');
+
+Nightmare.Promise = require('bluebird');
+// OR:
+Nightmare.Promise = require('q').Promise;
+```
+
+You can also specify a custom Promise library per-instance with the `Promise` constructor option like so:
+
+```js
+var Nightmare = require('nightmare');
+
+var es6Nightmare = Nightmare();
+var bluebirdNightmare = Nightmare({
+    Promise: require('bluebird')
+});
+
+var es6Promise = es6Nightmare.goto('https://github.com/segmentio/nightmare').then();
+var bluebirdPromise = bluebirdNightmare.goto('https://github.com/segmentio/nightmare').then();
+
+es6Promise.isFulfilled() // throws: `TypeError: es6EndPromise.isFulfilled is not a function`
+bluebirdPromise.isFulfilled() // returns: `true | false`
+```
+
+If you're using [ES6 with Enhanced Object Literals](benmvp.com/learning-es6-enhanced-object-literals/) then specifying your custom Promise library is even easier:
+
+```js
+var Nightmare = require('nightmare');
+var Promise = require('bluebird');
+
+var nightmare = Nightmare({ Promise });
 ```
 
 ### Extending Nightmare

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -86,6 +86,8 @@ function Nightmare(options) {
   // http://electron.atom.io/docs/api/browser-window/#new-browserwindowoptions
   options.webPreferences.partition = options.webPreferences.partition !== undefined ? options.webPreferences.partition : DEFAULT_PARTITION;
 
+  options.Promise = options.Promise || Nightmare.Promise || Promise;
+
   var electron_path = options.electronPath || default_electron_path
 
   if (options.paths) {
@@ -274,6 +276,12 @@ Nightmare.childActions = {};
  * Version
  */
 Nightmare.version = require(path.resolve(__dirname, '..', 'package.json')).version;
+
+/**
+ * Promise library (can override)
+ */
+
+Nightmare.Promise = Promise;
 
 /**
  * Override headers for all HTTP requests
@@ -479,7 +487,7 @@ Nightmare.prototype.queue = function(done) {
 Nightmare.prototype.then = function(fulfill, reject) {
   var self = this;
 
-  return new Promise(function (success, failure) {
+  return new this.options.Promise(function (success, failure) {
     self._rejectActivePromise = failure;
     self.run(function(err, result) {
       if (err) failure(err);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "basic-auth": "^1.0.3",
     "basic-auth-connect": "^1.0.0",
+    "bluebird": "^3.4.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.3.0",
     "express": "^4.13.3",

--- a/test/index.js
+++ b/test/index.js
@@ -1892,7 +1892,61 @@ describe('Nightmare', function () {
       nightmare = Nightmare({ electronPath: require('electron') });
       nightmare.should.be.ok;
     });
+
+    it('should allow to use external Promise', function*() {
+      nightmare = Nightmare({ Promise: require('bluebird') });
+      nightmare.should.be.ok;
+      var thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.be.an.instanceof(require('bluebird'));
+      yield thenPromise;
+      var catchPromise = nightmare.goto('about:blank').catch();
+      catchPromise.should.be.an.instanceof(require('bluebird'));
+      yield catchPromise;
+      var endPromise = nightmare.goto('about:blank').end().then();
+      endPromise.constructor.should.equal(require('bluebird'));
+      endPromise.should.be.an.instanceof(require('bluebird'));
+      yield endPromise;
+    });
   });
+
+  describe('Nightmare.Promise', function() {
+    var nightmare;
+    afterEach(function*() {
+      // `withDeprecationTracking()` messes w/ prototype constructor references
+      Nightmare.Promise = require('..').Promise = Promise;
+      yield nightmare.end();
+    });
+
+    it('should default to native Promise', function*() {
+      Nightmare.Promise.should.equal(Promise);
+      nightmare = Nightmare();
+      nightmare.should.be.ok;
+      var thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.be.an.instanceof(Promise);
+      yield thenPromise;
+    });
+
+    it('should override default Promise library', function*() {
+      // `withDeprecationTracking()` messes w/ prototype constructor references
+      Nightmare.Promise = require('..').Promise = require('bluebird');
+      Nightmare.Promise.should.equal(require('bluebird'));
+      nightmare = Nightmare();
+      nightmare.should.be.ok;
+      var thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.be.an.instanceof(require('bluebird'));
+      yield thenPromise;
+    });
+
+    it('should not override per-instance Promise library', function*() {
+      Nightmare.Promise.should.equal(Promise);
+      nightmare = Nightmare({ Promise: require('bluebird') });
+      nightmare.should.be.ok;
+      var thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.not.be.an.instanceof(Promise);
+      thenPromise.should.be.an.instanceof(require('bluebird'));
+      yield thenPromise;
+    });
+  })
 
   describe('Nightmare.action(name, fn)', function() {
     afterEach(function*() {

--- a/test/index.js
+++ b/test/index.js
@@ -1896,13 +1896,13 @@ describe('Nightmare', function () {
     it('should allow to use external Promise', function*() {
       nightmare = Nightmare({ Promise: require('bluebird') });
       nightmare.should.be.ok;
-      var thenPromise = nightmare.goto('about:blank').then();
+      const thenPromise = nightmare.goto('about:blank').then();
       thenPromise.should.be.an.instanceof(require('bluebird'));
       yield thenPromise;
-      var catchPromise = nightmare.goto('about:blank').catch();
+      const catchPromise = nightmare.goto('about:blank').catch();
       catchPromise.should.be.an.instanceof(require('bluebird'));
       yield catchPromise;
-      var endPromise = nightmare.goto('about:blank').end().then();
+      const endPromise = nightmare.goto('about:blank').end().then();
       endPromise.constructor.should.equal(require('bluebird'));
       endPromise.should.be.an.instanceof(require('bluebird'));
       yield endPromise;


### PR DESCRIPTION
Native ES6 Promises are nice, but libraries like [Bluebird](npmjs.com/package/bluebird) offer a lot of nice additional features. I'd like to be able to specify which Promise library/factory nightmare uses internally to wrap return values from `.then()` and `.catch()` *(inspired by [mongoose.Promise](http://mongoosejs.com/docs/promises.html#plugging-in-your-own-promises-library))*

## Use Case
```js
import Nightmare from 'nightmare';
import Promise from 'bluebird';

class MyCrawler {

  nightmare = null;

  // PRIVATE
  _authPromise = null;

  constructor() {
    this.nightmare = Nightmare();
  }

  async authenticate() {
    if (this._authPromise && !this._authPromise.isFulfilled()) {
      return await this._authPromise();
    } else {
      return await (this._authPromise = Promise.resolve(this.nightmare.goto('...').then()));
    }
  }

}
```

The problem here is the `Promise#isFulfilled()` method that is a Bluebird-only method, forcing me to wrap `Nightmare#then()` in an awkward `Promise.resolve(...)`.

## Solution
With the ability to specify the internal `Promise` library/factory, I could have nightmare return a Bluebird Promise:
```js
import Nightmare from 'nightmare';
import Promise from 'bluebird';

Nightmare.Promise = Promise; // Option #1

class MyCrawler {

  nightmare = null;

  // PRIVATE
  _authPromise = null;

  constructor() {
    this.nightmare = Nightmare({ Promise: Promise }); // Option #2
    this.nightmare = Nightmare({ Promise }); // Option #3 (b/c ES6 is AWESOME!)
  }

  async authenticate() {
    if (this._authPromise && !this._authPromise.isFulfilled()) {
      return await this._authPromise();
    } else {
      return await (this._authPromise = this.nightmare.goto('...').then());
    }
  }

}
```

Please review my code & consider it for inclusion in the next release. `nightmare` is one of my favorite & most-used NPM packages, and I think this feature would be a really, really useful addition!