### PR TITLE
Improve confirm dialog behavior

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -65,5 +65,6 @@ window.addEventListener('error', function(e) {
   // overwrite the default confirm
   window.confirm = function(message, defaultResponse){
     __nightmare.ipc.send('page', 'confirm', message, defaultResponse);
+    return typeof defaultResponse === 'undefined' ? true : defaultResponse;
   }
 })()


### PR DESCRIPTION
Enable confirm dialog to return default response or true if default response is undefined.
In browser, confirm dialog default selection is 'ok' so makes sense that true should be returned by default.