### PR TITLE
Expose electron's process memory API

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -788,6 +788,14 @@ Nightmare heavily relies on [Electron](http://electron.atom.io/) for heavy lifti
 
 For help running nightmare on your server distro check out [How to run nightmare on Amazon Linux and CentOS](https://gist.github.com/dimkir/f4afde77366ff041b66d2252b45a13db) guide.
 
+#### Memory Profiling
+Nightmare exposes Electron's [process memory API](https://github.com/electron/electron/blob/master/docs/api/process.md#processgetprocessmemoryinfo).
+
+```js
+var memoryStats = yield nightmare.getElectronMemoryInfo();
+console.log(memoryStats.sharedBytes);
+```
+
 #### Debugging
 There are three good ways to get more information about what's happening inside the headless browser:
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -382,6 +382,22 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
 };
 
 /**
+ * Returns electron process memory information
+ */
+
+Nightmare.prototype.getElectronMemoryInfo = function(callback) {
+  this.queue(function(done){
+    this.child.call('get-process-memory-info', (err, result) => {
+      if (typeof callback === 'function') {
+        callback(err, result);
+      }
+      done(err, result);
+    });
+  });
+  return this;
+}
+
+/**
  * inject javascript
  */
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -313,6 +313,14 @@ app.on('ready', function() {
   });
 
   /**
+   * process memory stats
+   */
+
+  parent.respondTo('get-process-memory-info', function(done) {
+    done(null, process.getProcessMemoryInfo());
+  });
+
+  /**
    * javascript
    */
 

--- a/test/index.js
+++ b/test/index.js
@@ -2075,6 +2075,24 @@ describe('Nightmare', function () {
     });
   })
 
+  describe('Nightmare.getElectronMemoryInfo', function() {
+    beforeEach(function() {
+      nightmare = Nightmare();
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should return memory info', function*() {
+      var stats = yield nightmare
+        .getElectronMemoryInfo();
+
+      stats.should.have.property('privateBytes');
+      stats.should.have.property('sharedBytes');
+    })
+  })
+
   describe('Nightmare.use', function() {
     beforeEach(function() {
       nightmare = Nightmare();

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
 --slow 3s
---timeout 10s
+--timeout 12s


### PR DESCRIPTION
Would be nice to profile memory during headless test execution.

Essentially proxies to:
https://github.com/electron/electron/blob/master/docs/api/process.md#pro
cessgetprocessmemoryinfo