### PR TITLE
added electron-context-menu for right-click menu (with inspect element)

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -13,6 +13,8 @@ var app = require('electron').app;
 var fs = require('fs');
 var urlFormat = require('url');
 var FrameManager = require('./frame-manager');
+require('electron-context-menu')();
+
 
 // URL protocols that don't need to be checked for validity
 const KNOWN_PROTOCOLS = ['http', 'https', 'file', 'about', 'javascript'];

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
     "electron": "^1.4.4",
+    "electron-context-menu": "^0.8.0",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",
@@ -45,6 +46,6 @@
     "split": "^1.0.0"
   },
   "engines": {
-    "node":">=4.0.0"
+    "node": ">=4.0.0"
   }
 }


### PR DESCRIPTION
Hi there,

Thank you for having such a great tool! I added a right-click menu (see video: https://kitchen.codebuffet.co/index.php/s/vyPPrgO8uH0icGA) that will allow you to select and inspect elements on the spot. I found this especially helpful when trying to test and slightly adjust your automated interaction with different pages. Hope all is well, have a nice day!