### PR TITLE
Allow hidden DevTools

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -192,7 +192,7 @@ var nightmare = Nightmare({
 ```
 
 ##### openDevTools
-Optionally show the DevTools in the Electron window using `true`, or use an object hash containing `mode: 'detach'` to show in a separate window. The hash gets passed to [`contents.openDevTools()`](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#contentsopendevtoolsoptions) to be handled.  This is also useful for testing purposes.  Note that this option is honored only if `show` is set to `true`.
+Optionally show the DevTools in the Electron window using `true`, or use an object hash containing `mode: 'detach'` to show in a separate window. The hash gets passed to [`contents.openDevTools()`](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#contentsopendevtoolsoptions) to be handled.  This is also useful for testing purposes.
 
 ```js
 var nightmare = Nightmare({

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -85,7 +85,7 @@ app.on('ready', function() {
      */
 
     win = new BrowserWindow(options);
-    if(options.show && options.openDevTools){
+    if(options.openDevTools){
       if(typeof options.openDevTools === 'object') {
         win.openDevTools(options.openDevTools);
       } else {

--- a/test/index.js
+++ b/test/index.js
@@ -2144,7 +2144,7 @@ describe('Nightmare', function () {
           this.child.once('waitForDevTools', done);
           this.child.emit('waitForDevTools');
         });
-      nightmare = Nightmare({show:true, openDevTools:true});
+      nightmare = Nightmare({openDevTools:true});
 
     });
 


### PR DESCRIPTION
Is there a specific important reason for only allowing `openDevTools` when `show:true`?

This PR removes that restriction.

e.g. once this is merged [alexbardas/nightmare-har-plugin](https://github.com/alexbardas/nightmare-har-plugin) can be used with show:false to extract HAR for a page and all sort of other devtools functionality becomes available headless-ly.