### PR TITLE
Xpath support

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -67,11 +67,25 @@ exports.path = function(done) {
 
 exports.visible = function(selector, done) {
   debug('.visible() for ' + selector);
-  this.evaluate_now(function(selector) {
-    var elem = document.querySelector(selector);
-    if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
-    else return false;
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      try {
+        var elem = document.evaluate(selector, document, null,
+          XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+        if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
+        else return false;
+      } catch (err) {
+        return false;
+      }
+
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var elem = document.querySelector(selector);
+      if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
+      else return false;
+    }, done, selector);
+  }
 };
 
 /**
@@ -83,9 +97,16 @@ exports.visible = function(selector, done) {
 
 exports.exists = function(selector, done) {
   debug('.exists() for ' + selector);
-  this.evaluate_now(function(selector) {
-    return (document.querySelector(selector)!==null);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      return (document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue !== null);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      return (document.querySelector(selector) !== null);
+    }, done, selector);
+  }
 };
 
 /**
@@ -97,16 +118,30 @@ exports.exists = function(selector, done) {
 
 exports.click = function(selector, done) {
   debug('.click() on ' + selector);
-  this.evaluate_now(function (selector) {
-    document.activeElement.blur();
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('click', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      document.activeElement.blur();
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('click', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      document.activeElement.blur();
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('click', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -118,15 +153,28 @@ exports.click = function(selector, done) {
 
 exports.mousedown = function(selector, done) {
   debug('.mousedown() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('mousedown', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mousedown', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mousedown', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -138,15 +186,28 @@ exports.mousedown = function(selector, done) {
 
 exports.mouseup = function(selector, done) {
   debug('.mouseup() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('mouseup', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mouseup', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mouseup', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -158,15 +219,28 @@ exports.mouseup = function(selector, done) {
 
 exports.mouseover = function(selector, done) {
   debug('.mouseover() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initMouseEvent('mouseover', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initMouseEvent('mouseover', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initMouseEvent('mouseover', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -175,12 +249,33 @@ exports.mouseover = function(selector, done) {
  */
 
 var focusSelector = function(done, selector) {
+  if(this.options.useXpath) {
+    return this.evaluate_now(function(selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if(element) {
+        element.focus();
+      }
+    }, done.bind(this), selector);
+  }
   return this.evaluate_now(function(selector) {
     document.querySelector(selector).focus();
   }, done.bind(this), selector);
 };
 
 var blurSelector = function(done, selector) {
+  if(this.options.useXpath) {
+    return this.evaluate_now(function(selector) {
+      //it is possible the element has been removed from the DOM
+      //between the action and the call to blur the element
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if(element) {
+        element.blur()
+      }
+    }, done.bind(this), selector);
+  }
+
   return this.evaluate_now(function(selector) {
     //it is possible the element has been removed from the DOM
     //between the action and the call to blur the element
@@ -219,9 +314,16 @@ exports.type = function() {
 
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
-      this.evaluate_now(function(selector) {
-        document.querySelector(selector).value = '';
-      }, blurDone, selector);
+      if(self.options.useXpath) {
+        this.evaluate_now(function(selector) {
+          document.evaluate(selector, document,
+            null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.value = '';
+        }, blurDone, selector);
+      } else {
+        this.evaluate_now(function(selector) {
+          document.querySelector(selector).value = '';
+        }, blurDone, selector);
+      }
     } else {
       self.child.call('type', text, blurDone);
     }
@@ -238,8 +340,8 @@ exports.type = function() {
 
 exports.insert = function(selector, text, done) {
   if (arguments.length === 2) {
-    done = text
-    text = null
+    done = text;
+    text = null;
   }
 
   debug('.insert() %s into %s', text, selector);
@@ -250,17 +352,24 @@ exports.insert = function(selector, text, done) {
       debug('Unable to .insert() into non-existent selector %s', selector);
       return done(err);
     }
-    
+
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
-      this.evaluate_now(function(selector) {
-        document.querySelector(selector).value = '';
-      }, blurDone, selector);
+      if(this.options.useXpath) {
+        this.evaluate_now(function(selector) {
+          document.evaluate(selector, document,
+            null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.value = '';
+        }, blurDone, selector);
+      } else {
+        this.evaluate_now(function(selector) {
+          document.querySelector(selector).value = '';
+        }, blurDone, selector);
+      }
     } else {
       child.call('insert', text, blurDone);
     }
   }, selector);
-}
+};
 
 /**
  * Check a checkbox, fire change event
@@ -271,13 +380,24 @@ exports.insert = function(selector, text, done) {
 
 exports.check = function(selector, done) {
   debug('.check() ' + selector);
-  this.evaluate_now(function(selector) {
-    var element = document.querySelector(selector);
-    var event = document.createEvent('HTMLEvents');
-    element.checked = true;
-    event.initEvent('change', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function(selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var event = document.createEvent('HTMLEvents');
+      element.checked = true;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function(selector) {
+      var element = document.querySelector(selector);
+      var event = document.createEvent('HTMLEvents');
+      element.checked = true;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /*
@@ -289,13 +409,24 @@ exports.check = function(selector, done) {
 
 exports.uncheck = function(selector, done){
   debug('.uncheck() ' + selector);
-  this.evaluate_now(function(selector) {
+  if(this.options.useXpath) {
+    this.evaluate_now(function(selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var event = document.createEvent('HTMLEvents');
+      element.checked = null;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function(selector) {
       var element = document.querySelector(selector);
       var event = document.createEvent('HTMLEvents');
       element.checked = null;
       event.initEvent('change', true, true);
       element.dispatchEvent(event);
     }, done, selector);
+  }
 };
 
 /**
@@ -310,13 +441,26 @@ exports.uncheck = function(selector, done){
 
 exports.select = function(selector, option, done) {
   debug('.select() ' + selector);
-  this.evaluate_now(function(selector, option) {
-    var element = document.querySelector(selector);
-    var event = document.createEvent('HTMLEvents');
-    element.value = option;
-    event.initEvent('change', true, true);
-    element.dispatchEvent(event);
-  }, done, selector, option);
+  if(this.options.useXpath) {
+    this.evaluate_now(function(selector, option) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var optionElement = document.evaluate(option, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var event = document.createEvent('HTMLEvents');
+      element.value = optionElement.value;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector, option);
+  } else {
+    this.evaluate_now(function(selector, option) {
+      var element = document.querySelector(selector);
+      var event = document.createEvent('HTMLEvents');
+      element.value = option;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector, option);
+  }
 };
 
 /**
@@ -422,10 +566,18 @@ function waitms (ms, done) {
 
 function waitelem (self, selector, done) {
   var elementPresent;
-  eval("elementPresent = function() {"+
+  if(self.options.useXpath) {
+    eval("elementPresent = function() {"+
+      "  var element = document.evaluate('"+jsesc(selector)+"', document," +
+      "    null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;"+
+      "  return (element ? true : false);" +
+      "};");
+  } else {
+    eval("elementPresent = function() {"+
       "  var element = document.querySelector('"+jsesc(selector)+"');"+
       "  return (element ? true : false);" +
       "};");
+  }
   waitfn.apply(this, [self, elementPresent, done]);
 }
 
@@ -443,10 +595,10 @@ function waitfn() {
   var executionTimer;
   var softTimeoutTimer;
   var self = arguments[0];
-  
+
   var args = sliced(arguments);
   var done = args[args.length-1];
-  
+
   var timeoutTimer = setTimeout(function(){
     clearTimeout(executionTimer);
     clearTimeout(softTimeoutTimer);
@@ -749,7 +901,7 @@ exports.cookies.clearAll = function(done){
  * Authentication
  */
 
- exports.authentication = function (login, password, done) {
-   debug('.authentication()');
-   this.child.call('authentication', login, password, done);
- };
+exports.authentication = function (login, password, done) {
+  debug('.authentication()');
+  this.child.call('authentication', login, password, done);
+};

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -67,11 +67,25 @@ exports.path = function(done) {
 
 exports.visible = function(selector, done) {
   debug('.visible() for ' + selector);
-  this.evaluate_now(function(selector) {
-    var elem = document.querySelector(selector);
-    if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
-    else return false;
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      try {
+        var elem = document.evaluate(selector, document, null,
+          XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+        if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
+        else return false;
+      } catch (err) {
+        return false;
+      }
+
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var elem = document.querySelector(selector);
+      if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
+      else return false;
+    }, done, selector);
+  }
 };
 
 /**
@@ -83,9 +97,16 @@ exports.visible = function(selector, done) {
 
 exports.exists = function(selector, done) {
   debug('.exists() for ' + selector);
-  this.evaluate_now(function(selector) {
-    return (document.querySelector(selector)!==null);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      return (document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue !== null);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      return (document.querySelector(selector) !== null);
+    }, done, selector);
+  }
 };
 
 /**
@@ -97,16 +118,30 @@ exports.exists = function(selector, done) {
 
 exports.click = function(selector, done) {
   debug('.click() on ' + selector);
-  this.evaluate_now(function (selector) {
-    document.activeElement.blur();
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('click', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      document.activeElement.blur();
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('click', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      document.activeElement.blur();
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('click', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -118,15 +153,28 @@ exports.click = function(selector, done) {
 
 exports.mousedown = function(selector, done) {
   debug('.mousedown() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('mousedown', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mousedown', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mousedown', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -138,15 +186,28 @@ exports.mousedown = function(selector, done) {
 
 exports.mouseup = function(selector, done) {
   debug('.mouseup() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initEvent('mouseup', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mouseup', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initEvent('mouseup', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -158,15 +219,28 @@ exports.mouseup = function(selector, done) {
 
 exports.mouseover = function(selector, done) {
   debug('.mouseover() on ' + selector);
-  this.evaluate_now(function (selector) {
-    var element = document.querySelector(selector);
-    if (!element) {
-      throw new Error('Unable to find element by selector: ' + selector);
-    }
-    var event = document.createEvent('MouseEvent');
-    event.initMouseEvent('mouseover', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function (selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initMouseEvent('mouseover', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function (selector) {
+      var element = document.querySelector(selector);
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector);
+      }
+      var event = document.createEvent('MouseEvent');
+      event.initMouseEvent('mouseover', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /**
@@ -175,12 +249,33 @@ exports.mouseover = function(selector, done) {
  */
 
 var focusSelector = function(done, selector) {
+  if(this.options.useXpath) {
+    return this.evaluate_now(function(selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if(element) {
+        element.focus();
+      }
+    }, done.bind(this), selector);
+  }
   return this.evaluate_now(function(selector) {
     document.querySelector(selector).focus();
   }, done.bind(this), selector);
 };
 
 var blurSelector = function(done, selector) {
+  if(this.options.useXpath) {
+    return this.evaluate_now(function(selector) {
+      //it is possible the element has been removed from the DOM
+      //between the action and the call to blur the element
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      if(element) {
+        element.blur()
+      }
+    }, done.bind(this), selector);
+  }
+
   return this.evaluate_now(function(selector) {
     //it is possible the element has been removed from the DOM
     //between the action and the call to blur the element
@@ -219,9 +314,16 @@ exports.type = function() {
 
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
-      this.evaluate_now(function(selector) {
-        document.querySelector(selector).value = '';
-      }, blurDone, selector);
+      if(self.options.useXpath) {
+        this.evaluate_now(function(selector) {
+          document.evaluate(selector, document,
+            null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.value = '';
+        }, blurDone, selector);
+      } else {
+        this.evaluate_now(function(selector) {
+          document.querySelector(selector).value = '';
+        }, blurDone, selector);
+      }
     } else {
       self.child.call('type', text, blurDone);
     }
@@ -238,8 +340,8 @@ exports.type = function() {
 
 exports.insert = function(selector, text, done) {
   if (arguments.length === 2) {
-    done = text
-    text = null
+    done = text;
+    text = null;
   }
 
   debug('.insert() %s into %s', text, selector);
@@ -250,17 +352,24 @@ exports.insert = function(selector, text, done) {
       debug('Unable to .insert() into non-existent selector %s', selector);
       return done(err);
     }
-    
+
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
-      this.evaluate_now(function(selector) {
-        document.querySelector(selector).value = '';
-      }, blurDone, selector);
+      if(this.options.useXpath) {
+        this.evaluate_now(function(selector) {
+          document.evaluate(selector, document,
+            null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.value = '';
+        }, blurDone, selector);
+      } else {
+        this.evaluate_now(function(selector) {
+          document.querySelector(selector).value = '';
+        }, blurDone, selector);
+      }
     } else {
       child.call('insert', text, blurDone);
     }
   }, selector);
-}
+};
 
 /**
  * Check a checkbox, fire change event
@@ -271,13 +380,24 @@ exports.insert = function(selector, text, done) {
 
 exports.check = function(selector, done) {
   debug('.check() ' + selector);
-  this.evaluate_now(function(selector) {
-    var element = document.querySelector(selector);
-    var event = document.createEvent('HTMLEvents');
-    element.checked = true;
-    event.initEvent('change', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
+  if(this.options.useXpath) {
+    this.evaluate_now(function(selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var event = document.createEvent('HTMLEvents');
+      element.checked = true;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function(selector) {
+      var element = document.querySelector(selector);
+      var event = document.createEvent('HTMLEvents');
+      element.checked = true;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  }
 };
 
 /*
@@ -289,13 +409,24 @@ exports.check = function(selector, done) {
 
 exports.uncheck = function(selector, done){
   debug('.uncheck() ' + selector);
-  this.evaluate_now(function(selector) {
+  if(this.options.useXpath) {
+    this.evaluate_now(function(selector) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var event = document.createEvent('HTMLEvents');
+      element.checked = null;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector);
+  } else {
+    this.evaluate_now(function(selector) {
       var element = document.querySelector(selector);
       var event = document.createEvent('HTMLEvents');
       element.checked = null;
       event.initEvent('change', true, true);
       element.dispatchEvent(event);
     }, done, selector);
+  }
 };
 
 /**
@@ -310,13 +441,26 @@ exports.uncheck = function(selector, done){
 
 exports.select = function(selector, option, done) {
   debug('.select() ' + selector);
-  this.evaluate_now(function(selector, option) {
-    var element = document.querySelector(selector);
-    var event = document.createEvent('HTMLEvents');
-    element.value = option;
-    event.initEvent('change', true, true);
-    element.dispatchEvent(event);
-  }, done, selector, option);
+  if(this.options.useXpath) {
+    this.evaluate_now(function(selector, option) {
+      var element = document.evaluate(selector, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var optionElement = document.evaluate(option, document,
+        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var event = document.createEvent('HTMLEvents');
+      element.value = optionElement.value;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector, option);
+  } else {
+    this.evaluate_now(function(selector, option) {
+      var element = document.querySelector(selector);
+      var event = document.createEvent('HTMLEvents');
+      element.value = option;
+      event.initEvent('change', true, true);
+      element.dispatchEvent(event);
+    }, done, selector, option);
+  }
 };
 
 /**
@@ -422,10 +566,18 @@ function waitms (ms, done) {
 
 function waitelem (self, selector, done) {
   var elementPresent;
-  eval("elementPresent = function() {"+
+  if(self.options.useXpath) {
+    eval("elementPresent = function() {"+
+      "  var element = document.evaluate('"+jsesc(selector)+"', document," +
+      "    null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;"+
+      "  return (element ? true : false);" +
+      "};");
+  } else {
+    eval("elementPresent = function() {"+
       "  var element = document.querySelector('"+jsesc(selector)+"');"+
       "  return (element ? true : false);" +
       "};");
+  }
   waitfn.apply(this, [self, elementPresent, done]);
 }
 
@@ -443,10 +595,10 @@ function waitfn() {
   var executionTimer;
   var softTimeoutTimer;
   var self = arguments[0];
-  
+
   var args = sliced(arguments);
   var done = args[args.length-1];
-  
+
   var timeoutTimer = setTimeout(function(){
     clearTimeout(executionTimer);
     clearTimeout(softTimeoutTimer);

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -67,25 +67,11 @@ exports.path = function(done) {
 
 exports.visible = function(selector, done) {
   debug('.visible() for ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function (selector) {
-      try {
-        var elem = document.evaluate(selector, document, null,
-          XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-        if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
-        else return false;
-      } catch (err) {
-        return false;
-      }
-
-    }, done, selector);
-  } else {
-    this.evaluate_now(function (selector) {
-      var elem = document.querySelector(selector);
-      if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
-      else return false;
-    }, done, selector);
-  }
+  this.evaluate_now(function(selector) {
+    var elem = document.querySelector(selector);
+    if (elem) return (elem.offsetWidth > 0 && elem.offsetHeight > 0);
+    else return false;
+  }, done, selector);
 };
 
 /**
@@ -97,16 +83,9 @@ exports.visible = function(selector, done) {
 
 exports.exists = function(selector, done) {
   debug('.exists() for ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function (selector) {
-      return (document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue !== null);
-    }, done, selector);
-  } else {
-    this.evaluate_now(function (selector) {
-      return (document.querySelector(selector) !== null);
-    }, done, selector);
-  }
+  this.evaluate_now(function(selector) {
+    return (document.querySelector(selector)!==null);
+  }, done, selector);
 };
 
 /**
@@ -118,30 +97,16 @@ exports.exists = function(selector, done) {
 
 exports.click = function(selector, done) {
   debug('.click() on ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function (selector) {
-      document.activeElement.blur();
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initEvent('click', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  } else {
-    this.evaluate_now(function (selector) {
-      document.activeElement.blur();
-      var element = document.querySelector(selector);
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initEvent('click', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  }
+  this.evaluate_now(function (selector) {
+    document.activeElement.blur();
+    var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
+    var event = document.createEvent('MouseEvent');
+    event.initEvent('click', true, true);
+    element.dispatchEvent(event);
+  }, done, selector);
 };
 
 /**
@@ -153,28 +118,15 @@ exports.click = function(selector, done) {
 
 exports.mousedown = function(selector, done) {
   debug('.mousedown() on ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function (selector) {
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initEvent('mousedown', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  } else {
-    this.evaluate_now(function (selector) {
-      var element = document.querySelector(selector);
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initEvent('mousedown', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  }
+  this.evaluate_now(function (selector) {
+    var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
+    var event = document.createEvent('MouseEvent');
+    event.initEvent('mousedown', true, true);
+    element.dispatchEvent(event);
+  }, done, selector);
 };
 
 /**
@@ -186,28 +138,15 @@ exports.mousedown = function(selector, done) {
 
 exports.mouseup = function(selector, done) {
   debug('.mouseup() on ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function (selector) {
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initEvent('mouseup', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  } else {
-    this.evaluate_now(function (selector) {
-      var element = document.querySelector(selector);
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initEvent('mouseup', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  }
+  this.evaluate_now(function (selector) {
+    var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
+    var event = document.createEvent('MouseEvent');
+    event.initEvent('mouseup', true, true);
+    element.dispatchEvent(event);
+  }, done, selector);
 };
 
 /**
@@ -219,28 +158,15 @@ exports.mouseup = function(selector, done) {
 
 exports.mouseover = function(selector, done) {
   debug('.mouseover() on ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function (selector) {
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initMouseEvent('mouseover', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  } else {
-    this.evaluate_now(function (selector) {
-      var element = document.querySelector(selector);
-      if (!element) {
-        throw new Error('Unable to find element by selector: ' + selector);
-      }
-      var event = document.createEvent('MouseEvent');
-      event.initMouseEvent('mouseover', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  }
+  this.evaluate_now(function (selector) {
+    var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
+    var event = document.createEvent('MouseEvent');
+    event.initMouseEvent('mouseover', true, true);
+    element.dispatchEvent(event);
+  }, done, selector);
 };
 
 /**
@@ -249,33 +175,12 @@ exports.mouseover = function(selector, done) {
  */
 
 var focusSelector = function(done, selector) {
-  if(this.options.useXpath) {
-    return this.evaluate_now(function(selector) {
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      if(element) {
-        element.focus();
-      }
-    }, done.bind(this), selector);
-  }
   return this.evaluate_now(function(selector) {
     document.querySelector(selector).focus();
   }, done.bind(this), selector);
 };
 
 var blurSelector = function(done, selector) {
-  if(this.options.useXpath) {
-    return this.evaluate_now(function(selector) {
-      //it is possible the element has been removed from the DOM
-      //between the action and the call to blur the element
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      if(element) {
-        element.blur()
-      }
-    }, done.bind(this), selector);
-  }
-
   return this.evaluate_now(function(selector) {
     //it is possible the element has been removed from the DOM
     //between the action and the call to blur the element
@@ -314,16 +219,9 @@ exports.type = function() {
 
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
-      if(self.options.useXpath) {
-        this.evaluate_now(function(selector) {
-          document.evaluate(selector, document,
-            null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.value = '';
-        }, blurDone, selector);
-      } else {
-        this.evaluate_now(function(selector) {
-          document.querySelector(selector).value = '';
-        }, blurDone, selector);
-      }
+      this.evaluate_now(function(selector) {
+        document.querySelector(selector).value = '';
+      }, blurDone, selector);
     } else {
       self.child.call('type', text, blurDone);
     }
@@ -340,8 +238,8 @@ exports.type = function() {
 
 exports.insert = function(selector, text, done) {
   if (arguments.length === 2) {
-    done = text;
-    text = null;
+    done = text
+    text = null
   }
 
   debug('.insert() %s into %s', text, selector);
@@ -352,24 +250,17 @@ exports.insert = function(selector, text, done) {
       debug('Unable to .insert() into non-existent selector %s', selector);
       return done(err);
     }
-
+    
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
-      if(this.options.useXpath) {
-        this.evaluate_now(function(selector) {
-          document.evaluate(selector, document,
-            null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.value = '';
-        }, blurDone, selector);
-      } else {
-        this.evaluate_now(function(selector) {
-          document.querySelector(selector).value = '';
-        }, blurDone, selector);
-      }
+      this.evaluate_now(function(selector) {
+        document.querySelector(selector).value = '';
+      }, blurDone, selector);
     } else {
       child.call('insert', text, blurDone);
     }
   }, selector);
-};
+}
 
 /**
  * Check a checkbox, fire change event
@@ -380,24 +271,13 @@ exports.insert = function(selector, text, done) {
 
 exports.check = function(selector, done) {
   debug('.check() ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function(selector) {
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      var event = document.createEvent('HTMLEvents');
-      element.checked = true;
-      event.initEvent('change', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  } else {
-    this.evaluate_now(function(selector) {
-      var element = document.querySelector(selector);
-      var event = document.createEvent('HTMLEvents');
-      element.checked = true;
-      event.initEvent('change', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  }
+  this.evaluate_now(function(selector) {
+    var element = document.querySelector(selector);
+    var event = document.createEvent('HTMLEvents');
+    element.checked = true;
+    event.initEvent('change', true, true);
+    element.dispatchEvent(event);
+  }, done, selector);
 };
 
 /*
@@ -409,24 +289,13 @@ exports.check = function(selector, done) {
 
 exports.uncheck = function(selector, done){
   debug('.uncheck() ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function(selector) {
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      var event = document.createEvent('HTMLEvents');
-      element.checked = null;
-      event.initEvent('change', true, true);
-      element.dispatchEvent(event);
-    }, done, selector);
-  } else {
-    this.evaluate_now(function(selector) {
+  this.evaluate_now(function(selector) {
       var element = document.querySelector(selector);
       var event = document.createEvent('HTMLEvents');
       element.checked = null;
       event.initEvent('change', true, true);
       element.dispatchEvent(event);
     }, done, selector);
-  }
 };
 
 /**
@@ -441,26 +310,13 @@ exports.uncheck = function(selector, done){
 
 exports.select = function(selector, option, done) {
   debug('.select() ' + selector);
-  if(this.options.useXpath) {
-    this.evaluate_now(function(selector, option) {
-      var element = document.evaluate(selector, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      var optionElement = document.evaluate(option, document,
-        null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-      var event = document.createEvent('HTMLEvents');
-      element.value = optionElement.value;
-      event.initEvent('change', true, true);
-      element.dispatchEvent(event);
-    }, done, selector, option);
-  } else {
-    this.evaluate_now(function(selector, option) {
-      var element = document.querySelector(selector);
-      var event = document.createEvent('HTMLEvents');
-      element.value = option;
-      event.initEvent('change', true, true);
-      element.dispatchEvent(event);
-    }, done, selector, option);
-  }
+  this.evaluate_now(function(selector, option) {
+    var element = document.querySelector(selector);
+    var event = document.createEvent('HTMLEvents');
+    element.value = option;
+    event.initEvent('change', true, true);
+    element.dispatchEvent(event);
+  }, done, selector, option);
 };
 
 /**
@@ -566,18 +422,10 @@ function waitms (ms, done) {
 
 function waitelem (self, selector, done) {
   var elementPresent;
-  if(self.options.useXpath) {
-    eval("elementPresent = function() {"+
-      "  var element = document.evaluate('"+jsesc(selector)+"', document," +
-      "    null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;"+
-      "  return (element ? true : false);" +
-      "};");
-  } else {
-    eval("elementPresent = function() {"+
+  eval("elementPresent = function() {"+
       "  var element = document.querySelector('"+jsesc(selector)+"');"+
       "  return (element ? true : false);" +
       "};");
-  }
   waitfn.apply(this, [self, elementPresent, done]);
 }
 
@@ -595,10 +443,10 @@ function waitfn() {
   var executionTimer;
   var softTimeoutTimer;
   var self = arguments[0];
-
+  
   var args = sliced(arguments);
   var done = args[args.length-1];
-
+  
   var timeoutTimer = setTimeout(function(){
     clearTimeout(executionTimer);
     clearTimeout(softTimeoutTimer);

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,7 @@ describe('Nightmare', function () {
     Nightmare = withDeprecationTracking(Nightmare);
   });
 
-  after(function() {
+  after(function () {
     Nightmare.assertNoDeprecations();
   });
 
@@ -56,7 +56,7 @@ describe('Nightmare', function () {
     yield nightmare.end();
   });
 
-  it('should have version information', function*(){
+  it('should have version information', function*() {
     var nightmare = Nightmare();
     var versions = yield nightmare.engineVersions();
     nightmare.engineVersions.electron.should.be.ok;
@@ -69,16 +69,16 @@ describe('Nightmare', function () {
     yield nightmare.end();
   });
 
-  it('should kill its electron process when it is killed', function(done) {
+  it('should kill its electron process when it is killed', function (done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-unended.js'));
 
-    child.once('message', function(electronPid) {
-      child.once('exit', function() {
+    child.once('message', function (electronPid) {
+      child.once('exit', function () {
         try {
           electronPid.should.not.be.a.process;
         }
-        catch(error) {
+        catch (error) {
           // if the test failed, clean up the still-running process
           process.kill(electronPid, 'SIGINT');
           throw error;
@@ -89,25 +89,25 @@ describe('Nightmare', function () {
     });
   });
 
-  it('should gracefully handle electron being killed', function(done) {
+  it('should gracefully handle electron being killed', function (done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-unended.js'));
 
-    child.once('message', function(electronPid) {
+    child.once('message', function (electronPid) {
       process.kill(electronPid, 'SIGINT');
-      child.once('exit', function(){
+      child.once('exit', function () {
         electronPid.should.not.be.a.process;
         done();
       });
     });
   });
 
-  it('should end gracefully if the chain has not been started', function(done) {
+  it('should end gracefully if the chain has not been started', function (done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-created.js'));
 
-    child.once('message', function() {
-      child.once('exit', function(code) {
+    child.once('message', function () {
+      child.once('exit', function (code) {
         code.should.equal(0);
         done();
       });
@@ -115,30 +115,30 @@ describe('Nightmare', function () {
     });
   });
 
-  it('should exit with a non-zero code on uncaughtExecption', function(done) {
+  it('should exit with a non-zero code on uncaughtExecption', function (done) {
     var child = child_process.fork(
       path.join(__dirname, 'files', 'nightmare-error.js'), [], {silent: true});
 
-      child.once('exit', function(code) {
-        code.should.not.equal(0);
-        done();
-      });
+    child.once('exit', function (code) {
+      code.should.not.equal(0);
+      done();
+    });
   });
 
-  it('should provide a .catch function', function(done) {
+  it('should provide a .catch function', function (done) {
     var nightmare = Nightmare();
 
     nightmare
       .goto('about:blank')
-      .evaluate(function() {
+      .evaluate(function () {
         throw new Error('Test');
       })
-      .catch(function(err) {
+      .catch(function (err) {
         done();
       });
   });
 
-  it('should allow ending more than once', function(done){
+  it('should allow ending more than once', function (done) {
     var nightmare = Nightmare();
     nightmare.goto(fixture('navigation'))
       .end()
@@ -146,13 +146,13 @@ describe('Nightmare', function () {
       .then(() => done());
   });
 
-  it('should allow end with a callback', function(done){
+  it('should allow end with a callback', function (done) {
     var nightmare = Nightmare();
     nightmare.goto(fixture('navigation'))
       .end(() => done());
   });
 
-  it('should allow end with a callback to be thenable', function(done){
+  it('should allow end with a callback to be thenable', function (done) {
     var nightmare = Nightmare();
     nightmare.goto(fixture('navigation'))
       .end(() => 'nightmare')
@@ -169,7 +169,8 @@ describe('Nightmare', function () {
       .wait(1000)
       .wait(500)
       .end()
-      .then(() => {})
+      .then(() => {
+      })
       .should.be.rejectedWith('Nightmare Halted');
 
     const electronPid = nightmare.proc.pid;
@@ -183,22 +184,22 @@ describe('Nightmare', function () {
 
     return Promise.all([check1, check2]);
   });
-  
-  it('should successfully end on pages setting onunload or onbeforeunload', function(done) {
+
+  it('should successfully end on pages setting onunload or onbeforeunload', function (done) {
     var nightmare = Nightmare();
     nightmare.goto(fixture('unload'))
       .end()
       .then(() => done());
   });
 
-  it('should successfully end on pages binding unload or beforeunload', function(done) {
+  it('should successfully end on pages binding unload or beforeunload', function (done) {
     var nightmare = Nightmare();
     nightmare.goto(fixture('unload/add-event-listener.html'))
       .end()
       .then(() => done());
   });
 
-  it('should provide useful errors for .click', function(done) {
+  it('should provide useful errors for .click', function (done) {
     var nightmare = Nightmare();
 
     nightmare
@@ -210,7 +211,7 @@ describe('Nightmare', function () {
       });
   });
 
-  it('should provide useful errors for .mousedown', function(done) {
+  it('should provide useful errors for .mousedown', function (done) {
     var nightmare = Nightmare();
 
     nightmare
@@ -222,7 +223,7 @@ describe('Nightmare', function () {
       });
   });
 
-  it('should provide useful errors for .mouseup', function(done) {
+  it('should provide useful errors for .mouseup', function (done) {
     var nightmare = Nightmare();
 
     nightmare
@@ -234,7 +235,7 @@ describe('Nightmare', function () {
       });
   });
 
-  it('should provide useful errors for .mouseover', function(done) {
+  it('should provide useful errors for .mouseover', function (done) {
     var nightmare = Nightmare();
 
     nightmare
@@ -249,7 +250,7 @@ describe('Nightmare', function () {
   describe('navigation', function () {
     var nightmare;
 
-    beforeEach(function() {
+    beforeEach(function () {
       nightmare = Nightmare({
         webPreferences: {partition: 'test-partition' + Math.random()},
         loadTimeout: 45 * 1000,
@@ -267,19 +268,23 @@ describe('Nightmare', function () {
       data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
     });
 
-    it('should reject with a useful message when no URL', function() {
+    it('should reject with a useful message when no URL', function () {
       return nightmare.goto(undefined).then(
-        function() {throw new Error('goto(undefined) didn’t cause an error');},
-        function(error) {
+        function () {
+          throw new Error('goto(undefined) didn’t cause an error');
+        },
+        function (error) {
           error.should.include('url');
         }
       );
     });
 
-    it('should reject with a useful message for an empty URL', function() {
+    it('should reject with a useful message for an empty URL', function () {
       return nightmare.goto('').then(
-        function() {throw new Error('goto(undefined) didn’t cause an error');},
-        function(error) {
+        function () {
+          throw new Error('goto(undefined) didn’t cause an error');
+        },
+        function (error) {
           error.should.include('url');
         }
       );
@@ -375,7 +380,7 @@ describe('Nightmare', function () {
         }, 'A', 'B');
     });
 
-    describe('asynchronous wait', function(){
+    describe('asynchronous wait', function () {
       it('should wait until the evaluate fn with arguments returns true with a callback', function*() {
         yield nightmare
           .goto(fixture('navigation'))
@@ -392,7 +397,7 @@ describe('Nightmare', function () {
         yield nightmare
           .goto(fixture('navigation'))
           .wait(function (expectedA, expectedB) {
-            return new Promise(function(resolve) {
+            return new Promise(function (resolve) {
               setTimeout(() => {
                 var textA = document.querySelector('a.a').textContent;
                 var textB = document.querySelector('a.b').textContent;
@@ -419,42 +424,42 @@ describe('Nightmare', function () {
       });
     });
 
-    it('should fail if navigation target is invalid', function() {
+    it('should fail if navigation target is invalid', function () {
       return nightmare.goto('http://this-is-not-a-real-domain.tld')
         .then(
-          function() {
+          function () {
             throw new Error('Navigation to an invalid domain succeeded');
-          }, function(error) {
+          }, function (error) {
             error.should.contain.keys('message', 'code', 'url');
             error.code.should.be.a('number');
           });
     });
 
-    it('should fail if navigation target is a malformed URL', function(done) {
+    it('should fail if navigation target is a malformed URL', function (done) {
       nightmare.goto('somewhere out there')
-        .then(function() {
+        .then(function () {
           done(new Error('Navigation to an invalid domain succeeded'));
         })
-        .catch(function(error) {
+        .catch(function (error) {
           done();
         });
     });
 
-    it('should fail if navigating to an unknown protocol', function(done) {
+    it('should fail if navigating to an unknown protocol', function (done) {
       nightmare.goto('fake-protocol://blahblahblah')
-        .then(function() {
+        .then(function () {
           done(new Error('Navigation to an invalid protocol succeeded'));
         })
-        .catch(function(error) {
+        .catch(function (error) {
           done();
         });
     });
 
-    it('should not fail if the URL loads but a resource fails', function() {
+    it('should not fail if the URL loads but a resource fails', function () {
       return nightmare.goto(fixture('navigation/invalid-image'));
     });
 
-    it('should not fail if a child frame fails', function() {
+    it('should not fail if a child frame fails', function () {
       return nightmare.goto(fixture('navigation/invalid-frame'));
     });
 
@@ -464,48 +469,48 @@ describe('Nightmare', function () {
       data.url.should.equal(fixture('navigation/valid-frame'));
     });
 
-    it('should not fail if response was a valid error (e.g. 404)', function() {
+    it('should not fail if response was a valid error (e.g. 404)', function () {
       return nightmare.goto(fixture('navigation/not-a-real-page'));
     });
 
-    it('should fail if the response dies in flight', function(done) {
+    it('should fail if the response dies in flight', function (done) {
       nightmare.goto(fixture('do-not-respond'))
-        .then(function() {
+        .then(function () {
           done(new Error('Navigation succeeded but server connection died'));
         })
-        .catch(function(error) {
+        .catch(function (error) {
           done();
         });
     });
 
-    it('should not fail for a redirect', function() {
+    it('should not fail for a redirect', function () {
       return nightmare.goto(fixture('redirect?url=%2Fnavigation'));
     });
 
-    it('should fail for a redirect to an invalid URL', function(done) {
+    it('should fail for a redirect to an invalid URL', function (done) {
       nightmare.goto(
         fixture('redirect?url=http%3A%2F%2Fthis-is-not-a-real-domain.tld'))
-        .then(function() {
+        .then(function () {
           done(new Error('Navigation succeeded with redirect to bad location'));
         })
-        .catch(function(error) {
+        .catch(function (error) {
           done();
         });
     });
 
-    it('should succeed properly if request handler is present', function() {
+    it('should succeed properly if request handler is present', function () {
       Nightmare.action(
         'monitorRequest',
-        function(name, options, parent, win, renderer, done) {
+        function (name, options, parent, win, renderer, done) {
           win.webContents.session.webRequest.onBeforeRequest(
             ['*://localhost:*'],
-            function(details, callback) {
+            function (details, callback) {
               callback({cancel: false});
             }
           );
           done();
         },
-        function(done) {
+        function (done) {
           done();
           return this;
         });
@@ -515,29 +520,29 @@ describe('Nightmare', function () {
         .end();
     });
 
-    it('should fail properly if request handler is present', function(done) {
+    it('should fail properly if request handler is present', function (done) {
       Nightmare.action(
         'monitorRequest',
-        function(name, options, parent, win, renderer, done) {
+        function (name, options, parent, win, renderer, done) {
           win.webContents.session.webRequest.onBeforeRequest(
             ['*://localhost:*'],
-            function(details, callback) {
+            function (details, callback) {
               callback({cancel: false});
             }
           );
           done();
         },
-        function(done) {
+        function (done) {
           done();
           return this;
         });
 
       Nightmare({webPreferences: {partition: 'test-partition'}})
         .goto('http://this-is-not-a-real-domain.tld')
-        .then(function() {
+        .then(function () {
           done(new Error('Navigation to an invalid domain succeeded'));
         })
-        .catch(function(error) {
+        .catch(function (error) {
           done();
         });
     });
@@ -549,7 +554,7 @@ describe('Nightmare', function () {
       gotoResult.should.be.an('object');
 
       var linkText = yield nightmare
-        .evaluate(function() {
+        .evaluate(function () {
           return document.querySelector('.a').textContent;
         });
       linkText.should.equal('LINK');
@@ -563,100 +568,100 @@ describe('Nightmare', function () {
       data.url.should.equal(fixture('navigation/a.html'));
 
       var linkText = yield nightmare
-        .evaluate(function() {
+        .evaluate(function () {
           return document.querySelector('.d').textContent;
         });
       linkText.should.equal('D');
     });
 
-    it('should fail immediately/not time out for 304 statuses', function() {
+    it('should fail immediately/not time out for 304 statuses', function () {
       return Nightmare({gotoTimeout: 500})
         .goto(fixture('not-modified'))
         .end()
-        .then(function() {
-          throw new Error('Navigating to a 304 should return an error');
-        },
-        function(error) {
-          if (error.code === -7) {
-            throw new Error('Navigating to a 304 should not time out');
-          }
-        });
+        .then(function () {
+            throw new Error('Navigating to a 304 should return an error');
+          },
+          function (error) {
+            if (error.code === -7) {
+              throw new Error('Navigating to a 304 should not time out');
+            }
+          });
     });
 
-    it('should not time out for aborted loads', function() {
+    it('should not time out for aborted loads', function () {
       Nightmare.action(
         'abortRequests',
-        function(name, options, parent, win, renderer, done) {
+        function (name, options, parent, win, renderer, done) {
           win.webContents.session.webRequest.onBeforeRequest(
             ['*://localhost:*'],
-            function(details, callback) {
+            function (details, callback) {
               setTimeout(() => win.webContents.stop(), 0);
               callback({cancel: false});
             }
           );
           done();
         },
-        function() {
+        function () {
           done();
         });
 
       return Nightmare({gotoTimeout: 500})
         .goto(fixture('navigation'))
         .end()
-        .then(function() {
-          throw new Error('An aborted page load should return an error');
-        },
-        function(error) {
-          if (error.code === -7) {
-            throw new Error('Aborting a page load should not time out');
-          }
-        });
+        .then(function () {
+            throw new Error('An aborted page load should return an error');
+          },
+          function (error) {
+            if (error.code === -7) {
+              throw new Error('Aborting a page load should not time out');
+            }
+          });
     });
 
-    describe('timeouts', function() {
-      it('should time out after 30 seconds of loading', function() {
+    describe('timeouts', function () {
+      it('should time out after 30 seconds of loading', function () {
         // allow this test to go particularly long
         this.timeout(40000);
         return nightmare.goto(fixture('wait')).should.be.rejected
-          .then(function(error) {
+          .then(function (error) {
             error.code.should.equal(-7);
           });
       });
 
-      it('should allow custom goto timeout on the constructor', function() {
+      it('should allow custom goto timeout on the constructor', function () {
         var startTime = Date.now();
         return Nightmare({gotoTimeout: 1000}).goto(fixture('wait')).end()
           .should.be.rejected
-          .then(function(error) {
+          .then(function (error) {
             // allow a few extra seconds for browser startup
             (startTime - Date.now()).should.be.below(3000);
           });
       });
 
-      it('should allow a timeout to succeed if DOM loaded', function() {
+      it('should allow a timeout to succeed if DOM loaded', function () {
         return Nightmare({gotoTimeout: 1000})
           .goto(fixture('navigation/hanging-resources.html'))
           .end()
-          .then(function(data) {
+          .then(function (data) {
             data.details.should.include('1000 ms');
           });
       });
 
-      it('should allow actions on a hanging page', function() {
+      it('should allow actions on a hanging page', function () {
         return Nightmare({gotoTimeout: 500})
           .goto(fixture('navigation/hanging-resources.html'))
           .evaluate(() => document.title)
           .end()
-          .then(function(title) {
+          .then(function (title) {
             title.should.equal('Hanging resource load');
           });
       });
 
-      it('should allow loading a new page after timing out', function() {
+      it('should allow loading a new page after timing out', function () {
         nightmare.end().then();
         nightmare = Nightmare({gotoTimeout: 1000});
         return nightmare.goto(fixture('wait')).should.be.rejected
-          .then(function() {
+          .then(function () {
             return nightmare.goto(fixture('navigation'));
           });
       });
@@ -676,7 +681,7 @@ describe('Nightmare', function () {
   describe('evaluation', function () {
     var nightmare;
 
-    beforeEach(function() {
+    beforeEach(function () {
       nightmare = Nightmare();
     });
 
@@ -731,7 +736,25 @@ describe('Nightmare', function () {
         .visible('.hidden');
       visible.should.be.false;
 
-        // non-existent element
+      // non-existent element
+      visible = yield nightmare
+        .visible('#asdfasdfasdf');
+      visible.should.be.false;
+    });
+
+    it('should check if an element is visible', function*() {
+      // visible element
+      var visible = yield nightmare
+        .goto(fixture('evaluation'))
+        .visible('h1.title');
+      visible.should.be.true;
+
+      // hidden element
+      visible = yield nightmare
+        .visible('.hidden');
+      visible.should.be.false;
+
+      // non-existent element
       visible = yield nightmare
         .visible('#asdfasdfasdf');
       visible.should.be.false;
@@ -746,37 +769,37 @@ describe('Nightmare', function () {
       title.should.equal('Evaluation -- testparameter');
     });
 
-    it('should capture invalid evaluate fn', function() {
+    it('should capture invalid evaluate fn', function () {
       return nightmare
         .goto(fixture('evaluation'))
         .evaluate('not_a_function')
         .should.be.rejected;
     });
 
-    describe('asynchronous', function(){
+    describe('asynchronous', function () {
       it('should allow for asynchronous evaluation with a callback', function*() {
         var asyncValue = yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function(done) {
+          .evaluate(function (done) {
             setTimeout(() => done(null, 'nightmare'), 1000);
           });
 
-          asyncValue.should.equal('nightmare');
+        asyncValue.should.equal('nightmare');
       });
       it('should allow for arguments with asynchronous evaluation with a callback', function*() {
         var asyncValue = yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function(str, done) {
+          .evaluate(function (str, done) {
             setTimeout(() => done(null, str), 1000);
           }, 'nightmare');
 
-          asyncValue.should.equal('nightmare');
+        asyncValue.should.equal('nightmare');
       });
 
       it('should allow for errors in asynchronous evaluation with a callback', function*() {
         yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function(done) {
+          .evaluate(function (done) {
             setTimeout(() => done(new Error('nightmare')), 1000);
           }).should.be.rejected;
       });
@@ -785,39 +808,39 @@ describe('Nightmare', function () {
         this.timeout(40000);
         yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function(done) {
+          .evaluate(function (done) {
             //don't call done
           }).should.be.rejected;
       });
 
       it('should allow for asynchronous evaluation with a promise', function*() {
-        var asyncValue =  yield nightmare
+        var asyncValue = yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function() {
+          .evaluate(function () {
             return new Promise(resolve => {
               setTimeout(() => resolve('nightmare'), 1000);
             });
           })
 
-          asyncValue.should.equal('nightmare');
+        asyncValue.should.equal('nightmare');
       });
 
       it('should allow for arguments with asynchronous evaluation with a promise', function*() {
-        var asyncValue =  yield nightmare
+        var asyncValue = yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function(str) {
+          .evaluate(function (str) {
             return new Promise(resolve => {
               setTimeout(() => resolve(str), 1000);
             });
           }, 'nightmare')
 
-          asyncValue.should.equal('nightmare');
+        asyncValue.should.equal('nightmare');
       });
 
       it('should allow for errors in asynchronous evaluation with a promise', function*() {
         yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function() {
+          .evaluate(function () {
             return new Promise((resolve, reject) => {
               setTimeout(() => reject(new Error('nightmare')), 1000);
             });
@@ -828,7 +851,7 @@ describe('Nightmare', function () {
         this.timeout(40000);
         yield nightmare
           .goto(fixture('evaluation'))
-          .evaluate(function() {
+          .evaluate(function () {
             return new Promise((resolve, reject) => {
               return 'nightmare';
             });
@@ -840,7 +863,7 @@ describe('Nightmare', function () {
   describe('manipulation', function () {
     var nightmare;
 
-    beforeEach(function() {
+    beforeEach(function () {
       nightmare = Nightmare();
     });
 
@@ -916,7 +939,7 @@ describe('Nightmare', function () {
         })
         .goto(fixture('manipulation'))
         .type('input[type=search]', input)
-        .evaluate(function() {
+        .evaluate(function () {
           return document.querySelector('input[type=search]').value;
         });
 
@@ -924,43 +947,43 @@ describe('Nightmare', function () {
       events.should.equal(0);
     });
 
-    it('should type integer', function* () {
-        var input = 10;
-        var events = input.toString().length * 3;
+    it('should type integer', function*() {
+      var input = 10;
+      var events = input.toString().length * 3;
 
-        var value = yield nightmare
-          .on('console', function (type, input, message) {
-            if (type === 'log') events--;
-          })
-          .goto(fixture('manipulation'))
-          .type('input[type=search]', input)
-          .evaluate(function() {
-            return document.querySelector('input[type=search]').value;
-          });
+      var value = yield nightmare
+        .on('console', function (type, input, message) {
+          if (type === 'log') events--;
+        })
+        .goto(fixture('manipulation'))
+        .type('input[type=search]', input)
+        .evaluate(function () {
+          return document.querySelector('input[type=search]').value;
+        });
 
-        value.should.equal('10');
-        events.should.equal(0);
+      value.should.equal('10');
+      events.should.equal(0);
     });
 
 
-    it('should type object', function* () {
-        var input = {
-          foo: 'bar'
-        };
-        var events = input.toString().length * 3;
+    it('should type object', function*() {
+      var input = {
+        foo: 'bar'
+      };
+      var events = input.toString().length * 3;
 
-        var value = yield nightmare
-          .on('console', function (type, input, message) {
-            if (type === 'log') events--;
-          })
-          .goto(fixture('manipulation'))
-          .type('input[type=search]', input)
-          .evaluate(function() {
-            return document.querySelector('input[type=search]').value;
-          });
+      var value = yield nightmare
+        .on('console', function (type, input, message) {
+          if (type === 'log') events--;
+        })
+        .goto(fixture('manipulation'))
+        .type('input[type=search]', input)
+        .evaluate(function () {
+          return document.querySelector('input[type=search]').value;
+        });
 
-        value.should.equal('[object Object]');
-        events.should.equal(0);
+      value.should.equal('[object Object]');
+      events.should.equal(0);
     });
 
     it('should clear inputs', function*() {
@@ -974,7 +997,7 @@ describe('Nightmare', function () {
         .goto(fixture('manipulation'))
         .type('input[type=search]', input)
         .type('input[type=search]')
-        .evaluate(function() {
+        .evaluate(function () {
           return document.querySelector('input[type=search]').value;
         });
 
@@ -988,7 +1011,7 @@ describe('Nightmare', function () {
       var value = yield nightmare
         .goto(fixture('manipulation'))
         .insert('input[type=search]', input)
-        .evaluate(function() {
+        .evaluate(function () {
           return document.querySelector('input[type=search]').value;
         });
 
@@ -1000,21 +1023,21 @@ describe('Nightmare', function () {
       var value = yield nightmare
         .goto(fixture('manipulation'))
         .insert('input[type=search]')
-        .evaluate(function() {
+        .evaluate(function () {
           return document.querySelector('input[type=search]').value;
         });
 
       value.should.equal('');
     })
 
-    it('should not type in a nonexistent selector', function(){
+    it('should not type in a nonexistent selector', function () {
       return nightmare
         .goto(fixture('manipulation'))
         .type('does-not-exist', 'nightmare')
         .should.be.rejected;
     });
 
-    it('should not insert in a nonexistent selector', function(){
+    it('should not insert in a nonexistent selector', function () {
       return nightmare
         .goto(fixture('manipulation'))
         .insert('does-not-exist', 'nightmare')
@@ -1026,7 +1049,7 @@ describe('Nightmare', function () {
         .goto(fixture('manipulation'))
         .type('input[type=search]', 'test')
         .click('p')
-        .evaluate(function() {
+        .evaluate(function () {
           return document.activeElement === document.body;
         });
       isBody.should.be.true;
@@ -1038,13 +1061,13 @@ describe('Nightmare', function () {
         .click('div[data-test="test"]')
     });
 
-    it('should not allow for code injection with .click()', function(done){
+    it('should not allow for code injection with .click()', function (done) {
       var exception;
       nightmare
         .goto(fixture('manipulation'))
         .click('"]\'); document.title = \'injected title\'; (\'"')
         .catch((e) => exception = e)
-        .then(()=> nightmare.title())
+        .then(() => nightmare.title())
         .then((title) => {
           exception.should.exist;
           title.should.equal('Manipulation');
@@ -1054,7 +1077,9 @@ describe('Nightmare', function () {
 
     it('should not fail if selector no longer exists to blur after typing', function*() {
       yield nightmare
-        .on('console', function(){ console.log(arguments)})
+        .on('console', function () {
+          console.log(arguments)
+        })
         .goto(fixture('manipulation'))
         .type('input#disappears', 'nightmare');
     });
@@ -1163,10 +1188,10 @@ describe('Nightmare', function () {
     });
   });
 
-  describe('cookies', function() {
+  describe('cookies', function () {
     var nightmare;
 
-    beforeEach(function() {
+    beforeEach(function () {
       nightmare = Nightmare({webPreferences: {partition: 'test-partition'}})
         .goto(fixture('cookie'));
     });
@@ -1256,7 +1281,7 @@ describe('Nightmare', function () {
         }
       ])
 
-      var cookies = yield cookies.get({ path: '/cookie'})
+      var cookies = yield cookies.get({path: '/cookie'})
       cookies.length.should.equal(1)
 
       cookies[0].name.should.equal('nightmare')
@@ -1283,7 +1308,7 @@ describe('Nightmare', function () {
 
       yield cookies.clear('nightmare');
 
-      var cookies = yield cookies.get({ path: '/cookie' });
+      var cookies = yield cookies.get({path: '/cookie'});
 
       cookies.length.should.equal(0);
     });
@@ -1356,15 +1381,15 @@ describe('Nightmare', function () {
   describe('rendering', function () {
     var nightmare;
 
-    before(function(done) {
+    before(function (done) {
       mkdirp(tmp_dir, done)
     })
 
-    after(function(done) {
+    after(function (done) {
       rimraf(tmp_dir, done)
     })
 
-    beforeEach(function() {
+    beforeEach(function () {
       nightmare = Nightmare();
     });
 
@@ -1375,8 +1400,8 @@ describe('Nightmare', function () {
     it('should take a screenshot', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .screenshot(tmp_dir+'/test.png');
-      var stats = fs.statSync(tmp_dir+'/test.png');
+        .screenshot(tmp_dir + '/test.png');
+      var stats = fs.statSync(tmp_dir + '/test.png');
       stats.size.should.be.at.least(1000);
     });
 
@@ -1391,16 +1416,16 @@ describe('Nightmare', function () {
     it('should take a clipped screenshot', function*() {
       yield nightmare
         .goto('https://github.com/')
-        .screenshot(tmp_dir+'/test-clipped.png', {
+        .screenshot(tmp_dir + '/test-clipped.png', {
           x: 200,
           y: 100,
           width: 100,
           height: 100
         });
-      var stats = fs.statSync(tmp_dir+'/test.png');
-      var statsClipped = fs.statSync(tmp_dir+'/test-clipped.png');
+      var stats = fs.statSync(tmp_dir + '/test.png');
+      var statsClipped = fs.statSync(tmp_dir + '/test-clipped.png');
       statsClipped.size.should.be.at.least(300);
-      stats.size.should.be.at.least(10*statsClipped.size);
+      stats.size.should.be.at.least(10 * statsClipped.size);
     });
 
     it('should buffer a clipped screenshot', function*() {
@@ -1424,8 +1449,12 @@ describe('Nightmare', function () {
         var image = yield nightmare
           .goto('about:blank')
           .viewport(100, 100)
-          .evaluate(function() { document.body.style.background = '#900'; })
-          .evaluate(function() { document.body.style.background = '#090'; })
+          .evaluate(function () {
+            document.body.style.background = '#900';
+          })
+          .evaluate(function () {
+            document.body.style.background = '#090';
+          })
           .screenshot();
 
         var png = new PNG();
@@ -1439,8 +1468,12 @@ describe('Nightmare', function () {
       var image = yield nightmare
         .goto('about:blank')
         .viewport(100, 100)
-        .evaluate(function() { document.body.style.background = '#900'; })
-        .evaluate(function() { document.body.style.background = '#090'; })
+        .evaluate(function () {
+          document.body.style.background = '#900';
+        })
+        .evaluate(function () {
+          document.body.style.background = '#090';
+        })
         .wait(1000)
         .screenshot();
 
@@ -1450,14 +1483,18 @@ describe('Nightmare', function () {
       firstPixel.should.deep.equal([0, 153, 0]);
     });
 
-    it('should not subscribe to frames until necessary', function() {
+    it('should not subscribe to frames until necessary', function () {
       var didSubscribe = false;
       var FrameManager = require('../lib/frame-manager.js');
       var manager = FrameManager({
         webContents: {
-          beginFrameSubscription: function() { didSubscribe = true; },
-          endFrameSubscription: function() {},
-          executeJavaScript: function() {}
+          beginFrameSubscription: function () {
+            didSubscribe = true;
+          },
+          endFrameSubscription: function () {
+          },
+          executeJavaScript: function () {
+          }
         }
       });
       didSubscribe.should.be.false;
@@ -1467,7 +1504,7 @@ describe('Nightmare', function () {
       var loaded = yield nightmare
         .goto(fixture('rendering'))
         .wait(2000)
-        .evaluate(function() {
+        .evaluate(function () {
           return !!window.jQuery;
         });
       loaded.should.be.at.least(true);
@@ -1477,32 +1514,32 @@ describe('Nightmare', function () {
       yield nightmare
         .goto(fixture('rendering'))
         .wait(2000)
-        .screenshot(tmp_dir+'/font-rendering.png');
-      var stats = fs.statSync(tmp_dir+'/font-rendering.png');
+        .screenshot(tmp_dir + '/font-rendering.png');
+      var stats = fs.statSync(tmp_dir + '/font-rendering.png');
       stats.size.should.be.at.least(1000);
     });
 
     it('should save as html', function*() {
       yield nightmare
         .goto(fixture('manipulation'))
-        .html(tmp_dir+'/test.html');
-      var stats = fs.statSync(tmp_dir+'/test.html');
+        .html(tmp_dir + '/test.html');
+      var stats = fs.statSync(tmp_dir + '/test.html');
       stats.should.be.ok;
     });
 
     it('should render a PDF', function*() {
       yield nightmare
         .goto(fixture('manipulation'))
-        .pdf(tmp_dir+'/test.pdf');
-      var stats = fs.statSync(tmp_dir+'/test.pdf');
+        .pdf(tmp_dir + '/test.pdf');
+      var stats = fs.statSync(tmp_dir + '/test.pdf');
       stats.size.should.be.at.least(1000);
     });
 
     it('should accept options to render a PDF', function*() {
       yield nightmare
         .goto(fixture('manipulation'))
-        .pdf(tmp_dir+'/test2.pdf', {printBackground: false});
-      var stats = fs.statSync(tmp_dir+'/test2.pdf');
+        .pdf(tmp_dir + '/test2.pdf', {printBackground: false});
+      var stats = fs.statSync(tmp_dir + '/test2.pdf');
       stats.size.should.be.at.least(1000);
     });
 
@@ -1518,10 +1555,10 @@ describe('Nightmare', function () {
     });
   });
 
-  describe('referer', function() {
+  describe('referer', function () {
     var nightmare;
 
-    beforeEach(function() {
+    beforeEach(function () {
       nightmare = Nightmare({webPreferences: {partition: 'test-partition'}});
     });
 
@@ -1538,7 +1575,7 @@ describe('Nightmare', function () {
         .evaluate(function () {
           return document.body.innerText;
         })
-        ;
+      ;
 
       referer.should.be.equal(returnedReferer.trim());
     })
@@ -1547,7 +1584,7 @@ describe('Nightmare', function () {
   describe('events', function () {
     var nightmare;
 
-    beforeEach(function() {
+    beforeEach(function () {
       nightmare = Nightmare();
     });
 
@@ -1604,13 +1641,14 @@ describe('Nightmare', function () {
         yield nightmare
           .goto('https://alskdjfasdfuuu.com');
       }
-      catch(error) {}
+      catch (error) {
+      }
       fired.should.be.true;
     });
 
-    it('should fire an event on javascript window.alert', function*(){
+    it('should fire an event on javascript window.alert', function*() {
       var alert = '';
-      nightmare.on('page', function(type, message){
+      nightmare.on('page', function (type, message) {
         if (type === 'alert') {
           alert = message;
         }
@@ -1618,16 +1656,16 @@ describe('Nightmare', function () {
 
       yield nightmare
         .goto(fixture('events'))
-        .evaluate(function(){
+        .evaluate(function () {
           alert('my alert');
         });
       alert.should.equal('my alert');
     });
 
-    it('should fire an event on javascript window.prompt', function*(){
+    it('should fire an event on javascript window.prompt', function*() {
       var prompt = '';
       var response = ''
-      nightmare.on('page', function(type, message, res){
+      nightmare.on('page', function (type, message, res) {
         if (type === 'prompt') {
           prompt = message;
           response = res
@@ -1636,17 +1674,17 @@ describe('Nightmare', function () {
 
       yield nightmare
         .goto(fixture('events'))
-        .evaluate(function(){
+        .evaluate(function () {
           prompt('my prompt', 'hello!');
         });
       prompt.should.equal('my prompt');
       response.should.equal('hello!');
     });
 
-    it('should fire an event on javascript window.confirm', function*(){
+    it('should fire an event on javascript window.confirm', function*() {
       var confirm = '';
       var response = ''
-      nightmare.on('page', function(type, message, res){
+      nightmare.on('page', function (type, message, res) {
         if (type === 'confirm') {
           confirm = message;
           response = res
@@ -1655,7 +1693,7 @@ describe('Nightmare', function () {
 
       yield nightmare
         .goto(fixture('events'))
-        .evaluate(function(){
+        .evaluate(function () {
           confirm('my confirm', 'hello!');
         });
       confirm.should.equal('my confirm');
@@ -1664,7 +1702,7 @@ describe('Nightmare', function () {
 
     it('should only fire once when using once', function*() {
       var events = 0;
-      nightmare.once('page', function(type, message) {
+      nightmare.once('page', function (type, message) {
         events++;
       });
 
@@ -1675,7 +1713,7 @@ describe('Nightmare', function () {
 
     it('should remove event listener', function*() {
       var events = 0;
-      var handler = function(type, message) {
+      var handler = function (type, message) {
         if (type === 'alert') {
           events++;
         }
@@ -1685,14 +1723,14 @@ describe('Nightmare', function () {
 
       yield nightmare
         .goto(fixture('events'))
-        .evaluate(function(){
+        .evaluate(function () {
           alert('alert one');
         });
 
       nightmare.removeListener('page', handler);
 
       yield nightmare
-        .evaluate(function(){
+        .evaluate(function () {
           alert('alert two');
         });
 
@@ -1704,22 +1742,22 @@ describe('Nightmare', function () {
     var nightmare;
     var server;
 
-    before(function(done) {
+    before(function (done) {
       // set up an HTTPS server using self-signed certificates -- Nightmare
       // will only be able to talk to it if 'ignore-certificate-errors' is set.
       server = https.createServer({
         key: fs.readFileSync(path.join(__dirname, 'files', 'server.key')),
         cert: fs.readFileSync(path.join(__dirname, 'files', 'server.crt'))
-      }, function(request, response) {
+      }, function (request, response) {
         response.end('ok\n');
-      }).listen(0, 'localhost', function() {
+      }).listen(0, 'localhost', function () {
         var address = server.address();
         server.url = `https://${address.address}:${address.port}`;
         done();
       });
     });
 
-    after(function() {
+    after(function () {
       server.close();
       server = null;
     });
@@ -1728,7 +1766,7 @@ describe('Nightmare', function () {
       yield nightmare.end();
     });
 
-    it('should set useragent', function* () {
+    it('should set useragent', function*() {
       nightmare = new Nightmare();
       var useragent = yield nightmare
         .useragent('firefox')
@@ -1739,7 +1777,7 @@ describe('Nightmare', function () {
       useragent.should.eql('firefox');
     });
 
-    it('should wait and fail with waitTimeout', function() {
+    it('should wait and fail with waitTimeout', function () {
       nightmare = Nightmare({waitTimeout: 254});
       return nightmare
         .goto(fixture('navigation'))
@@ -1747,7 +1785,7 @@ describe('Nightmare', function () {
         .should.be.rejected;
     });
 
-    it('should wait and fail with waitTimeout and a ms wait time', function() {
+    it('should wait and fail with waitTimeout and a ms wait time', function () {
       nightmare = Nightmare({waitTimeout: 254});
       return nightmare
         .goto(fixture('navigation'))
@@ -1755,7 +1793,7 @@ describe('Nightmare', function () {
         .should.be.rejected;
     });
 
-    it('should wait and fail with waitTimeout with queued functions', function() {
+    it('should wait and fail with waitTimeout with queued functions', function () {
       nightmare = Nightmare({waitTimeout: 254});
       return nightmare
         .goto(fixture('navigation'))
@@ -1772,7 +1810,7 @@ describe('Nightmare', function () {
         .evaluate(function () {
           return JSON.parse(document.querySelector('pre').innerHTML);
         });
-      data.should.eql({ name: 'my', pass: 'auth' });
+      data.should.eql({name: 'my', pass: 'auth'});
     });
 
     it('should fail on authentication failure', function*() {
@@ -1783,7 +1821,7 @@ describe('Nightmare', function () {
         .should.be.rejected;
     });
 
-    it('should be able to update authentication', function*(){
+    it('should be able to update authentication', function*() {
       nightmare = Nightmare();
       var data = yield nightmare
         .authentication('my', 'auth')
@@ -1793,11 +1831,11 @@ describe('Nightmare', function () {
         .evaluate(function () {
           return JSON.parse(document.querySelector('pre').innerHTML);
         });
-      data.should.eql({ name: 'my2', pass: 'auth2' });
+      data.should.eql({name: 'my2', pass: 'auth2'});
     });
 
     it('should set viewport', function*() {
-      var size = { width: 400, height: 300, useContentSize: true };
+      var size = {width: 400, height: 300, useContentSize: true};
       nightmare = Nightmare(size);
       var result = yield nightmare
         .goto(fixture('options'))
@@ -1825,7 +1863,7 @@ describe('Nightmare', function () {
     it('should set all headers', function*() {
       nightmare = Nightmare();
       var headers = yield nightmare
-        .header({ 'X-Foo': 'foo', 'X-Bar': 'bar'})
+        .header({'X-Foo': 'foo', 'X-Bar': 'bar'})
         .goto(fixture('headers'))
         .evaluate(function () {
           return JSON.parse(document.querySelector('pre').innerHTML);
@@ -1837,7 +1875,7 @@ describe('Nightmare', function () {
     it('should set headers for that request', function*() {
       nightmare = Nightmare();
       var headers = yield nightmare
-        .goto(fixture('headers'), { 'X-Nightmare-Header': 'hello world' })
+        .goto(fixture('headers'), {'X-Nightmare-Header': 'hello world'})
         .evaluate(function () {
           return JSON.parse(document.querySelector('pre').innerHTML);
         });
@@ -1856,7 +1894,7 @@ describe('Nightmare', function () {
     });
 
     it('should be constructable with paths', function*() {
-      nightmare = Nightmare({ paths:{ userData : __dirname } });
+      nightmare = Nightmare({paths: {userData: __dirname}});
       nightmare.should.be.ok;
     });
 
@@ -1871,30 +1909,30 @@ describe('Nightmare', function () {
       nightmare.should.be.ok;
       var touchEvents = yield nightmare
         .goto(server.url)
-        .evaluate(function() {
+        .evaluate(function () {
           return 'ontouchstart' in window;
         });
       touchEvents.should.be.true;
     });
 
     it('should support switches with values', function*() {
-      nightmare = Nightmare({ switches: { 'force-device-scale-factor': '5' } });
+      nightmare = Nightmare({switches: {'force-device-scale-factor': '5'}});
       nightmare.should.be.ok;
       var scaleFactor = yield nightmare
         .goto('about:blank')
-        .evaluate(function() {
+        .evaluate(function () {
           return window.devicePixelRatio;
         });
       scaleFactor.should.equal(5);
     });
 
     it('should allow to use external Electron', function*() {
-      nightmare = Nightmare({ electronPath: require('electron') });
+      nightmare = Nightmare({electronPath: require('electron')});
       nightmare.should.be.ok;
     });
 
     it('should allow to use external Promise', function*() {
-      nightmare = Nightmare({ Promise: require('bluebird') });
+      nightmare = Nightmare({Promise: require('bluebird')});
       nightmare.should.be.ok;
       const thenPromise = nightmare.goto('about:blank').then();
       thenPromise.should.be.an.instanceof(require('bluebird'));
@@ -1909,7 +1947,7 @@ describe('Nightmare', function () {
     });
   });
 
-  describe('Nightmare.Promise', function() {
+  describe('Nightmare.Promise', function () {
     var nightmare;
     afterEach(function*() {
       // `withDeprecationTracking()` messes w/ prototype constructor references
@@ -1939,7 +1977,7 @@ describe('Nightmare', function () {
 
     it('should not override per-instance Promise library', function*() {
       Nightmare.Promise.should.equal(Promise);
-      nightmare = Nightmare({ Promise: require('bluebird') });
+      nightmare = Nightmare({Promise: require('bluebird')});
       nightmare.should.be.ok;
       var thenPromise = nightmare.goto('about:blank').then();
       thenPromise.should.not.be.an.instanceof(Promise);
@@ -1948,14 +1986,14 @@ describe('Nightmare', function () {
     });
   })
 
-  describe('Nightmare.action(name, fn)', function() {
+  describe('Nightmare.action(name, fn)', function () {
     afterEach(function*() {
       yield nightmare.end();
     });
 
     it('should support custom actions', function*() {
       Nightmare.action('size', function (done) {
-        this.evaluate_now(function() {
+        this.evaluate_now(function () {
           var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
           var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
           return {
@@ -1998,14 +2036,14 @@ describe('Nightmare', function () {
       color.should.equal('rgb(0, 0, 0)')
     })
 
-    it('should support extending Electron', function*(){
+    it('should support extending Electron', function*() {
       Nightmare.action('bind',
-        function(ns, options, parent, win, renderer, done) {
+        function (ns, options, parent, win, renderer, done) {
           var sliced = require('sliced');
-          parent.on('bind', function(name) {
+          parent.on('bind', function (name) {
             if (renderer.listeners(name)
-              .length == 0) {
-              renderer.on(name, function() {
+                .length == 0) {
+              renderer.on(name, function () {
                 parent.emit.apply(parent, [name].concat(sliced(arguments, 1)))
               });
             }
@@ -2013,7 +2051,7 @@ describe('Nightmare', function () {
           });
           done();
         },
-        function() {
+        function () {
           var name = arguments[0],
             handler, done;
           if (arguments.length == 2) {
@@ -2033,11 +2071,11 @@ describe('Nightmare', function () {
       nightmare = new Nightmare();
       yield nightmare
         .goto('http://example.com')
-        .on('sample-event', function() {
+        .on('sample-event', function () {
           eventResults = arguments;
         })
         .bind('sample-event')
-        .evaluate(function() {
+        .evaluate(function () {
           ipc.send('sample-event', 'sample', 3, {
             sample: 'sample'
           });
@@ -2052,12 +2090,12 @@ describe('Nightmare', function () {
     it('should allow env variables', function*() {
       Nightmare.action('envtest',
         function (name, options, parent, win, renderer, done) {
-          parent.respondTo('envtest', function(done){
+          parent.respondTo('envtest', function (done) {
             done(null, process.env);
           });
           done();
         },
-        function(done) {
+        function (done) {
           this.child.call('envtest', done);
         }
       );
@@ -2075,8 +2113,8 @@ describe('Nightmare', function () {
     });
   })
 
-  describe('Nightmare.use', function() {
-    beforeEach(function() {
+  describe('Nightmare.use', function () {
+    beforeEach(function () {
       nightmare = Nightmare();
     });
 
@@ -2091,7 +2129,7 @@ describe('Nightmare', function () {
 
       tagName.should.equal('H1')
 
-      function select (tagname) {
+      function select(tagname) {
         return function (nightmare) {
           nightmare.evaluate(function (tagname) {
             return document.querySelector(tagname).tagName
@@ -2101,8 +2139,8 @@ describe('Nightmare', function () {
     })
   })
 
-  describe('custom preload script', function() {
-    beforeEach(function() {
+  describe('custom preload script', function () {
+    beforeEach(function () {
       nightmare = Nightmare();
     });
 
@@ -2119,7 +2157,7 @@ describe('Nightmare', function () {
 
       var value = yield nightmare
         .goto(fixture('preload'))
-        .evaluate(function() {
+        .evaluate(function () {
           return window.preload
         })
 
@@ -2127,12 +2165,15 @@ describe('Nightmare', function () {
     })
   })
 
-  describe('devtools', function(){
-    beforeEach(function() {
+  describe('devtools', function () {
+    beforeEach(function () {
       Nightmare.action('waitForDevTools',
-        function(ns, options, parent, win, renderer, done){
-          parent.on('waitForDevTools', function() {
-            function opened() { parent.emit('waitForDevTools', null, true); }
+        function (ns, options, parent, win, renderer, done) {
+          parent.on('waitForDevTools', function () {
+            function opened() {
+              parent.emit('waitForDevTools', null, true);
+            }
+
             if (win.webContents.isDevToolsOpened()) {
               return opened();
             }
@@ -2140,19 +2181,19 @@ describe('Nightmare', function () {
           });
           done();
         },
-        function(done){
+        function (done) {
           this.child.once('waitForDevTools', done);
           this.child.emit('waitForDevTools');
         });
-      nightmare = Nightmare({show:true, openDevTools:true});
+      nightmare = Nightmare({show: true, openDevTools: true});
 
     });
 
-    afterEach(function*(){
+    afterEach(function*() {
       yield nightmare.end();
     });
 
-    it('should open devtools', function*(){
+    it('should open devtools', function*() {
       var devToolsOpen = yield nightmare
         .goto(fixture('simple'))
         .waitForDevTools();
@@ -2161,11 +2202,11 @@ describe('Nightmare', function () {
     });
   });
 
-  describe('ipc', function(){
-    beforeEach(function() {
+  describe('ipc', function () {
+    beforeEach(function () {
       Nightmare.action('test',
-        function(_, __, parent, ___, ____, done) {
-          parent.respondTo('test', function(arg1, done) {
+        function (_, __, parent, ___, ____, done) {
+          parent.respondTo('test', function (arg1, done) {
             done.progress('one');
             done.progress('two');
             if (arg1 === 'error') {
@@ -2177,24 +2218,32 @@ describe('Nightmare', function () {
           });
           done();
         },
-        function(options, done) {
+        function (options, done) {
           var channel = this.child.call('test', options.arg || options, done);
-          if (options.onData) { channel.on('data', options.onData); }
-          if (options.onEnd) { channel.on('end', options.onEnd); }
+          if (options.onData) {
+            channel.on('data', options.onData);
+          }
+          if (options.onEnd) {
+            channel.on('end', options.onEnd);
+          }
         });
       Nightmare.action('noImplementation',
-        function(done) {
+        function (done) {
           this.child.call('noImplementation', done);
         });
       nightmare = Nightmare();
     });
 
-    afterEach(function*(){
+    afterEach(function*() {
       yield nightmare.end();
     });
 
-    it('should only make one IPC instance per process', function() {
-      var processStub = {send: function() {}, on: function(){}};
+    it('should only make one IPC instance per process', function () {
+      var processStub = {
+        send: function () {
+        }, on: function () {
+        }
+      };
       var ipc1 = IPC(processStub);
       var ipc2 = IPC(processStub);
       ipc1.should.equal(ipc2);
@@ -2205,12 +2254,12 @@ describe('Nightmare', function () {
       result.should.equal('Got x');
     });
 
-    it('should support errors across IPC', function(done) {
+    it('should support errors across IPC', function (done) {
       nightmare.test('error').then(
-        function() {
+        function () {
           done(new Error('Action succeeded when it should have errored!'));
         },
-        function() {
+        function () {
           done();
         });
     });
@@ -2225,32 +2274,32 @@ describe('Nightmare', function () {
       progress.should.deep.equal(['one', 'two', [null, 'Got x']]);
     });
 
-    it('should trigger error if no responder is registered', function(done) {
+    it('should trigger error if no responder is registered', function (done) {
       nightmare.noImplementation().then(
-        function() {
+        function () {
           done(new Error('Action succeeded when it should have errored!'));
         },
-        function() {
+        function () {
           done();
         });
     });
 
     it('should log a warning when replacing a responder', function*() {
       Nightmare.action('uhoh',
-        function(_, __, parent, ___, ____, done) {
-          parent.respondTo('test', function(done) {
+        function (_, __, parent, ___, ____, done) {
+          parent.respondTo('test', function (done) {
             done();
           });
           done();
         },
-        function(done) {
+        function (done) {
           this.child.call('test', done);
         });
 
       var logged = false;
       var instance = Nightmare();
-      instance._queue.splice(1, 0, [function(done) {
-        this.child.on('nightmare:ipc:debug', function(message) {
+      instance._queue.splice(1, 0, [function (done) {
+        this.child.on('nightmare:ipc:debug', function (message) {
           if (message.toLowerCase().indexOf('replacing') > -1) {
             logged = true;
           }
@@ -2265,7 +2314,7 @@ describe('Nightmare', function () {
     });
   });
 
-  describe('partitioning', function(){
+  describe('partitioning', function () {
     afterEach(function*() {
       yield nightmare.end();
     });
@@ -2275,7 +2324,7 @@ describe('Nightmare', function () {
       nightmare = Nightmare();
       yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           window.localStorage.setItem('testing', 'This string should not persist between instances.')
         })
         .end();
@@ -2283,7 +2332,7 @@ describe('Nightmare', function () {
       nightmare = Nightmare();
       var value = yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           return window.localStorage.getItem('testing') || ''
         });
 
@@ -2293,37 +2342,37 @@ describe('Nightmare', function () {
     // Setting the partition to null we default to the electron default behavior
     // which is to use a persistent storage between instances.
     it('should persist between instances if partition is null', function *() {
-      nightmare = Nightmare({ webPreferences: { partition: null } });
+      nightmare = Nightmare({webPreferences: {partition: null}});
       yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           window.localStorage.setItem('testing', 'This string should persist between instances.')
         })
         .end();
 
-      nightmare = Nightmare({ webPreferences: { partition: null } });
+      nightmare = Nightmare({webPreferences: {partition: null}});
       var value = yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           return window.localStorage.getItem('testing') || ''
         });
 
       value.should.equal('This string should persist between instances.');
     });
 
-    it('should not persist between instances if partition name doesnt start with "persist:"', function *(){
-      nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
+    it('should not persist between instances if partition name doesnt start with "persist:"', function *() {
+      nightmare = Nightmare({webPreferences: {partition: 'nonpersist'}});
       yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           window.localStorage.setItem('testing', 'This string not should persist between instances.')
         })
         .end();
 
-      nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
+      nightmare = Nightmare({webPreferences: {partition: 'nonpersist'}});
       var value = yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           return window.localStorage.getItem('testing') || ''
         });
 
@@ -2331,25 +2380,428 @@ describe('Nightmare', function () {
     });
 
     it('should persist between instances if partition starts with "persist:"', function *() {
-      nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
+      nightmare = Nightmare({webPreferences: {partition: 'persist: testing'}});
       yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           window.localStorage.setItem('testing', 'This string should persist between instances.')
         })
         .end();
 
-      nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
+      nightmare = Nightmare({webPreferences: {partition: 'persist: testing'}});
       var value = yield nightmare
         .goto(fixture('simple'))
-        .evaluate(function() {
+        .evaluate(function () {
           return window.localStorage.getItem('testing') || ''
         });
 
       value.should.equal('This string should persist between instances.');
     });
-  })
+  });
+
+  describe('xpath selector', function () {
+
+    it('should provide useful errors for .click', function (done) {
+      var nightmare = Nightmare({useXpath: true});
+
+      nightmare
+        .goto('about:blank')
+        .click('//a[@class="not-here"]')
+        .catch(function (error) {
+          error.should.include('//a[@class="not-here"]');
+          done();
+        });
+    });
+
+    it('should provide useful errors for .mousedown', function (done) {
+      var nightmare = Nightmare({useXpath: true});
+
+      nightmare
+        .goto('about:blank')
+        .mousedown('//a[@class="not-here"]')
+        .catch(function (error) {
+          error.should.include('//a[@class="not-here"]');
+          done();
+        });
+    });
+
+    it('should provide useful errors for .mouseup', function (done) {
+      var nightmare = Nightmare({useXpath: true});
+
+      nightmare
+        .goto('about:blank')
+        .mouseup('//a[@class="not-here"]')
+        .catch(function (error) {
+          error.should.include('//a[@class="not-here"]');
+          done();
+        });
+    });
+
+    it('should provide useful errors for .mouseover', function (done) {
+      var nightmare = Nightmare({useXpath: true});
+
+      nightmare
+        .goto('about:blank')
+        .mouseover('//a[@class="not-here"]')
+        .catch(function (error) {
+          error.should.include('//a[@class="not-here"]');
+          done();
+        });
+    });
+
+    describe('navigation', function () {
+      var nightmare;
+
+      beforeEach(function () {
+        nightmare = Nightmare({
+          webPreferences: {partition: 'test-partition' + Math.random()},
+          loadTimeout: 45 * 1000,
+          waitTimeout: 5 * 1000,
+          useXpath: true
+        });
+      });
+
+      afterEach(function*() {
+        yield nightmare.end();
+        Nightmare.resetActions();
+      });
+
+      it('should click on a link and then go back', function*() {
+        var title = yield nightmare
+          .goto(fixture('navigation'))
+          .click('//a')
+          .title();
+
+        title.should.equal('A');
+
+        var title = yield nightmare
+          .back()
+          .title();
+
+        title.should.equal('Navigation')
+      });
+
+      it('should work for links that dont go anywhere', function*() {
+        var title = yield nightmare
+          .goto(fixture('navigation'))
+          .click('//a')
+          .title();
+
+        title.should.equal('A');
+
+        var title = yield nightmare
+          .click('//a[@class="d"]')
+          .title();
+
+        title.should.equal('A')
+      })
+
+      it('should click on a link, go back, and then go forward', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .click('//a')
+          .back()
+          .forward();
+      });
+
+      it('should wait until element is present', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait('//a');
+      });
+
+      it('should soft timeout if element does not appear', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait('//ul', 150);
+      });
+
+      it('should wait until element is present with a modified poll interval', function*() {
+        nightmare = Nightmare({
+          pollInterval: 50,
+          useXpath: true
+        });
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait('//a');
+      });
+
+    });
+
+    describe('evaluation', function () {
+      var nightmare;
+
+      beforeEach(function () {
+        nightmare = Nightmare({useXpath: true});
+      });
+
+      afterEach(function*() {
+        yield nightmare.end();
+      });
+
+      it('should check if the selector exists', function*() {
+        // existent element
+        var exists = yield nightmare
+          .goto(fixture('evaluation'))
+          .exists('//h1[@class="title"]');
+        exists.should.be.true;
+
+        // non-existent element
+        exists = yield nightmare.exists('//a[@class="blahblahblah"]');
+        exists.should.be.false;
+      });
+
+      it('should check if an element is visible', function*() {
+        // visible element
+        var visible = yield nightmare
+          .goto(fixture('evaluation'))
+          .visible('//h1[@class="title"]');
+        visible.should.be.true;
+
+        // hidden element
+        visible = yield nightmare
+          .visible('//div[@class="hidden"]');
+        visible.should.be.false;
+
+        // non-existent element
+        visible = yield nightmare
+          .visible('//[@id="asdfasdfasdf"]');
+        visible.should.be.false;
+      });
+
+    });
+
+    describe('manipulation', function () {
+      var nightmare;
+
+      beforeEach(function () {
+        nightmare = Nightmare({useXpath: true});
+      });
+
+      afterEach(function*() {
+        yield nightmare.end();
+      });
+
+      it('should type', function*() {
+        var input = 'nightmare'
+        var events = input.length * 3
+
+        var value = yield nightmare
+          .on('console', function (type, input, message) {
+            if (type === 'log') events--;
+          })
+          .goto(fixture('manipulation'))
+          .type('//input[@type="search"]', input)
+          .evaluate(function () {
+            return document.querySelector('input[type=search]').value;
+          });
+
+        value.should.equal('nightmare');
+        events.should.equal(0);
+      });
+
+      it('should type integer', function*() {
+        var input = 10;
+        var events = input.toString().length * 3;
+
+        var value = yield nightmare
+          .on('console', function (type, input, message) {
+            if (type === 'log') events--;
+          })
+          .goto(fixture('manipulation'))
+          .type('//input[@type="search"]', input)
+          .evaluate(function () {
+            return document.querySelector('input[type=search]').value;
+          });
+
+        value.should.equal('10');
+        events.should.equal(0);
+      });
+
+
+      it('should type object', function*() {
+        var input = {
+          foo: 'bar'
+        };
+        var events = input.toString().length * 3;
+
+        var value = yield nightmare
+          .on('console', function (type, input, message) {
+            if (type === 'log') events--;
+          })
+          .goto(fixture('manipulation'))
+          .type('//input[@type="search"]', input)
+          .evaluate(function () {
+            return document.querySelector('input[type=search]').value;
+          });
+
+        value.should.equal('[object Object]');
+        events.should.equal(0);
+      });
+
+      it('should clear inputs', function*() {
+        var input = 'nightmare'
+        var events = input.length * 3
+
+        var value = yield nightmare
+          .on('console', function (type, input, message) {
+            if (type === 'log') events--;
+          })
+          .goto(fixture('manipulation'))
+          .type('//input[@type="search"]', input)
+          .type('//input[@type="search"]')
+          .evaluate(function () {
+            return document.querySelector('input[type=search]').value;
+          });
+
+        value.should.equal('');
+        events.should.equal(0);
+      });
+
+      it('should support inserting text', function*() {
+        var input = 'nightmare insert typing';
+
+        var value = yield nightmare
+          .goto(fixture('manipulation'))
+          .insert('//input[@type="search"]', input)
+          .evaluate(function () {
+            return document.querySelector('input[type=search]').value;
+          });
+
+        value.should.equal('nightmare insert typing');
+      });
+
+      it('should support clearing inserted text', function*() {
+
+        var value = yield nightmare
+          .goto(fixture('manipulation'))
+          .insert('//input[@type="search"]')
+          .evaluate(function () {
+            return document.querySelector('input[type=search]').value;
+          });
+
+        value.should.equal('');
+      });
+
+      it('should not type in a nonexistent selector', function () {
+        return nightmare
+          .goto(fixture('manipulation'))
+          .type('//[@class="does-not-exist"]', 'nightmare')
+          .should.be.rejected;
+      });
+
+      it('should not insert in a nonexistent selector', function () {
+        return nightmare
+          .goto(fixture('manipulation'))
+          .insert('//[@class="does-not-exist"]', 'nightmare')
+          .should.be.rejected;
+      });
+
+      it('should blur the active element when something is clicked', function*() {
+        var isBody = yield nightmare
+          .goto(fixture('manipulation'))
+          .type('//input[@type="search"]', 'test')
+          .click('//p')
+          .evaluate(function () {
+            return document.activeElement === document.body;
+          });
+        isBody.should.be.true;
+      });
+
+      it('should allow for clicking on elements with attribute selectors', function*() {
+        yield nightmare
+          .goto(fixture('manipulation'))
+          .click('//div[@data-test="test"]')
+      });
+
+      it('should not fail if selector no longer exists to blur after typing', function*() {
+        yield nightmare
+          .on('console', function () {
+            console.log(arguments)
+          })
+          .goto(fixture('manipulation'))
+          .type('//input[@id="disappears"]', 'nightmare');
+      });
+
+      it('should type and click', function*() {
+        var title = yield nightmare
+          .goto(fixture('manipulation'))
+          .type('//input[@type="search"]', 'nightmare')
+          .click('//button[@type="submit"]')
+          .wait(500)
+          .title();
+
+        title.should.equal('Manipulation - Results');
+      });
+
+      it('should type and click several times', function*() {
+        var title = yield nightmare
+          .goto(fixture('manipulation'))
+          .type('//input[@type="search"]', 'github nightmare')
+          .click('//button[@type="submit"]')
+          .wait(500)
+          .click('//a')
+          .wait(500)
+          .title();
+        title.should.equal('Manipulation - Result - Nightmare');
+      });
+
+      it('should checkbox', function*() {
+        var checkbox = yield nightmare
+          .goto(fixture('manipulation'))
+          .check('//input[@type="checkbox"]')
+          .evaluate(function () {
+            return document.querySelector('input[type=checkbox]').checked;
+          });
+        checkbox.should.be.true;
+      });
+
+      it('should uncheck', function*() {
+        var checkbox = yield nightmare
+          .goto(fixture('manipulation'))
+          .check('//input[@type="checkbox"]')
+          .uncheck('//input[@type="checkbox"]')
+          .evaluate(function () {
+            return document.querySelector('input[type=checkbox]').checked;
+          });
+        checkbox.should.be.false;
+      });
+
+      it('should select', function*() {
+        var select = yield nightmare
+          .goto(fixture('manipulation'))
+          .select('//select', '//option[@value="b"]')
+          .evaluate(function () {
+            return document.querySelector('select').value;
+          });
+        select.should.equal('b');
+      });
+
+      it('should hover over an element', function*() {
+        var color = yield nightmare
+          .goto(fixture('manipulation'))
+          .mouseover('//h1')
+          .evaluate(function () {
+            var element = document.querySelector('h1');
+            return element.style.background;
+          });
+        color.should.equal('rgb(102, 255, 102)');
+      });
+
+      it('should mousedown on an element', function*() {
+        var color = yield nightmare
+          .goto(fixture('manipulation'))
+          .mousedown('//h1')
+          .evaluate(function () {
+            var element = document.querySelector('h1');
+            return element.style.background;
+          });
+        color.should.equal('rgb(255, 0, 0)');
+      });
+    });
+  });
 });
+
 
 /**
  * Generate a URL to a specific fixture.
@@ -2367,9 +2819,9 @@ function fixture(path) {
  */
 
 function withDeprecationTracking(constructor) {
-  var newConstructor = function() {
+  var newConstructor = function () {
     var instance = constructor.apply(this, arguments);
-    instance.queue((done)=>{
+    instance.queue((done) => {
       instance.proc.stderr.pipe(split()).on('data', (line) => {
         if (line.indexOf('deprecated') > -1) {
           newConstructor.__deprecations.add(line);
@@ -2380,7 +2832,7 @@ function withDeprecationTracking(constructor) {
     return instance;
   };
   newConstructor.__deprecations = new Set();
-  newConstructor.assertNoDeprecations = function() {
+  newConstructor.assertNoDeprecations = function () {
     var deprecations = Nightmare.__deprecations;
     if (deprecations.size) {
       var plural = deprecations.size === 1 ? '' : 's';
@@ -2422,9 +2874,13 @@ Nightmare.resetActions = function () {
 /**
  * Simple assertion for running processes
  */
-chai.Assertion.addProperty('process', function() {
+chai.Assertion.addProperty('process', function () {
   var running = true;
-  try { process.kill(this._obj, 0); } catch(e) { running = false; }
+  try {
+    process.kill(this._obj, 0);
+  } catch (e) {
+    running = false;
+  }
   this.assert(
     running,
     'expected process ##{this} to be running',

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,2336 @@ process.setMaxListeners(0);
 
 var base = 'http://localhost:7500/';
 
-describe('Nightmare', function () {
+// describe('Nightmare', function () {
+//   before(function (done) {
+//     server.listen(7500, done);
+//     Nightmare = withDeprecationTracking(Nightmare);
+//   });
+//
+//   after(function() {
+//     Nightmare.assertNoDeprecations();
+//   });
+//
+//   it('should be constructable', function*() {
+//     var nightmare = Nightmare();
+//     nightmare.should.be.ok;
+//     yield nightmare.end();
+//   });
+//
+//   it('should have version information', function*(){
+//     var nightmare = Nightmare();
+//     var versions = yield nightmare.engineVersions();
+//     nightmare.engineVersions.electron.should.be.ok;
+//     nightmare.engineVersions.chrome.should.be.ok;
+//
+//     versions.electron.should.be.ok;
+//     versions.chrome.should.be.ok;
+//
+//     Nightmare.version.should.be.ok;
+//     yield nightmare.end();
+//   });
+//
+//   it('should kill its electron process when it is killed', function(done) {
+//     var child = child_process.fork(
+//       path.join(__dirname, 'files', 'nightmare-unended.js'));
+//
+//     child.once('message', function(electronPid) {
+//       child.once('exit', function() {
+//         try {
+//           electronPid.should.not.be.a.process;
+//         }
+//         catch(error) {
+//           // if the test failed, clean up the still-running process
+//           process.kill(electronPid, 'SIGINT');
+//           throw error;
+//         }
+//         done();
+//       });
+//       child.kill();
+//     });
+//   });
+//
+//   it('should gracefully handle electron being killed', function(done) {
+//     var child = child_process.fork(
+//       path.join(__dirname, 'files', 'nightmare-unended.js'));
+//
+//     child.once('message', function(electronPid) {
+//       process.kill(electronPid, 'SIGINT');
+//       child.once('exit', function(){
+//         electronPid.should.not.be.a.process;
+//         done();
+//       });
+//     });
+//   });
+//
+//   it('should end gracefully if the chain has not been started', function(done) {
+//     var child = child_process.fork(
+//       path.join(__dirname, 'files', 'nightmare-created.js'));
+//
+//     child.once('message', function() {
+//       child.once('exit', function(code) {
+//         code.should.equal(0);
+//         done();
+//       });
+//       child.kill();
+//     });
+//   });
+//
+//   it('should exit with a non-zero code on uncaughtExecption', function(done) {
+//     var child = child_process.fork(
+//       path.join(__dirname, 'files', 'nightmare-error.js'), [], {silent: true});
+//
+//       child.once('exit', function(code) {
+//         code.should.not.equal(0);
+//         done();
+//       });
+//   });
+//
+//   it('should provide a .catch function', function(done) {
+//     var nightmare = Nightmare();
+//
+//     nightmare
+//       .goto('about:blank')
+//       .evaluate(function() {
+//         throw new Error('Test');
+//       })
+//       .catch(function(err) {
+//         done();
+//       });
+//   });
+//
+//   it('should allow ending more than once', function(done){
+//     var nightmare = Nightmare();
+//     nightmare.goto(fixture('navigation'))
+//       .end()
+//       .then(() => nightmare.end())
+//       .then(() => done());
+//   });
+//
+//   it('should allow end with a callback', function(done){
+//     var nightmare = Nightmare();
+//     nightmare.goto(fixture('navigation'))
+//       .end(() => done());
+//   });
+//
+//   it('should allow end with a callback to be thenable', function(done){
+//     var nightmare = Nightmare();
+//     nightmare.goto(fixture('navigation'))
+//       .end(() => 'nightmare')
+//       .then((str) => {
+//         str.should.equal('nightmare');
+//         done();
+//       });
+//   });
+//
+//   it('should kill electron process when halted', function () {
+//     var nightmare = Nightmare();
+//
+//     const check1 = nightmare.goto(fixture('navigation'))
+//       .wait(1000)
+//       .wait(500)
+//       .end()
+//       .then(() => {})
+//       .should.be.rejectedWith('Nightmare Halted');
+//
+//     const electronPid = nightmare.proc.pid;
+//
+//     const check2 = new Promise((resolve, reject) => {
+//       nightmare.halt('Nightmare Halted', () => {
+//         electronPid.should.not.be.a.process;
+//         resolve();
+//       });
+//     });
+//
+//     return Promise.all([check1, check2]);
+//   });
+//  
+//   it('should successfully end on pages setting onunload or onbeforeunload', function(done) {
+//     var nightmare = Nightmare();
+//     nightmare.goto(fixture('unload'))
+//       .end()
+//       .then(() => done());
+//   });
+//
+//   it('should successfully end on pages binding unload or beforeunload', function(done) {
+//     var nightmare = Nightmare();
+//     nightmare.goto(fixture('unload/add-event-listener.html'))
+//       .end()
+//       .then(() => done());
+//   });
+//
+//   it('should provide useful errors for .click', function(done) {
+//     var nightmare = Nightmare();
+//
+//     nightmare
+//       .goto('about:blank')
+//       .click('a.not-here')
+//       .catch(function (error) {
+//         error.should.include('a.not-here');
+//         done();
+//       });
+//   });
+//
+//   it('should provide useful errors for .mousedown', function(done) {
+//     var nightmare = Nightmare();
+//
+//     nightmare
+//       .goto('about:blank')
+//       .mousedown('a.not-here')
+//       .catch(function (error) {
+//         error.should.include('a.not-here');
+//         done();
+//       });
+//   });
+//
+//   it('should provide useful errors for .mouseup', function(done) {
+//     var nightmare = Nightmare();
+//
+//     nightmare
+//       .goto('about:blank')
+//       .mouseup('a.not-here')
+//       .catch(function (error) {
+//         error.should.include('a.not-here');
+//         done();
+//       });
+//   });
+//
+//   it('should provide useful errors for .mouseover', function(done) {
+//     var nightmare = Nightmare();
+//
+//     nightmare
+//       .goto('about:blank')
+//       .mouseover('a.not-here')
+//       .catch(function (error) {
+//         error.should.include('a.not-here');
+//         done();
+//       });
+//   });
+//
+//   describe('navigation', function () {
+//     var nightmare;
+//
+//     beforeEach(function() {
+//       nightmare = Nightmare({
+//         webPreferences: {partition: 'test-partition' + Math.random()},
+//         loadTimeout: 45 * 1000,
+//         waitTimeout: 5 * 1000,
+//       });
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//       Nightmare.resetActions();
+//     });
+//
+//     it('should return data about the response', function*() {
+//       var data = yield nightmare.goto(fixture('navigation'));
+//       data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
+//     });
+//
+//     it('should reject with a useful message when no URL', function() {
+//       return nightmare.goto(undefined).then(
+//         function() {throw new Error('goto(undefined) didn’t cause an error');},
+//         function(error) {
+//           error.should.include('url');
+//         }
+//       );
+//     });
+//
+//     it('should reject with a useful message for an empty URL', function() {
+//       return nightmare.goto('').then(
+//         function() {throw new Error('goto(undefined) didn’t cause an error');},
+//         function(error) {
+//           error.should.include('url');
+//         }
+//       );
+//     });
+//
+//     it('should click on a link and then go back', function*() {
+//       var title = yield nightmare
+//         .goto(fixture('navigation'))
+//         .click('a')
+//         .title()
+//
+//       title.should.equal('A')
+//
+//       var title = yield nightmare
+//         .back()
+//         .title()
+//
+//       title.should.equal('Navigation')
+//     });
+//
+//     it('should work for links that dont go anywhere', function*() {
+//       var title = yield nightmare
+//         .goto(fixture('navigation'))
+//         .click('a')
+//         .title()
+//
+//       title.should.equal('A')
+//
+//       var title = yield nightmare
+//         .click('.d')
+//         .title()
+//
+//       title.should.equal('A')
+//     })
+//
+//     it('should click on a link, go back, and then go forward', function*() {
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .click('a')
+//         .back()
+//         .forward();
+//     });
+//
+//     it('should refresh the page', function*() {
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .refresh();
+//     });
+//
+//     it('should wait until element is present', function*() {
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .wait('a');
+//     });
+//
+//     it('should soft timeout if element does not appear', function*() {
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .wait('ul', 150);
+//     });
+//
+//     it('should wait until element is present with a modified poll interval', function*() {
+//       nightmare = Nightmare({
+//         pollInterval: 50
+//       });
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .wait('a');
+//     });
+//
+//     it('should escape the css selector correctly when waiting for an element', function*() {
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .wait('#escaping\\:test');
+//     });
+//
+//     it('should wait until the evaluate fn returns true', function*() {
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .wait(function () {
+//           var text = document.querySelector('a').textContent;
+//           return (text === 'A');
+//         });
+//     });
+//
+//     it('should wait until the evaluate fn with arguments returns true', function*() {
+//       yield nightmare
+//         .goto(fixture('navigation'))
+//         .wait(function (expectedA, expectedB) {
+//           var textA = document.querySelector('a.a').textContent;
+//           var textB = document.querySelector('a.b').textContent;
+//           return (expectedA === textA && expectedB === textB);
+//         }, 'A', 'B');
+//     });
+//
+//     describe('asynchronous wait', function(){
+//       it('should wait until the evaluate fn with arguments returns true with a callback', function*() {
+//         yield nightmare
+//           .goto(fixture('navigation'))
+//           .wait(function (expectedA, expectedB, done) {
+//             setTimeout(() => {
+//               var textA = document.querySelector('a.a').textContent;
+//               var textB = document.querySelector('a.b').textContent;
+//               done(null, expectedA === textA && expectedB === textB);
+//             }, 2000);
+//           }, 'A', 'B');
+//       });
+//
+//       it('should wait until the evaluate fn with arguments returns true with a promise', function*() {
+//         yield nightmare
+//           .goto(fixture('navigation'))
+//           .wait(function (expectedA, expectedB) {
+//             return new Promise(function(resolve) {
+//               setTimeout(() => {
+//                 var textA = document.querySelector('a.a').textContent;
+//                 var textB = document.querySelector('a.b').textContent;
+//                 resolve(expectedA === textA && expectedB === textB);
+//               }, 2000);
+//             });
+//           }, 'A', 'B');
+//       });
+//
+//       it('should reject timeout on wait', function*() {
+//         yield nightmare
+//           .goto(fixture('navigation'))
+//           .wait(function (done) {
+//             //never call done
+//           }).should.be.rejected;
+//       });
+//
+//       it('should run multiple times before timeout on wait', function*() {
+//         yield nightmare
+//           .goto(fixture('navigation'))
+//           .wait(function (done) {
+//             setTimeout(() => done(null, false), 500);
+//           }).should.be.rejected;
+//       });
+//     });
+//
+//     it('should fail if navigation target is invalid', function() {
+//       return nightmare.goto('http://this-is-not-a-real-domain.tld')
+//         .then(
+//           function() {
+//             throw new Error('Navigation to an invalid domain succeeded');
+//           }, function(error) {
+//             error.should.contain.keys('message', 'code', 'url');
+//             error.code.should.be.a('number');
+//           });
+//     });
+//
+//     it('should fail if navigation target is a malformed URL', function(done) {
+//       nightmare.goto('somewhere out there')
+//         .then(function() {
+//           done(new Error('Navigation to an invalid domain succeeded'));
+//         })
+//         .catch(function(error) {
+//           done();
+//         });
+//     });
+//
+//     it('should fail if navigating to an unknown protocol', function(done) {
+//       nightmare.goto('fake-protocol://blahblahblah')
+//         .then(function() {
+//           done(new Error('Navigation to an invalid protocol succeeded'));
+//         })
+//         .catch(function(error) {
+//           done();
+//         });
+//     });
+//
+//     it('should not fail if the URL loads but a resource fails', function() {
+//       return nightmare.goto(fixture('navigation/invalid-image'));
+//     });
+//
+//     it('should not fail if a child frame fails', function() {
+//       return nightmare.goto(fixture('navigation/invalid-frame'));
+//     });
+//
+//     it('should return correct data when child frames are present', function*() {
+//       var data = yield nightmare.goto(fixture('navigation/valid-frame'));
+//       data.should.have.property('url');
+//       data.url.should.equal(fixture('navigation/valid-frame'));
+//     });
+//
+//     it('should not fail if response was a valid error (e.g. 404)', function() {
+//       return nightmare.goto(fixture('navigation/not-a-real-page'));
+//     });
+//
+//     it('should fail if the response dies in flight', function(done) {
+//       nightmare.goto(fixture('do-not-respond'))
+//         .then(function() {
+//           done(new Error('Navigation succeeded but server connection died'));
+//         })
+//         .catch(function(error) {
+//           done();
+//         });
+//     });
+//
+//     it('should not fail for a redirect', function() {
+//       return nightmare.goto(fixture('redirect?url=%2Fnavigation'));
+//     });
+//
+//     it('should fail for a redirect to an invalid URL', function(done) {
+//       nightmare.goto(
+//         fixture('redirect?url=http%3A%2F%2Fthis-is-not-a-real-domain.tld'))
+//         .then(function() {
+//           done(new Error('Navigation succeeded with redirect to bad location'));
+//         })
+//         .catch(function(error) {
+//           done();
+//         });
+//     });
+//
+//     it('should succeed properly if request handler is present', function() {
+//       Nightmare.action(
+//         'monitorRequest',
+//         function(name, options, parent, win, renderer, done) {
+//           win.webContents.session.webRequest.onBeforeRequest(
+//             ['*://localhost:*'],
+//             function(details, callback) {
+//               callback({cancel: false});
+//             }
+//           );
+//           done();
+//         },
+//         function(done) {
+//           done();
+//           return this;
+//         });
+//
+//       return Nightmare({webPreferences: {partition: 'test-partition'}})
+//         .goto(fixture('navigation'))
+//         .end();
+//     });
+//
+//     it('should fail properly if request handler is present', function(done) {
+//       Nightmare.action(
+//         'monitorRequest',
+//         function(name, options, parent, win, renderer, done) {
+//           win.webContents.session.webRequest.onBeforeRequest(
+//             ['*://localhost:*'],
+//             function(details, callback) {
+//               callback({cancel: false});
+//             }
+//           );
+//           done();
+//         },
+//         function(done) {
+//           done();
+//           return this;
+//         });
+//
+//       Nightmare({webPreferences: {partition: 'test-partition'}})
+//         .goto('http://this-is-not-a-real-domain.tld')
+//         .then(function() {
+//           done(new Error('Navigation to an invalid domain succeeded'));
+//         })
+//         .catch(function(error) {
+//           done();
+//         });
+//     });
+//
+//     it('should support javascript URLs', function*() {
+//       var gotoResult = yield nightmare
+//         .goto(fixture('navigation'))
+//         .goto('javascript:void(document.querySelector(".a").textContent="LINK");');
+//       gotoResult.should.be.an('object');
+//
+//       var linkText = yield nightmare
+//         .evaluate(function() {
+//           return document.querySelector('.a').textContent;
+//         });
+//       linkText.should.equal('LINK');
+//     });
+//
+//     it('should support javascript URLs that load pages', function*() {
+//       var data = yield nightmare
+//         .goto(fixture('navigation'))
+//         .goto(`javascript:window.location='${fixture('navigation/a.html')}'`);
+//       data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
+//       data.url.should.equal(fixture('navigation/a.html'));
+//
+//       var linkText = yield nightmare
+//         .evaluate(function() {
+//           return document.querySelector('.d').textContent;
+//         });
+//       linkText.should.equal('D');
+//     });
+//
+//     it('should fail immediately/not time out for 304 statuses', function() {
+//       return Nightmare({gotoTimeout: 500})
+//         .goto(fixture('not-modified'))
+//         .end()
+//         .then(function() {
+//           throw new Error('Navigating to a 304 should return an error');
+//         },
+//         function(error) {
+//           if (error.code === -7) {
+//             throw new Error('Navigating to a 304 should not time out');
+//           }
+//         });
+//     });
+//
+//     it('should not time out for aborted loads', function() {
+//       Nightmare.action(
+//         'abortRequests',
+//         function(name, options, parent, win, renderer, done) {
+//           win.webContents.session.webRequest.onBeforeRequest(
+//             ['*://localhost:*'],
+//             function(details, callback) {
+//               setTimeout(() => win.webContents.stop(), 0);
+//               callback({cancel: false});
+//             }
+//           );
+//           done();
+//         },
+//         function() {
+//           done();
+//         });
+//
+//       return Nightmare({gotoTimeout: 500})
+//         .goto(fixture('navigation'))
+//         .end()
+//         .then(function() {
+//           throw new Error('An aborted page load should return an error');
+//         },
+//         function(error) {
+//           if (error.code === -7) {
+//             throw new Error('Aborting a page load should not time out');
+//           }
+//         });
+//     });
+//
+//     describe('timeouts', function() {
+//       it('should time out after 30 seconds of loading', function() {
+//         // allow this test to go particularly long
+//         this.timeout(40000);
+//         return nightmare.goto(fixture('wait')).should.be.rejected
+//           .then(function(error) {
+//             error.code.should.equal(-7);
+//           });
+//       });
+//
+//       it('should allow custom goto timeout on the constructor', function() {
+//         var startTime = Date.now();
+//         return Nightmare({gotoTimeout: 1000}).goto(fixture('wait')).end()
+//           .should.be.rejected
+//           .then(function(error) {
+//             // allow a few extra seconds for browser startup
+//             (startTime - Date.now()).should.be.below(3000);
+//           });
+//       });
+//
+//       it('should allow a timeout to succeed if DOM loaded', function() {
+//         return Nightmare({gotoTimeout: 1000})
+//           .goto(fixture('navigation/hanging-resources.html'))
+//           .end()
+//           .then(function(data) {
+//             data.details.should.include('1000 ms');
+//           });
+//       });
+//
+//       it('should allow actions on a hanging page', function() {
+//         return Nightmare({gotoTimeout: 500})
+//           .goto(fixture('navigation/hanging-resources.html'))
+//           .evaluate(() => document.title)
+//           .end()
+//           .then(function(title) {
+//             title.should.equal('Hanging resource load');
+//           });
+//       });
+//
+//       it('should allow loading a new page after timing out', function() {
+//         nightmare.end().then();
+//         nightmare = Nightmare({gotoTimeout: 1000});
+//         return nightmare.goto(fixture('wait')).should.be.rejected
+//           .then(function() {
+//             return nightmare.goto(fixture('navigation'));
+//           });
+//       });
+//
+//       it('should allow for timeouts for non-goto loads', function*() { // ###
+//         this.timeout(40000);
+//         var nightmare = Nightmare({loadTimeout: 30000});
+//         yield nightmare
+//           .goto(fixture('navigation'))
+//           .click('#never-ends');
+//
+//         yield nightmare.end();
+//       });
+//     });
+//   });
+//
+//   describe('evaluation', function () {
+//     var nightmare;
+//
+//     beforeEach(function() {
+//       nightmare = Nightmare();
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should get the title', function*() {
+//       var title = yield nightmare
+//         .goto(fixture('evaluation'))
+//         .title();
+//       title.should.eql('Evaluation');
+//     });
+//
+//     it('should get the url', function*() {
+//       var url = yield nightmare
+//         .goto(fixture('evaluation'))
+//         .url();
+//       url.should.have.string(fixture('evaluation'));
+//     });
+//
+//     it('should get the path', function*() {
+//       var path = yield nightmare
+//         .goto(fixture('evaluation'))
+//         .path();
+//       var formalUrl = fixture('evaluation') + '/';
+//
+//       formalUrl.should.have.string(path);
+//     });
+//
+//     it('should check if the selector exists', function*() {
+//       // existent element
+//       var exists = yield nightmare
+//         .goto(fixture('evaluation'))
+//         .exists('h1.title');
+//       exists.should.be.true;
+//
+//       // non-existent element
+//       exists = yield nightmare.exists('a.blahblahblah');
+//       exists.should.be.false;
+//     });
+//
+//     it('should check if an element is visible', function*() {
+//       // visible element
+//       var visible = yield nightmare
+//         .goto(fixture('evaluation'))
+//         .visible('h1.title');
+//       visible.should.be.true;
+//
+//       // hidden element
+//       visible = yield nightmare
+//         .visible('.hidden');
+//       visible.should.be.false;
+//
+//         // non-existent element
+//       visible = yield nightmare
+//         .visible('#asdfasdfasdf');
+//       visible.should.be.false;
+//     });
+//
+//     it('should check if an element is visible', function*() {
+//       // visible element
+//       var visible = yield nightmare
+//         .goto(fixture('evaluation'))
+//         .visible('h1.title');
+//       visible.should.be.true;
+//
+//       // hidden element
+//       visible = yield nightmare
+//         .visible('.hidden');
+//       visible.should.be.false;
+//
+//       // non-existent element
+//       visible = yield nightmare
+//         .visible('#asdfasdfasdf');
+//       visible.should.be.false;
+//     });
+//
+//     it('should evaluate javascript on the page, with parameters', function*() {
+//       var title = yield nightmare
+//         .goto(fixture('evaluation'))
+//         .evaluate(function (parameter) {
+//           return document.title + ' -- ' + parameter;
+//         }, 'testparameter');
+//       title.should.equal('Evaluation -- testparameter');
+//     });
+//
+//     it('should capture invalid evaluate fn', function() {
+//       return nightmare
+//         .goto(fixture('evaluation'))
+//         .evaluate('not_a_function')
+//         .should.be.rejected;
+//     });
+//
+//     describe('asynchronous', function(){
+//       it('should allow for asynchronous evaluation with a callback', function*() {
+//         var asyncValue = yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function(done) {
+//             setTimeout(() => done(null, 'nightmare'), 1000);
+//           });
+//
+//           asyncValue.should.equal('nightmare');
+//       });
+//       it('should allow for arguments with asynchronous evaluation with a callback', function*() {
+//         var asyncValue = yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function(str, done) {
+//             setTimeout(() => done(null, str), 1000);
+//           }, 'nightmare');
+//
+//           asyncValue.should.equal('nightmare');
+//       });
+//
+//       it('should allow for errors in asynchronous evaluation with a callback', function*() {
+//         yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function(done) {
+//             setTimeout(() => done(new Error('nightmare')), 1000);
+//           }).should.be.rejected;
+//       });
+//
+//       it('should allow for timeouts in asynchronous evaluation with a callback', function*() {
+//         this.timeout(40000);
+//         yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function(done) {
+//             //don't call done
+//           }).should.be.rejected;
+//       });
+//
+//       it('should allow for asynchronous evaluation with a promise', function*() {
+//         var asyncValue =  yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function() {
+//             return new Promise(resolve => {
+//               setTimeout(() => resolve('nightmare'), 1000);
+//             });
+//           })
+//
+//           asyncValue.should.equal('nightmare');
+//       });
+//
+//       it('should allow for arguments with asynchronous evaluation with a promise', function*() {
+//         var asyncValue =  yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function(str) {
+//             return new Promise(resolve => {
+//               setTimeout(() => resolve(str), 1000);
+//             });
+//           }, 'nightmare')
+//
+//           asyncValue.should.equal('nightmare');
+//       });
+//
+//       it('should allow for errors in asynchronous evaluation with a promise', function*() {
+//         yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function() {
+//             return new Promise((resolve, reject) => {
+//               setTimeout(() => reject(new Error('nightmare')), 1000);
+//             });
+//           }).should.be.rejected;
+//       });
+//
+//       it('should allow for timeouts in asynchronous evaluation with a promise', function*() {
+//         this.timeout(40000);
+//         yield nightmare
+//           .goto(fixture('evaluation'))
+//           .evaluate(function() {
+//             return new Promise((resolve, reject) => {
+//               return 'nightmare';
+//             });
+//           }).should.be.rejected;
+//       });
+//     });
+//   });
+//
+//   describe('manipulation', function () {
+//     var nightmare;
+//
+//     beforeEach(function() {
+//       nightmare = Nightmare();
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should inject javascript onto the page', function*() {
+//       var globalNumber = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .inject('js', 'test/files/globals.js')
+//         .evaluate(function () {
+//           return globalNumber;
+//         });
+//       globalNumber.should.equal(7);
+//
+//       var numAnchors = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .inject('js', 'test/files/jquery-2.1.1.min.js')
+//         .evaluate(function () {
+//           return $('h1').length;
+//         });
+//       numAnchors.should.equal(1);
+//     });
+//
+//     it('should inject javascript onto the page ending with a comment', function*() {
+//       var globalNumber = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .inject('js', 'test/files/globals.js')
+//         .evaluate(function () {
+//           return globalNumber;
+//         });
+//       globalNumber.should.equal(7);
+//
+//       var numAnchors = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .inject('js', 'test/files/jquery-1.9.0.min.js')
+//         .evaluate(function () {
+//           return $('h1').length;
+//         });
+//       numAnchors.should.equal(1);
+//     });
+//
+//     it('should inject css onto the page', function*() {
+//       var color = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .inject('js', 'test/files/jquery-2.1.1.min.js')
+//         .inject('css', 'test/files/test.css')
+//         .evaluate(function () {
+//           return $('body').css('background-color');
+//         });
+//       color.should.equal('rgb(255, 0, 0)');
+//     });
+//
+//     it('should not inject unsupported types onto the page', function*() {
+//       var color = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .inject('js', 'test/files/jquery-2.1.1.min.js')
+//         .inject('pdf', 'test/files/test.css')
+//         .evaluate(function () {
+//           return $('body').css('background-color');
+//         });
+//       color.should.not.equal('rgb(255, 0, 0)');
+//     });
+//
+//     it('should type', function*() {
+//       var input = 'nightmare'
+//       var events = input.length * 3
+//
+//       var value = yield nightmare
+//         .on('console', function (type, input, message) {
+//           if (type === 'log') events--;
+//         })
+//         .goto(fixture('manipulation'))
+//         .type('input[type=search]', input)
+//         .evaluate(function() {
+//           return document.querySelector('input[type=search]').value;
+//         });
+//
+//       value.should.equal('nightmare');
+//       events.should.equal(0);
+//     });
+//
+//     it('should type integer', function* () {
+//         var input = 10;
+//         var events = input.toString().length * 3;
+//
+//         var value = yield nightmare
+//           .on('console', function (type, input, message) {
+//             if (type === 'log') events--;
+//           })
+//           .goto(fixture('manipulation'))
+//           .type('input[type=search]', input)
+//           .evaluate(function() {
+//             return document.querySelector('input[type=search]').value;
+//           });
+//
+//         value.should.equal('10');
+//         events.should.equal(0);
+//     });
+//
+//
+//     it('should type object', function* () {
+//         var input = {
+//           foo: 'bar'
+//         };
+//         var events = input.toString().length * 3;
+//
+//         var value = yield nightmare
+//           .on('console', function (type, input, message) {
+//             if (type === 'log') events--;
+//           })
+//           .goto(fixture('manipulation'))
+//           .type('input[type=search]', input)
+//           .evaluate(function() {
+//             return document.querySelector('input[type=search]').value;
+//           });
+//
+//         value.should.equal('[object Object]');
+//         events.should.equal(0);
+//     });
+//
+//     it('should clear inputs', function*() {
+//       var input = 'nightmare'
+//       var events = input.length * 3
+//
+//       var value = yield nightmare
+//         .on('console', function (type, input, message) {
+//           if (type === 'log') events--;
+//         })
+//         .goto(fixture('manipulation'))
+//         .type('input[type=search]', input)
+//         .type('input[type=search]')
+//         .evaluate(function() {
+//           return document.querySelector('input[type=search]').value;
+//         });
+//
+//       value.should.equal('');
+//       events.should.equal(0);
+//     });
+//
+//     it('should support inserting text', function*() {
+//       var input = 'nightmare insert typing'
+//
+//       var value = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .insert('input[type=search]', input)
+//         .evaluate(function() {
+//           return document.querySelector('input[type=search]').value;
+//         });
+//
+//       value.should.equal('nightmare insert typing');
+//     })
+//
+//     it('should support clearing inserted text', function*() {
+//
+//       var value = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .insert('input[type=search]')
+//         .evaluate(function() {
+//           return document.querySelector('input[type=search]').value;
+//         });
+//
+//       value.should.equal('');
+//     })
+//
+//     it('should not type in a nonexistent selector', function(){
+//       return nightmare
+//         .goto(fixture('manipulation'))
+//         .type('does-not-exist', 'nightmare')
+//         .should.be.rejected;
+//     });
+//
+//     it('should not insert in a nonexistent selector', function(){
+//       return nightmare
+//         .goto(fixture('manipulation'))
+//         .insert('does-not-exist', 'nightmare')
+//         .should.be.rejected;
+//     });
+//
+//     it('should blur the active element when something is clicked', function*() {
+//       var isBody = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .type('input[type=search]', 'test')
+//         .click('p')
+//         .evaluate(function() {
+//           return document.activeElement === document.body;
+//         });
+//       isBody.should.be.true;
+//     });
+//
+//     it('should allow for clicking on elements with attribute selectors', function*() {
+//       yield nightmare
+//         .goto(fixture('manipulation'))
+//         .click('div[data-test="test"]')
+//     });
+//
+//     it('should not allow for code injection with .click()', function(done){
+//       var exception;
+//       nightmare
+//         .goto(fixture('manipulation'))
+//         .click('"]\'); document.title = \'injected title\'; (\'"')
+//         .catch((e) => exception = e)
+//         .then(()=> nightmare.title())
+//         .then((title) => {
+//           exception.should.exist;
+//           title.should.equal('Manipulation');
+//           done();
+//         });
+//     });
+//
+//     it('should not fail if selector no longer exists to blur after typing', function*() {
+//       yield nightmare
+//         .on('console', function(){ console.log(arguments)})
+//         .goto(fixture('manipulation'))
+//         .type('input#disappears', 'nightmare');
+//     });
+//
+//     it('should type and click', function*() {
+//       var title = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .type('input[type=search]', 'nightmare')
+//         .click('button[type=submit]')
+//         .wait(500)
+//         .title();
+//
+//       title.should.equal('Manipulation - Results');
+//     });
+//
+//     it('should type and click several times', function*() {
+//       var title = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .type('input[type=search]', 'github nightmare')
+//         .click('button[type=submit]')
+//         .wait(500)
+//         .click('a')
+//         .wait(500)
+//         .title();
+//       title.should.equal('Manipulation - Result - Nightmare');
+//     });
+//
+//     it('should checkbox', function*() {
+//       var checkbox = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .check('input[type=checkbox]')
+//         .evaluate(function () {
+//           return document.querySelector('input[type=checkbox]').checked;
+//         });
+//       checkbox.should.be.true;
+//     });
+//
+//     it('should uncheck', function*() {
+//       var checkbox = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .check('input[type=checkbox]')
+//         .uncheck('input[type=checkbox]')
+//         .evaluate(function () {
+//           return document.querySelector('input[type=checkbox]').checked;
+//         });
+//       checkbox.should.be.false;
+//     });
+//
+//     it('should select', function*() {
+//       var select = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .select('select', 'b')
+//         .evaluate(function () {
+//           return document.querySelector('select').value;
+//         });
+//       select.should.equal('b');
+//     });
+//
+//     it('should scroll to specified position', function*() {
+//       // start at the top
+//       var coordinates = yield nightmare
+//         .viewport(320, 320)
+//         .goto(fixture('manipulation'))
+//         .evaluate(function () {
+//           return {
+//             top: document.body.scrollTop,
+//             left: document.body.scrollLeft
+//           };
+//         });
+//       coordinates.top.should.equal(0);
+//       coordinates.left.should.equal(0);
+//
+//       // scroll down a bit
+//       coordinates = yield nightmare
+//         .scrollTo(100, 50)
+//         .evaluate(function () {
+//           return {
+//             top: document.body.scrollTop,
+//             left: document.body.scrollLeft
+//           };
+//         });
+//       coordinates.top.should.equal(100);
+//       coordinates.left.should.equal(50);
+//     });
+//
+//     it('should hover over an element', function*() {
+//       var color = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .mouseover('h1')
+//         .evaluate(function () {
+//           var element = document.querySelector('h1');
+//           return element.style.background;
+//         });
+//       color.should.equal('rgb(102, 255, 102)');
+//     });
+//
+//     it('should mousedown on an element', function*() {
+//       var color = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .mousedown('h1')
+//         .evaluate(function () {
+//           var element = document.querySelector('h1');
+//           return element.style.background;
+//         });
+//       color.should.equal('rgb(255, 0, 0)');
+//     });
+//   });
+//
+//   describe('cookies', function() {
+//     var nightmare;
+//
+//     beforeEach(function() {
+//       nightmare = Nightmare({webPreferences: {partition: 'test-partition'}})
+//         .goto(fixture('cookie'));
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('.set(name, value) & .get(name)', function*() {
+//       var cookies = nightmare.cookies
+//
+//       yield cookies.set('hi', 'hello')
+//       var cookie = yield cookies.get('hi')
+//
+//       cookie.name.should.equal('hi')
+//       cookie.value.should.equal('hello')
+//       cookie.path.should.equal('/')
+//       cookie.secure.should.equal(false)
+//     })
+//
+//     it('.set(obj) & .get(name)', function*() {
+//       var cookies = nightmare.cookies
+//
+//       yield cookies.set({
+//         name: 'nightmare',
+//         value: 'rocks',
+//         path: '/cookie'
+//       })
+//       var cookie = yield cookies.get('nightmare')
+//
+//       cookie.name.should.equal('nightmare')
+//       cookie.value.should.equal('rocks')
+//       cookie.path.should.equal('/cookie')
+//       cookie.secure.should.equal(false)
+//     })
+//
+//     it('.set([cookie1, cookie2]) & .get()', function*() {
+//       var cookies = nightmare.cookies
+//
+//       yield cookies.set([
+//         {
+//           name: 'hi',
+//           value: 'hello',
+//           path: '/'
+//         },
+//         {
+//           name: 'nightmare',
+//           value: 'rocks',
+//           path: '/cookie'
+//         }
+//       ])
+//
+//       var cookies = yield cookies.get()
+//       cookies.length.should.equal(2)
+//
+//       // sort in case they come in a different order
+//       cookies = cookies.sort(function (a, b) {
+//         if (a.name > b.name) return 1
+//         if (a.name < b.name) return -1
+//         return 0
+//       })
+//
+//       cookies[0].name.should.equal('hi')
+//       cookies[0].value.should.equal('hello')
+//       cookies[0].path.should.equal('/')
+//       cookies[0].secure.should.equal(false)
+//
+//       cookies[1].name.should.equal('nightmare')
+//       cookies[1].value.should.equal('rocks')
+//       cookies[1].path.should.equal('/cookie')
+//       cookies[1].secure.should.equal(false)
+//     })
+//
+//     it('.set([cookie1, cookie2]) & .get(query)', function*() {
+//       var cookies = nightmare.cookies
+//
+//       yield cookies.set([
+//         {
+//           name: 'hi',
+//           value: 'hello',
+//           path: '/'
+//         },
+//         {
+//           name: 'nightmare',
+//           value: 'rocks',
+//           path: '/cookie'
+//         }
+//       ])
+//
+//       var cookies = yield cookies.get({ path: '/cookie'})
+//       cookies.length.should.equal(1)
+//
+//       cookies[0].name.should.equal('nightmare')
+//       cookies[0].value.should.equal('rocks')
+//       cookies[0].path.should.equal('/cookie')
+//       cookies[0].secure.should.equal(false)
+//     })
+//
+//     it('.set([cookie]) & .clear(name) & .get(query)', function*() {
+//       var cookies = nightmare.cookies
+//
+//       yield cookies.set([
+//         {
+//           name: 'hi',
+//           value: 'hello',
+//           path: '/'
+//         },
+//         {
+//           name: 'nightmare',
+//           value: 'rocks',
+//           path: '/cookie'
+//         }
+//       ])
+//
+//       yield cookies.clear('nightmare');
+//
+//       var cookies = yield cookies.get({ path: '/cookie' });
+//
+//       cookies.length.should.equal(0);
+//     });
+//
+//     it('.set([cookie]) & .clear() & .get()', function*() {
+//       var cookies = nightmare.cookies
+//
+//       yield cookies.set([
+//         {
+//           name: 'hi',
+//           value: 'hello',
+//           path: '/'
+//         },
+//         {
+//           name: 'nightmare',
+//           value: 'rocks',
+//           path: '/cookie'
+//         }
+//       ])
+//
+//       yield cookies.clear();
+//
+//       var cookies = yield cookies.get();
+//
+//       cookies.length.should.equal(0);
+//     })
+//
+//     it('.set([cookie]) & .clearAll() & .get()', function*() {
+//       yield nightmare.cookies.set([
+//         {
+//           name: 'hi',
+//           value: 'hello',
+//           path: '/'
+//         },
+//         {
+//           name: 'nightmare',
+//           value: 'rocks',
+//           path: '/cookie'
+//         }
+//       ]);
+//
+//       yield nightmare.goto(fixture('simple'));
+//
+//       yield nightmare.cookies.set([
+//         {
+//           name: 'hi',
+//           value: 'hello',
+//           path: '/'
+//         },
+//         {
+//           name: 'nightmare',
+//           value: 'rocks',
+//           path: '/cookie'
+//         }
+//       ]);
+//
+//
+//       yield nightmare.cookies.clearAll();
+//
+//       var cookies = yield nightmare.cookies.get();
+//       cookies.length.should.equal(0);
+//
+//       yield nightmare.goto(fixture('cookie'))
+//
+//       cookies = yield nightmare.cookies.get();
+//       cookies.length.should.equal(0);
+//     })
+//   });
+//
+//   describe('rendering', function () {
+//     var nightmare;
+//
+//     before(function(done) {
+//       mkdirp(tmp_dir, done)
+//     })
+//
+//     after(function(done) {
+//       rimraf(tmp_dir, done)
+//     })
+//
+//     beforeEach(function() {
+//       nightmare = Nightmare();
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should take a screenshot', function*() {
+//       yield nightmare
+//         .goto('https://github.com/')
+//         .screenshot(tmp_dir+'/test.png');
+//       var stats = fs.statSync(tmp_dir+'/test.png');
+//       stats.size.should.be.at.least(1000);
+//     });
+//
+//     it('should buffer a screenshot', function*() {
+//       var image = yield nightmare
+//         .goto('https://github.com')
+//         .screenshot();
+//       Buffer.isBuffer(image).should.be.true;
+//       image.length.should.be.at.least(1000);
+//     });
+//
+//     it('should take a clipped screenshot', function*() {
+//       yield nightmare
+//         .goto('https://github.com/')
+//         .screenshot(tmp_dir+'/test-clipped.png', {
+//           x: 200,
+//           y: 100,
+//           width: 100,
+//           height: 100
+//         });
+//       var stats = fs.statSync(tmp_dir+'/test.png');
+//       var statsClipped = fs.statSync(tmp_dir+'/test-clipped.png');
+//       statsClipped.size.should.be.at.least(300);
+//       stats.size.should.be.at.least(10*statsClipped.size);
+//     });
+//
+//     it('should buffer a clipped screenshot', function*() {
+//       var image = yield nightmare
+//         .goto('https://github.com')
+//         .screenshot({
+//           x: 200,
+//           y: 100,
+//           width: 100,
+//           height: 100
+//         });
+//       Buffer.isBuffer(image).should.be.true;
+//       image.length.should.be.at.least(300);
+//     });
+//
+//     // repeat this test 3 times, since the concern here is non-determinism in
+//     // the timing accuracy of screenshots -- it might pass once, but likely not
+//     // several times in a row.
+//     for (var i = 0; i < 3; i++) {
+//       it('should screenshot an up-to-date image of the page (' + i + ')', function*() {
+//         var image = yield nightmare
+//           .goto('about:blank')
+//           .viewport(100, 100)
+//           .evaluate(function() { document.body.style.background = '#900'; })
+//           .evaluate(function() { document.body.style.background = '#090'; })
+//           .screenshot();
+//
+//         var png = new PNG();
+//         var imageData = yield png.parse.bind(png, image);
+//         var firstPixel = Array.from(imageData.data.slice(0, 3));
+//         firstPixel.should.deep.equal([0, 153, 0]);
+//       });
+//     }
+//
+//     it('should screenshot an an idle page', function*() {
+//       var image = yield nightmare
+//         .goto('about:blank')
+//         .viewport(100, 100)
+//         .evaluate(function() { document.body.style.background = '#900'; })
+//         .evaluate(function() { document.body.style.background = '#090'; })
+//         .wait(1000)
+//         .screenshot();
+//
+//       var png = new PNG();
+//       var imageData = yield png.parse.bind(png, image);
+//       var firstPixel = Array.from(imageData.data.slice(0, 3));
+//       firstPixel.should.deep.equal([0, 153, 0]);
+//     });
+//
+//     it('should not subscribe to frames until necessary', function() {
+//       var didSubscribe = false;
+//       var FrameManager = require('../lib/frame-manager.js');
+//       var manager = FrameManager({
+//         webContents: {
+//           beginFrameSubscription: function() { didSubscribe = true; },
+//           endFrameSubscription: function() {},
+//           executeJavaScript: function() {}
+//         }
+//       });
+//       didSubscribe.should.be.false;
+//     });
+//
+//     it('should load jquery correctly', function*() {
+//       var loaded = yield nightmare
+//         .goto(fixture('rendering'))
+//         .wait(2000)
+//         .evaluate(function() {
+//           return !!window.jQuery;
+//         });
+//       loaded.should.be.at.least(true);
+//     });
+//
+//     it('should render fonts correctly', function*() {
+//       yield nightmare
+//         .goto(fixture('rendering'))
+//         .wait(2000)
+//         .screenshot(tmp_dir+'/font-rendering.png');
+//       var stats = fs.statSync(tmp_dir+'/font-rendering.png');
+//       stats.size.should.be.at.least(1000);
+//     });
+//
+//     it('should save as html', function*() {
+//       yield nightmare
+//         .goto(fixture('manipulation'))
+//         .html(tmp_dir+'/test.html');
+//       var stats = fs.statSync(tmp_dir+'/test.html');
+//       stats.should.be.ok;
+//     });
+//
+//     it('should render a PDF', function*() {
+//       yield nightmare
+//         .goto(fixture('manipulation'))
+//         .pdf(tmp_dir+'/test.pdf');
+//       var stats = fs.statSync(tmp_dir+'/test.pdf');
+//       stats.size.should.be.at.least(1000);
+//     });
+//
+//     it('should accept options to render a PDF', function*() {
+//       yield nightmare
+//         .goto(fixture('manipulation'))
+//         .pdf(tmp_dir+'/test2.pdf', {printBackground: false});
+//       var stats = fs.statSync(tmp_dir+'/test2.pdf');
+//       stats.size.should.be.at.least(1000);
+//     });
+//
+//     it('should return a buffer from a PDF with no path', function*() {
+//       var buf = yield nightmare
+//         .goto(fixture('manipulation'))
+//         .pdf({printBackground: false});
+//
+//       var isBuffer = Buffer.isBuffer(buf);
+//
+//       buf.length.should.be.at.least(1000);
+//       isBuffer.should.be.true;
+//     });
+//   });
+//
+//   describe('referer', function() {
+//     var nightmare;
+//
+//     beforeEach(function() {
+//       nightmare = Nightmare({webPreferences: {partition: 'test-partition'}});
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should return referer from headers', function*() {
+//       var referer = 'http://my-referer.tld/';
+//       var returnedReferer = yield nightmare
+//         .goto(fixture('referer'), {
+//           'Referer': referer
+//         })
+//         .evaluate(function () {
+//           return document.body.innerText;
+//         })
+//         ;
+//
+//       referer.should.be.equal(returnedReferer.trim());
+//     })
+//   });
+//
+//   describe('events', function () {
+//     var nightmare;
+//
+//     beforeEach(function() {
+//       nightmare = Nightmare();
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should fire an event on page load complete', function*() {
+//       var fired = false;
+//       nightmare
+//         .on('did-finish-load', function () {
+//           fired = true;
+//         });
+//       yield nightmare
+//         .goto(fixture('events'));
+//       fired.should.be.true;
+//     });
+//
+//     it('should fire an event on javascript error', function*() {
+//       var fired = false;
+//       nightmare
+//         .on('page', function (type, errorMessage, errorStack) {
+//           if (type === 'error') {
+//             fired = true;
+//           }
+//         });
+//       yield nightmare
+//         .goto(fixture('events'));
+//       fired.should.be.true;
+//     });
+//
+//     it('should fire an event on javascript console.log', function*() {
+//       var log = '';
+//
+//       nightmare.on('console', function (type, str) {
+//         if (type === 'log') log = str
+//       });
+//
+//       yield nightmare.goto(fixture('events'));
+//       log.should.equal('my log');
+//
+//       yield nightmare.click('button')
+//       log.should.equal('clicked');
+//
+//     });
+//
+//     it('should fire an event on page load failure', function*() {
+//       var fired = false;
+//       nightmare
+//         .on('did-fail-load', function () {
+//           fired = true;
+//         });
+//       try {
+//         yield nightmare
+//           .goto('https://alskdjfasdfuuu.com');
+//       }
+//       catch(error) {}
+//       fired.should.be.true;
+//     });
+//
+//     it('should fire an event on javascript window.alert', function*(){
+//       var alert = '';
+//       nightmare.on('page', function(type, message){
+//         if (type === 'alert') {
+//           alert = message;
+//         }
+//       });
+//
+//       yield nightmare
+//         .goto(fixture('events'))
+//         .evaluate(function(){
+//           alert('my alert');
+//         });
+//       alert.should.equal('my alert');
+//     });
+//
+//     it('should fire an event on javascript window.prompt', function*(){
+//       var prompt = '';
+//       var response = ''
+//       nightmare.on('page', function(type, message, res){
+//         if (type === 'prompt') {
+//           prompt = message;
+//           response = res
+//         }
+//       });
+//
+//       yield nightmare
+//         .goto(fixture('events'))
+//         .evaluate(function(){
+//           prompt('my prompt', 'hello!');
+//         });
+//       prompt.should.equal('my prompt');
+//       response.should.equal('hello!');
+//     });
+//
+//     it('should fire an event on javascript window.confirm', function*(){
+//       var confirm = '';
+//       var response = ''
+//       nightmare.on('page', function(type, message, res){
+//         if (type === 'confirm') {
+//           confirm = message;
+//           response = res
+//         }
+//       });
+//
+//       yield nightmare
+//         .goto(fixture('events'))
+//         .evaluate(function(){
+//           confirm('my confirm', 'hello!');
+//         });
+//       confirm.should.equal('my confirm');
+//       response.should.equal('hello!');
+//     });
+//
+//     it('should only fire once when using once', function*() {
+//       var events = 0;
+//       nightmare.once('page', function(type, message) {
+//         events++;
+//       });
+//
+//       yield nightmare
+//         .goto(fixture('events'))
+//       events.should.equal(1);
+//     });
+//
+//     it('should remove event listener', function*() {
+//       var events = 0;
+//       var handler = function(type, message) {
+//         if (type === 'alert') {
+//           events++;
+//         }
+//       };
+//
+//       nightmare.on('page', handler);
+//
+//       yield nightmare
+//         .goto(fixture('events'))
+//         .evaluate(function(){
+//           alert('alert one');
+//         });
+//
+//       nightmare.removeListener('page', handler);
+//
+//       yield nightmare
+//         .evaluate(function(){
+//           alert('alert two');
+//         });
+//
+//       events.should.equal(1);
+//     });
+//   });
+//
+//   describe('options', function () {
+//     var nightmare;
+//     var server;
+//
+//     before(function(done) {
+//       // set up an HTTPS server using self-signed certificates -- Nightmare
+//       // will only be able to talk to it if 'ignore-certificate-errors' is set.
+//       server = https.createServer({
+//         key: fs.readFileSync(path.join(__dirname, 'files', 'server.key')),
+//         cert: fs.readFileSync(path.join(__dirname, 'files', 'server.crt'))
+//       }, function(request, response) {
+//         response.end('ok\n');
+//       }).listen(0, 'localhost', function() {
+//         var address = server.address();
+//         server.url = `https://${address.address}:${address.port}`;
+//         done();
+//       });
+//     });
+//
+//     after(function() {
+//       server.close();
+//       server = null;
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should set useragent', function* () {
+//       nightmare = new Nightmare();
+//       var useragent = yield nightmare
+//         .useragent('firefox')
+//         .goto(fixture('options'))
+//         .evaluate(function () {
+//           return window.navigator.userAgent;
+//         });
+//       useragent.should.eql('firefox');
+//     });
+//
+//     it('should wait and fail with waitTimeout', function() {
+//       nightmare = Nightmare({waitTimeout: 254});
+//       return nightmare
+//         .goto(fixture('navigation'))
+//         .wait('foobar')
+//         .should.be.rejected;
+//     });
+//
+//     it('should wait and fail with waitTimeout and a ms wait time', function() {
+//       nightmare = Nightmare({waitTimeout: 254});
+//       return nightmare
+//         .goto(fixture('navigation'))
+//         .wait(1000)
+//         .should.be.rejected;
+//     });
+//
+//     it('should wait and fail with waitTimeout with queued functions', function() {
+//       nightmare = Nightmare({waitTimeout: 254});
+//       return nightmare
+//         .goto(fixture('navigation'))
+//         .wait('foobar')
+//         .exists('baz')
+//         .should.be.rejected;
+//     });
+//
+//     it('should set authentication', function*() {
+//       nightmare = Nightmare();
+//       var data = yield nightmare
+//         .authentication('my', 'auth')
+//         .goto(fixture('auth'))
+//         .evaluate(function () {
+//           return JSON.parse(document.querySelector('pre').innerHTML);
+//         });
+//       data.should.eql({ name: 'my', pass: 'auth' });
+//     });
+//
+//     it('should fail on authentication failure', function*() {
+//       nightmare = Nightmare();
+//       var data = yield nightmare
+//         .authentication('my', 'wrong')
+//         .goto(fixture('auth'))
+//         .should.be.rejected;
+//     });
+//
+//     it('should be able to update authentication', function*(){
+//       nightmare = Nightmare();
+//       var data = yield nightmare
+//         .authentication('my', 'auth')
+//         .goto(fixture('auth'))
+//         .authentication('my2', 'auth2')
+//         .goto(fixture('auth2'))
+//         .evaluate(function () {
+//           return JSON.parse(document.querySelector('pre').innerHTML);
+//         });
+//       data.should.eql({ name: 'my2', pass: 'auth2' });
+//     });
+//
+//     it('should set viewport', function*() {
+//       var size = { width: 400, height: 300, useContentSize: true };
+//       nightmare = Nightmare(size);
+//       var result = yield nightmare
+//         .goto(fixture('options'))
+//         .evaluate(function () {
+//           return {
+//             width: window.innerWidth,
+//             height: window.innerHeight
+//           };
+//         });
+//       result.width.should.eql(size.width);
+//       result.height.should.eql(size.height);
+//     });
+//
+//     it('should set a single header', function*() {
+//       nightmare = Nightmare();
+//       var headers = yield nightmare
+//         .header('X-Nightmare-Header', 'hello world')
+//         .goto(fixture('headers'))
+//         .evaluate(function () {
+//           return JSON.parse(document.querySelector('pre').innerHTML);
+//         });
+//       headers['x-nightmare-header'].should.equal('hello world');
+//     });
+//
+//     it('should set all headers', function*() {
+//       nightmare = Nightmare();
+//       var headers = yield nightmare
+//         .header({ 'X-Foo': 'foo', 'X-Bar': 'bar'})
+//         .goto(fixture('headers'))
+//         .evaluate(function () {
+//           return JSON.parse(document.querySelector('pre').innerHTML);
+//         });
+//       headers['x-foo'].should.equal('foo');
+//       headers['x-bar'].should.equal('bar');
+//     });
+//
+//     it('should set headers for that request', function*() {
+//       nightmare = Nightmare();
+//       var headers = yield nightmare
+//         .goto(fixture('headers'), { 'X-Nightmare-Header': 'hello world' })
+//         .evaluate(function () {
+//           return JSON.parse(document.querySelector('pre').innerHTML);
+//         });
+//       headers['x-nightmare-header'].should.equal('hello world');
+//     });
+//
+//     it('should allow webPreferences settings', function*() {
+//       nightmare = Nightmare({webPreferences: {webSecurity: false}});
+//       var result = yield nightmare
+//         .goto(fixture('options'))
+//         .evaluate(function () {
+//           return document.getElementById('example-iframe').contentDocument;
+//         });
+//
+//       result.should.be.ok;
+//     });
+//
+//     it('should be constructable with paths', function*() {
+//       nightmare = Nightmare({ paths:{ userData : __dirname } });
+//       nightmare.should.be.ok;
+//     });
+//
+//     it('should be constructable with switches', function*() {
+//       nightmare = Nightmare({
+//         switches: {
+//           // empty string and non-string values all represent no value
+//           'ignore-certificate-errors': null,
+//           'touch-events': ''
+//         }
+//       });
+//       nightmare.should.be.ok;
+//       var touchEvents = yield nightmare
+//         .goto(server.url)
+//         .evaluate(function() {
+//           return 'ontouchstart' in window;
+//         });
+//       touchEvents.should.be.true;
+//     });
+//
+//     it('should support switches with values', function*() {
+//       nightmare = Nightmare({ switches: { 'force-device-scale-factor': '5' } });
+//       nightmare.should.be.ok;
+//       var scaleFactor = yield nightmare
+//         .goto('about:blank')
+//         .evaluate(function() {
+//           return window.devicePixelRatio;
+//         });
+//       scaleFactor.should.equal(5);
+//     });
+//
+//     it('should allow to use external Electron', function*() {
+//       nightmare = Nightmare({ electronPath: require('electron') });
+//       nightmare.should.be.ok;
+//     });
+//
+//     it('should allow to use external Promise', function*() {
+//       nightmare = Nightmare({ Promise: require('bluebird') });
+//       nightmare.should.be.ok;
+//       const thenPromise = nightmare.goto('about:blank').then();
+//       thenPromise.should.be.an.instanceof(require('bluebird'));
+//       yield thenPromise;
+//       const catchPromise = nightmare.goto('about:blank').catch();
+//       catchPromise.should.be.an.instanceof(require('bluebird'));
+//       yield catchPromise;
+//       const endPromise = nightmare.goto('about:blank').end().then();
+//       endPromise.constructor.should.equal(require('bluebird'));
+//       endPromise.should.be.an.instanceof(require('bluebird'));
+//       yield endPromise;
+//     });
+//   });
+//
+//   describe('Nightmare.Promise', function() {
+//     var nightmare;
+//     afterEach(function*() {
+//       // `withDeprecationTracking()` messes w/ prototype constructor references
+//       Nightmare.Promise = require('..').Promise = Promise;
+//       yield nightmare.end();
+//     });
+//
+//     it('should default to native Promise', function*() {
+//       Nightmare.Promise.should.equal(Promise);
+//       nightmare = Nightmare();
+//       nightmare.should.be.ok;
+//       var thenPromise = nightmare.goto('about:blank').then();
+//       thenPromise.should.be.an.instanceof(Promise);
+//       yield thenPromise;
+//     });
+//
+//     it('should override default Promise library', function*() {
+//       // `withDeprecationTracking()` messes w/ prototype constructor references
+//       Nightmare.Promise = require('..').Promise = require('bluebird');
+//       Nightmare.Promise.should.equal(require('bluebird'));
+//       nightmare = Nightmare();
+//       nightmare.should.be.ok;
+//       var thenPromise = nightmare.goto('about:blank').then();
+//       thenPromise.should.be.an.instanceof(require('bluebird'));
+//       yield thenPromise;
+//     });
+//
+//     it('should not override per-instance Promise library', function*() {
+//       Nightmare.Promise.should.equal(Promise);
+//       nightmare = Nightmare({ Promise: require('bluebird') });
+//       nightmare.should.be.ok;
+//       var thenPromise = nightmare.goto('about:blank').then();
+//       thenPromise.should.not.be.an.instanceof(Promise);
+//       thenPromise.should.be.an.instanceof(require('bluebird'));
+//       yield thenPromise;
+//     });
+//   })
+//
+//   describe('Nightmare.action(name, fn)', function() {
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should support custom actions', function*() {
+//       Nightmare.action('size', function (done) {
+//         this.evaluate_now(function() {
+//           var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+//           var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+//           return {
+//             height: h,
+//             width: w
+//           }
+//         }, done)
+//       })
+//
+//       nightmare = new Nightmare();
+//
+//       var size = yield nightmare
+//         .goto(fixture('simple'))
+//         .size()
+//
+//       size.height.should.be.a('number')
+//       size.width.should.be.a('number')
+//     })
+//
+//     it('should support custom namespaces', function*() {
+//       Nightmare.action('style', {
+//         background: function (done) {
+//           this.evaluate_now(function () {
+//             return window.getComputedStyle(document.body, null).backgroundColor
+//           }, done)
+//         },
+//         color: function (done) {
+//           this.evaluate_now(function () {
+//             return window.getComputedStyle(document.body, null).color
+//           }, done)
+//         }
+//       })
+//
+//       nightmare = Nightmare()
+//       yield nightmare.goto(fixture('simple'))
+//       var background = yield nightmare.style.background()
+//       var color = yield nightmare.style.color()
+//
+//       background.should.equal('rgba(0, 0, 0, 0)')
+//       color.should.equal('rgb(0, 0, 0)')
+//     })
+//
+//     it('should support extending Electron', function*(){
+//       Nightmare.action('bind',
+//         function(ns, options, parent, win, renderer, done) {
+//           var sliced = require('sliced');
+//           parent.on('bind', function(name) {
+//             if (renderer.listeners(name)
+//               .length == 0) {
+//               renderer.on(name, function() {
+//                 parent.emit.apply(parent, [name].concat(sliced(arguments, 1)))
+//               });
+//             }
+//             parent.emit('bind');
+//           });
+//           done();
+//         },
+//         function() {
+//           var name = arguments[0],
+//             handler, done;
+//           if (arguments.length == 2) {
+//             done = arguments[1];
+//           } else if (arguments.length == 3) {
+//             handler = arguments[1];
+//             done = arguments[2];
+//           }
+//           if (handler) {
+//             this.child.on(name, handler);
+//           }
+//           this.child.once('bind', done);
+//           this.child.emit('bind', name);
+//         });
+//
+//       var eventResults;
+//       nightmare = new Nightmare();
+//       yield nightmare
+//         .goto('http://example.com')
+//         .on('sample-event', function() {
+//           eventResults = arguments;
+//         })
+//         .bind('sample-event')
+//         .evaluate(function() {
+//           ipc.send('sample-event', 'sample', 3, {
+//             sample: 'sample'
+//           });
+//         });
+//
+//       eventResults.length.should.equal(3);
+//       eventResults[0].should.equal('sample');
+//       eventResults[1].should.equal(3);
+//       eventResults[2].sample.should.equal('sample');
+//     });
+//
+//     it('should allow env variables', function*() {
+//       Nightmare.action('envtest',
+//         function (name, options, parent, win, renderer, done) {
+//           parent.respondTo('envtest', function(done){
+//             done(null, process.env);
+//           });
+//           done();
+//         },
+//         function(done) {
+//           this.child.call('envtest', done);
+//         }
+//       );
+//       nightmare = Nightmare({
+//         env: {
+//           TZ: 'UTC'
+//         }
+//       });
+//       nightmare.should.be.ok;
+//       var envTest = yield nightmare
+//         .goto('about:bank')
+//         .envtest();
+//       envTest.should.be.ok;
+//       envTest.should.have.property('TZ', 'UTC');
+//     });
+//   })
+//
+//   describe('Nightmare.use', function() {
+//     beforeEach(function() {
+//       nightmare = Nightmare();
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should support extending nightmare', function*() {
+//       var tagName = yield nightmare
+//         .goto(fixture('simple'))
+//         .use(select('h1'))
+//
+//       tagName.should.equal('H1')
+//
+//       function select (tagname) {
+//         return function (nightmare) {
+//           nightmare.evaluate(function (tagname) {
+//             return document.querySelector(tagname).tagName
+//           }, tagname)
+//         }
+//       }
+//     })
+//   })
+//
+//   describe('custom preload script', function() {
+//     beforeEach(function() {
+//       nightmare = Nightmare();
+//     });
+//
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     it('should support passing your own preload script in', function*() {
+//       var nightmare = Nightmare({
+//         webPreferences: {
+//           preload: path.join(__dirname, 'fixtures', 'preload', 'index.js')
+//         }
+//       })
+//
+//       var value = yield nightmare
+//         .goto(fixture('preload'))
+//         .evaluate(function() {
+//           return window.preload
+//         })
+//
+//       value.should.equal('custom')
+//     })
+//   })
+//
+//   describe('devtools', function(){
+//     beforeEach(function() {
+//       Nightmare.action('waitForDevTools',
+//         function(ns, options, parent, win, renderer, done){
+//           parent.on('waitForDevTools', function() {
+//             function opened() { parent.emit('waitForDevTools', null, true); }
+//             if (win.webContents.isDevToolsOpened()) {
+//               return opened();
+//             }
+//             win.webContents.once('devtools-opened', opened);
+//           });
+//           done();
+//         },
+//         function(done){
+//           this.child.once('waitForDevTools', done);
+//           this.child.emit('waitForDevTools');
+//         });
+//       nightmare = Nightmare({show:true, openDevTools:true});
+//
+//     });
+//
+//     afterEach(function*(){
+//       yield nightmare.end();
+//     });
+//
+//     it('should open devtools', function*(){
+//       var devToolsOpen = yield nightmare
+//         .goto(fixture('simple'))
+//         .waitForDevTools();
+//
+//       devToolsOpen.should.be.true;
+//     });
+//   });
+//
+//   describe('ipc', function(){
+//     beforeEach(function() {
+//       Nightmare.action('test',
+//         function(_, __, parent, ___, ____, done) {
+//           parent.respondTo('test', function(arg1, done) {
+//             done.progress('one');
+//             done.progress('two');
+//             if (arg1 === 'error') {
+//               return done('Error!');
+//             }
+//             else {
+//               done(null, `Got ${arg1}`);
+//             }
+//           });
+//           done();
+//         },
+//         function(options, done) {
+//           var channel = this.child.call('test', options.arg || options, done);
+//           if (options.onData) { channel.on('data', options.onData); }
+//           if (options.onEnd) { channel.on('end', options.onEnd); }
+//         });
+//       Nightmare.action('noImplementation',
+//         function(done) {
+//           this.child.call('noImplementation', done);
+//         });
+//       nightmare = Nightmare();
+//     });
+//
+//     afterEach(function*(){
+//       yield nightmare.end();
+//     });
+//
+//     it('should only make one IPC instance per process', function() {
+//       var processStub = {send: function() {}, on: function(){}};
+//       var ipc1 = IPC(processStub);
+//       var ipc2 = IPC(processStub);
+//       ipc1.should.equal(ipc2);
+//     });
+//
+//     it('should support basic call-response', function*() {
+//       var result = yield nightmare.test('x');
+//       result.should.equal('Got x');
+//     });
+//
+//     it('should support errors across IPC', function(done) {
+//       nightmare.test('error').then(
+//         function() {
+//           done(new Error('Action succeeded when it should have errored!'));
+//         },
+//         function() {
+//           done();
+//         });
+//     });
+//
+//     it('should stream progress', function*() {
+//       var progress = [];
+//       yield nightmare.test({
+//         arg: 'x',
+//         onData: (data) => progress.push(data),
+//         onEnd: (error, data) => progress.push([error, data])
+//       });
+//       progress.should.deep.equal(['one', 'two', [null, 'Got x']]);
+//     });
+//
+//     it('should trigger error if no responder is registered', function(done) {
+//       nightmare.noImplementation().then(
+//         function() {
+//           done(new Error('Action succeeded when it should have errored!'));
+//         },
+//         function() {
+//           done();
+//         });
+//     });
+//
+//     it('should log a warning when replacing a responder', function*() {
+//       Nightmare.action('uhoh',
+//         function(_, __, parent, ___, ____, done) {
+//           parent.respondTo('test', function(done) {
+//             done();
+//           });
+//           done();
+//         },
+//         function(done) {
+//           this.child.call('test', done);
+//         });
+//
+//       var logged = false;
+//       var instance = Nightmare();
+//       instance._queue.splice(1, 0, [function(done) {
+//         this.child.on('nightmare:ipc:debug', function(message) {
+//           if (message.toLowerCase().indexOf('replacing') > -1) {
+//             logged = true;
+//           }
+//         });
+//         done();
+//       }, []]);
+//
+//       yield instance
+//         .goto('about:blank')
+//         .end();
+//       logged.should.be.true;
+//     });
+//   });
+//
+//   describe('partitioning', function(){
+//     afterEach(function*() {
+//       yield nightmare.end();
+//     });
+//
+//     // The default behavior for nightmare is to use a non-persistent partition name
+//     it('should not persist between instances by default', function *() {
+//       nightmare = Nightmare();
+//       yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           window.localStorage.setItem('testing', 'This string should not persist between instances.')
+//         })
+//         .end();
+//
+//       nightmare = Nightmare();
+//       var value = yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           return window.localStorage.getItem('testing') || ''
+//         });
+//
+//       value.should.equal('');
+//     })
+//
+//     // Setting the partition to null we default to the electron default behavior
+//     // which is to use a persistent storage between instances.
+//     it('should persist between instances if partition is null', function *() {
+//       nightmare = Nightmare({ webPreferences: { partition: null } });
+//       yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           window.localStorage.setItem('testing', 'This string should persist between instances.')
+//         })
+//         .end();
+//
+//       nightmare = Nightmare({ webPreferences: { partition: null } });
+//       var value = yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           return window.localStorage.getItem('testing') || ''
+//         });
+//
+//       value.should.equal('This string should persist between instances.');
+//     });
+//
+//     it('should not persist between instances if partition name doesnt start with "persist:"', function *(){
+//       nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
+//       yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           window.localStorage.setItem('testing', 'This string not should persist between instances.')
+//         })
+//         .end();
+//
+//       nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
+//       var value = yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           return window.localStorage.getItem('testing') || ''
+//         });
+//
+//       value.should.equal('');
+//     });
+//
+//     it('should persist between instances if partition starts with "persist:"', function *() {
+//       nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
+//       yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           window.localStorage.setItem('testing', 'This string should persist between instances.')
+//         })
+//         .end();
+//
+//       nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
+//       var value = yield nightmare
+//         .goto(fixture('simple'))
+//         .evaluate(function() {
+//           return window.localStorage.getItem('testing') || ''
+//         });
+//
+//       value.should.equal('This string should persist between instances.');
+//     });
+//   })
+// });
+
+describe('Nightmare with xpath selector', function () {
   before(function (done) {
     server.listen(7500, done);
     Nightmare = withDeprecationTracking(Nightmare);
@@ -50,198 +2379,50 @@ describe('Nightmare', function () {
     Nightmare.assertNoDeprecations();
   });
 
-  it('should be constructable', function*() {
-    var nightmare = Nightmare();
-    nightmare.should.be.ok;
-    yield nightmare.end();
-  });
-
-  it('should have version information', function*(){
-    var nightmare = Nightmare();
-    var versions = yield nightmare.engineVersions();
-    nightmare.engineVersions.electron.should.be.ok;
-    nightmare.engineVersions.chrome.should.be.ok;
-
-    versions.electron.should.be.ok;
-    versions.chrome.should.be.ok;
-
-    Nightmare.version.should.be.ok;
-    yield nightmare.end();
-  });
-
-  it('should kill its electron process when it is killed', function(done) {
-    var child = child_process.fork(
-      path.join(__dirname, 'files', 'nightmare-unended.js'));
-
-    child.once('message', function(electronPid) {
-      child.once('exit', function() {
-        try {
-          electronPid.should.not.be.a.process;
-        }
-        catch(error) {
-          // if the test failed, clean up the still-running process
-          process.kill(electronPid, 'SIGINT');
-          throw error;
-        }
-        done();
-      });
-      child.kill();
-    });
-  });
-
-  it('should gracefully handle electron being killed', function(done) {
-    var child = child_process.fork(
-      path.join(__dirname, 'files', 'nightmare-unended.js'));
-
-    child.once('message', function(electronPid) {
-      process.kill(electronPid, 'SIGINT');
-      child.once('exit', function(){
-        electronPid.should.not.be.a.process;
-        done();
-      });
-    });
-  });
-
-  it('should end gracefully if the chain has not been started', function(done) {
-    var child = child_process.fork(
-      path.join(__dirname, 'files', 'nightmare-created.js'));
-
-    child.once('message', function() {
-      child.once('exit', function(code) {
-        code.should.equal(0);
-        done();
-      });
-      child.kill();
-    });
-  });
-
-  it('should exit with a non-zero code on uncaughtExecption', function(done) {
-    var child = child_process.fork(
-      path.join(__dirname, 'files', 'nightmare-error.js'), [], {silent: true});
-
-      child.once('exit', function(code) {
-        code.should.not.equal(0);
-        done();
-      });
-  });
-
-  it('should provide a .catch function', function(done) {
-    var nightmare = Nightmare();
-
-    nightmare
-      .goto('about:blank')
-      .evaluate(function() {
-        throw new Error('Test');
-      })
-      .catch(function(err) {
-        done();
-      });
-  });
-
-  it('should allow ending more than once', function(done){
-    var nightmare = Nightmare();
-    nightmare.goto(fixture('navigation'))
-      .end()
-      .then(() => nightmare.end())
-      .then(() => done());
-  });
-
-  it('should allow end with a callback', function(done){
-    var nightmare = Nightmare();
-    nightmare.goto(fixture('navigation'))
-      .end(() => done());
-  });
-
-  it('should allow end with a callback to be thenable', function(done){
-    var nightmare = Nightmare();
-    nightmare.goto(fixture('navigation'))
-      .end(() => 'nightmare')
-      .then((str) => {
-        str.should.equal('nightmare');
-        done();
-      });
-  });
-
-  it('should kill electron process when halted', function () {
-    var nightmare = Nightmare();
-
-    const check1 = nightmare.goto(fixture('navigation'))
-      .wait(1000)
-      .wait(500)
-      .end()
-      .then(() => {})
-      .should.be.rejectedWith('Nightmare Halted');
-
-    const electronPid = nightmare.proc.pid;
-
-    const check2 = new Promise((resolve, reject) => {
-      nightmare.halt('Nightmare Halted', () => {
-        electronPid.should.not.be.a.process;
-        resolve();
-      });
-    });
-
-    return Promise.all([check1, check2]);
-  });
-  
-  it('should successfully end on pages setting onunload or onbeforeunload', function(done) {
-    var nightmare = Nightmare();
-    nightmare.goto(fixture('unload'))
-      .end()
-      .then(() => done());
-  });
-
-  it('should successfully end on pages binding unload or beforeunload', function(done) {
-    var nightmare = Nightmare();
-    nightmare.goto(fixture('unload/add-event-listener.html'))
-      .end()
-      .then(() => done());
-  });
-
   it('should provide useful errors for .click', function(done) {
-    var nightmare = Nightmare();
+    var nightmare = Nightmare({useXpath: true});
 
     nightmare
       .goto('about:blank')
-      .click('a.not-here')
+      .click('//a[@class="not-here"]')
       .catch(function (error) {
-        error.should.include('a.not-here');
+        error.should.include('//a[@class="not-here"]');
         done();
       });
   });
 
   it('should provide useful errors for .mousedown', function(done) {
-    var nightmare = Nightmare();
+    var nightmare = Nightmare({useXpath: true});
 
     nightmare
       .goto('about:blank')
-      .mousedown('a.not-here')
+      .mousedown('//a[@class="not-here"]')
       .catch(function (error) {
-        error.should.include('a.not-here');
+        error.should.include('//a[@class="not-here"]');
         done();
       });
   });
 
   it('should provide useful errors for .mouseup', function(done) {
-    var nightmare = Nightmare();
+    var nightmare = Nightmare({useXpath: true});
 
     nightmare
       .goto('about:blank')
-      .mouseup('a.not-here')
+      .mouseup('//a[@class="not-here"]')
       .catch(function (error) {
-        error.should.include('a.not-here');
+        error.should.include('//a[@class="not-here"]');
         done();
       });
   });
 
   it('should provide useful errors for .mouseover', function(done) {
-    var nightmare = Nightmare();
+    var nightmare = Nightmare({useXpath: true});
 
     nightmare
       .goto('about:blank')
-      .mouseover('a.not-here')
+      .mouseover('//a[@class="not-here"]')
       .catch(function (error) {
-        error.should.include('a.not-here');
+        error.should.include('//a[@class="not-here"]');
         done();
       });
   });
@@ -254,6 +2435,7 @@ describe('Nightmare', function () {
         webPreferences: {partition: 'test-partition' + Math.random()},
         loadTimeout: 45 * 1000,
         waitTimeout: 5 * 1000,
+        useXpath: true
       });
     });
 
@@ -262,40 +2444,17 @@ describe('Nightmare', function () {
       Nightmare.resetActions();
     });
 
-    it('should return data about the response', function*() {
-      var data = yield nightmare.goto(fixture('navigation'));
-      data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
-    });
-
-    it('should reject with a useful message when no URL', function() {
-      return nightmare.goto(undefined).then(
-        function() {throw new Error('goto(undefined) didn’t cause an error');},
-        function(error) {
-          error.should.include('url');
-        }
-      );
-    });
-
-    it('should reject with a useful message for an empty URL', function() {
-      return nightmare.goto('').then(
-        function() {throw new Error('goto(undefined) didn’t cause an error');},
-        function(error) {
-          error.should.include('url');
-        }
-      );
-    });
-
     it('should click on a link and then go back', function*() {
       var title = yield nightmare
         .goto(fixture('navigation'))
-        .click('a')
-        .title()
+        .click('//a')
+        .title();
 
-      title.should.equal('A')
+      title.should.equal('A');
 
       var title = yield nightmare
         .back()
-        .title()
+        .title();
 
       title.should.equal('Navigation')
     });
@@ -303,14 +2462,14 @@ describe('Nightmare', function () {
     it('should work for links that dont go anywhere', function*() {
       var title = yield nightmare
         .goto(fixture('navigation'))
-        .click('a')
-        .title()
+        .click('//a')
+        .title();
 
-      title.should.equal('A')
+      title.should.equal('A');
 
       var title = yield nightmare
-        .click('.d')
-        .title()
+        .click('//a[@class="d"]')
+        .title();
 
       title.should.equal('A')
     })
@@ -318,404 +2477,55 @@ describe('Nightmare', function () {
     it('should click on a link, go back, and then go forward', function*() {
       yield nightmare
         .goto(fixture('navigation'))
-        .click('a')
+        .click('//a')
         .back()
         .forward();
-    });
-
-    it('should refresh the page', function*() {
-      yield nightmare
-        .goto(fixture('navigation'))
-        .refresh();
     });
 
     it('should wait until element is present', function*() {
       yield nightmare
         .goto(fixture('navigation'))
-        .wait('a');
+        .wait('//a');
     });
 
     it('should soft timeout if element does not appear', function*() {
       yield nightmare
         .goto(fixture('navigation'))
-        .wait('ul', 150);
+        .wait('//ul', 150);
     });
 
     it('should wait until element is present with a modified poll interval', function*() {
       nightmare = Nightmare({
-        pollInterval: 50
+        pollInterval: 50,
+        useXpath: true
       });
       yield nightmare
         .goto(fixture('navigation'))
-        .wait('a');
+        .wait('//a');
     });
 
-    it('should escape the css selector correctly when waiting for an element', function*() {
-      yield nightmare
-        .goto(fixture('navigation'))
-        .wait('#escaping\\:test');
-    });
-
-    it('should wait until the evaluate fn returns true', function*() {
-      yield nightmare
-        .goto(fixture('navigation'))
-        .wait(function () {
-          var text = document.querySelector('a').textContent;
-          return (text === 'A');
-        });
-    });
-
-    it('should wait until the evaluate fn with arguments returns true', function*() {
-      yield nightmare
-        .goto(fixture('navigation'))
-        .wait(function (expectedA, expectedB) {
-          var textA = document.querySelector('a.a').textContent;
-          var textB = document.querySelector('a.b').textContent;
-          return (expectedA === textA && expectedB === textB);
-        }, 'A', 'B');
-    });
-
-    describe('asynchronous wait', function(){
-      it('should wait until the evaluate fn with arguments returns true with a callback', function*() {
-        yield nightmare
-          .goto(fixture('navigation'))
-          .wait(function (expectedA, expectedB, done) {
-            setTimeout(() => {
-              var textA = document.querySelector('a.a').textContent;
-              var textB = document.querySelector('a.b').textContent;
-              done(null, expectedA === textA && expectedB === textB);
-            }, 2000);
-          }, 'A', 'B');
-      });
-
-      it('should wait until the evaluate fn with arguments returns true with a promise', function*() {
-        yield nightmare
-          .goto(fixture('navigation'))
-          .wait(function (expectedA, expectedB) {
-            return new Promise(function(resolve) {
-              setTimeout(() => {
-                var textA = document.querySelector('a.a').textContent;
-                var textB = document.querySelector('a.b').textContent;
-                resolve(expectedA === textA && expectedB === textB);
-              }, 2000);
-            });
-          }, 'A', 'B');
-      });
-
-      it('should reject timeout on wait', function*() {
-        yield nightmare
-          .goto(fixture('navigation'))
-          .wait(function (done) {
-            //never call done
-          }).should.be.rejected;
-      });
-
-      it('should run multiple times before timeout on wait', function*() {
-        yield nightmare
-          .goto(fixture('navigation'))
-          .wait(function (done) {
-            setTimeout(() => done(null, false), 500);
-          }).should.be.rejected;
-      });
-    });
-
-    it('should fail if navigation target is invalid', function() {
-      return nightmare.goto('http://this-is-not-a-real-domain.tld')
-        .then(
-          function() {
-            throw new Error('Navigation to an invalid domain succeeded');
-          }, function(error) {
-            error.should.contain.keys('message', 'code', 'url');
-            error.code.should.be.a('number');
-          });
-    });
-
-    it('should fail if navigation target is a malformed URL', function(done) {
-      nightmare.goto('somewhere out there')
-        .then(function() {
-          done(new Error('Navigation to an invalid domain succeeded'));
-        })
-        .catch(function(error) {
-          done();
-        });
-    });
-
-    it('should fail if navigating to an unknown protocol', function(done) {
-      nightmare.goto('fake-protocol://blahblahblah')
-        .then(function() {
-          done(new Error('Navigation to an invalid protocol succeeded'));
-        })
-        .catch(function(error) {
-          done();
-        });
-    });
-
-    it('should not fail if the URL loads but a resource fails', function() {
-      return nightmare.goto(fixture('navigation/invalid-image'));
-    });
-
-    it('should not fail if a child frame fails', function() {
-      return nightmare.goto(fixture('navigation/invalid-frame'));
-    });
-
-    it('should return correct data when child frames are present', function*() {
-      var data = yield nightmare.goto(fixture('navigation/valid-frame'));
-      data.should.have.property('url');
-      data.url.should.equal(fixture('navigation/valid-frame'));
-    });
-
-    it('should not fail if response was a valid error (e.g. 404)', function() {
-      return nightmare.goto(fixture('navigation/not-a-real-page'));
-    });
-
-    it('should fail if the response dies in flight', function(done) {
-      nightmare.goto(fixture('do-not-respond'))
-        .then(function() {
-          done(new Error('Navigation succeeded but server connection died'));
-        })
-        .catch(function(error) {
-          done();
-        });
-    });
-
-    it('should not fail for a redirect', function() {
-      return nightmare.goto(fixture('redirect?url=%2Fnavigation'));
-    });
-
-    it('should fail for a redirect to an invalid URL', function(done) {
-      nightmare.goto(
-        fixture('redirect?url=http%3A%2F%2Fthis-is-not-a-real-domain.tld'))
-        .then(function() {
-          done(new Error('Navigation succeeded with redirect to bad location'));
-        })
-        .catch(function(error) {
-          done();
-        });
-    });
-
-    it('should succeed properly if request handler is present', function() {
-      Nightmare.action(
-        'monitorRequest',
-        function(name, options, parent, win, renderer, done) {
-          win.webContents.session.webRequest.onBeforeRequest(
-            ['*://localhost:*'],
-            function(details, callback) {
-              callback({cancel: false});
-            }
-          );
-          done();
-        },
-        function(done) {
-          done();
-          return this;
-        });
-
-      return Nightmare({webPreferences: {partition: 'test-partition'}})
-        .goto(fixture('navigation'))
-        .end();
-    });
-
-    it('should fail properly if request handler is present', function(done) {
-      Nightmare.action(
-        'monitorRequest',
-        function(name, options, parent, win, renderer, done) {
-          win.webContents.session.webRequest.onBeforeRequest(
-            ['*://localhost:*'],
-            function(details, callback) {
-              callback({cancel: false});
-            }
-          );
-          done();
-        },
-        function(done) {
-          done();
-          return this;
-        });
-
-      Nightmare({webPreferences: {partition: 'test-partition'}})
-        .goto('http://this-is-not-a-real-domain.tld')
-        .then(function() {
-          done(new Error('Navigation to an invalid domain succeeded'));
-        })
-        .catch(function(error) {
-          done();
-        });
-    });
-
-    it('should support javascript URLs', function*() {
-      var gotoResult = yield nightmare
-        .goto(fixture('navigation'))
-        .goto('javascript:void(document.querySelector(".a").textContent="LINK");');
-      gotoResult.should.be.an('object');
-
-      var linkText = yield nightmare
-        .evaluate(function() {
-          return document.querySelector('.a').textContent;
-        });
-      linkText.should.equal('LINK');
-    });
-
-    it('should support javascript URLs that load pages', function*() {
-      var data = yield nightmare
-        .goto(fixture('navigation'))
-        .goto(`javascript:window.location='${fixture('navigation/a.html')}'`);
-      data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
-      data.url.should.equal(fixture('navigation/a.html'));
-
-      var linkText = yield nightmare
-        .evaluate(function() {
-          return document.querySelector('.d').textContent;
-        });
-      linkText.should.equal('D');
-    });
-
-    it('should fail immediately/not time out for 304 statuses', function() {
-      return Nightmare({gotoTimeout: 500})
-        .goto(fixture('not-modified'))
-        .end()
-        .then(function() {
-          throw new Error('Navigating to a 304 should return an error');
-        },
-        function(error) {
-          if (error.code === -7) {
-            throw new Error('Navigating to a 304 should not time out');
-          }
-        });
-    });
-
-    it('should not time out for aborted loads', function() {
-      Nightmare.action(
-        'abortRequests',
-        function(name, options, parent, win, renderer, done) {
-          win.webContents.session.webRequest.onBeforeRequest(
-            ['*://localhost:*'],
-            function(details, callback) {
-              setTimeout(() => win.webContents.stop(), 0);
-              callback({cancel: false});
-            }
-          );
-          done();
-        },
-        function() {
-          done();
-        });
-
-      return Nightmare({gotoTimeout: 500})
-        .goto(fixture('navigation'))
-        .end()
-        .then(function() {
-          throw new Error('An aborted page load should return an error');
-        },
-        function(error) {
-          if (error.code === -7) {
-            throw new Error('Aborting a page load should not time out');
-          }
-        });
-    });
-
-    describe('timeouts', function() {
-      it('should time out after 30 seconds of loading', function() {
-        // allow this test to go particularly long
-        this.timeout(40000);
-        return nightmare.goto(fixture('wait')).should.be.rejected
-          .then(function(error) {
-            error.code.should.equal(-7);
-          });
-      });
-
-      it('should allow custom goto timeout on the constructor', function() {
-        var startTime = Date.now();
-        return Nightmare({gotoTimeout: 1000}).goto(fixture('wait')).end()
-          .should.be.rejected
-          .then(function(error) {
-            // allow a few extra seconds for browser startup
-            (startTime - Date.now()).should.be.below(3000);
-          });
-      });
-
-      it('should allow a timeout to succeed if DOM loaded', function() {
-        return Nightmare({gotoTimeout: 1000})
-          .goto(fixture('navigation/hanging-resources.html'))
-          .end()
-          .then(function(data) {
-            data.details.should.include('1000 ms');
-          });
-      });
-
-      it('should allow actions on a hanging page', function() {
-        return Nightmare({gotoTimeout: 500})
-          .goto(fixture('navigation/hanging-resources.html'))
-          .evaluate(() => document.title)
-          .end()
-          .then(function(title) {
-            title.should.equal('Hanging resource load');
-          });
-      });
-
-      it('should allow loading a new page after timing out', function() {
-        nightmare.end().then();
-        nightmare = Nightmare({gotoTimeout: 1000});
-        return nightmare.goto(fixture('wait')).should.be.rejected
-          .then(function() {
-            return nightmare.goto(fixture('navigation'));
-          });
-      });
-
-      it('should allow for timeouts for non-goto loads', function*() { // ###
-        this.timeout(40000);
-        var nightmare = Nightmare({loadTimeout: 30000});
-        yield nightmare
-          .goto(fixture('navigation'))
-          .click('#never-ends');
-
-        yield nightmare.end();
-      });
-    });
   });
 
   describe('evaluation', function () {
     var nightmare;
 
     beforeEach(function() {
-      nightmare = Nightmare();
+      nightmare = Nightmare({useXpath: true});
     });
 
     afterEach(function*() {
       yield nightmare.end();
     });
 
-    it('should get the title', function*() {
-      var title = yield nightmare
-        .goto(fixture('evaluation'))
-        .title();
-      title.should.eql('Evaluation');
-    });
-
-    it('should get the url', function*() {
-      var url = yield nightmare
-        .goto(fixture('evaluation'))
-        .url();
-      url.should.have.string(fixture('evaluation'));
-    });
-
-    it('should get the path', function*() {
-      var path = yield nightmare
-        .goto(fixture('evaluation'))
-        .path();
-      var formalUrl = fixture('evaluation') + '/';
-
-      formalUrl.should.have.string(path);
-    });
-
     it('should check if the selector exists', function*() {
       // existent element
       var exists = yield nightmare
         .goto(fixture('evaluation'))
-        .exists('h1.title');
+        .exists('//h1[@class="title"]');
       exists.should.be.true;
 
       // non-existent element
-      exists = yield nightmare.exists('a.blahblahblah');
+      exists = yield nightmare.exists('//a[@class="blahblahblah"]');
       exists.should.be.false;
     });
 
@@ -723,187 +2533,31 @@ describe('Nightmare', function () {
       // visible element
       var visible = yield nightmare
         .goto(fixture('evaluation'))
-        .visible('h1.title');
+        .visible('//h1[@class="title"]');
       visible.should.be.true;
 
       // hidden element
       visible = yield nightmare
-        .visible('.hidden');
+        .visible('//div[@class="hidden"]');
       visible.should.be.false;
 
-        // non-existent element
+      // non-existent element
       visible = yield nightmare
-        .visible('#asdfasdfasdf');
+        .visible('//[@id="asdfasdfasdf"]');
       visible.should.be.false;
     });
 
-    it('should evaluate javascript on the page, with parameters', function*() {
-      var title = yield nightmare
-        .goto(fixture('evaluation'))
-        .evaluate(function (parameter) {
-          return document.title + ' -- ' + parameter;
-        }, 'testparameter');
-      title.should.equal('Evaluation -- testparameter');
-    });
-
-    it('should capture invalid evaluate fn', function() {
-      return nightmare
-        .goto(fixture('evaluation'))
-        .evaluate('not_a_function')
-        .should.be.rejected;
-    });
-
-    describe('asynchronous', function(){
-      it('should allow for asynchronous evaluation with a callback', function*() {
-        var asyncValue = yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function(done) {
-            setTimeout(() => done(null, 'nightmare'), 1000);
-          });
-
-          asyncValue.should.equal('nightmare');
-      });
-      it('should allow for arguments with asynchronous evaluation with a callback', function*() {
-        var asyncValue = yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function(str, done) {
-            setTimeout(() => done(null, str), 1000);
-          }, 'nightmare');
-
-          asyncValue.should.equal('nightmare');
-      });
-
-      it('should allow for errors in asynchronous evaluation with a callback', function*() {
-        yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function(done) {
-            setTimeout(() => done(new Error('nightmare')), 1000);
-          }).should.be.rejected;
-      });
-
-      it('should allow for timeouts in asynchronous evaluation with a callback', function*() {
-        this.timeout(40000);
-        yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function(done) {
-            //don't call done
-          }).should.be.rejected;
-      });
-
-      it('should allow for asynchronous evaluation with a promise', function*() {
-        var asyncValue =  yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function() {
-            return new Promise(resolve => {
-              setTimeout(() => resolve('nightmare'), 1000);
-            });
-          })
-
-          asyncValue.should.equal('nightmare');
-      });
-
-      it('should allow for arguments with asynchronous evaluation with a promise', function*() {
-        var asyncValue =  yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function(str) {
-            return new Promise(resolve => {
-              setTimeout(() => resolve(str), 1000);
-            });
-          }, 'nightmare')
-
-          asyncValue.should.equal('nightmare');
-      });
-
-      it('should allow for errors in asynchronous evaluation with a promise', function*() {
-        yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function() {
-            return new Promise((resolve, reject) => {
-              setTimeout(() => reject(new Error('nightmare')), 1000);
-            });
-          }).should.be.rejected;
-      });
-
-      it('should allow for timeouts in asynchronous evaluation with a promise', function*() {
-        this.timeout(40000);
-        yield nightmare
-          .goto(fixture('evaluation'))
-          .evaluate(function() {
-            return new Promise((resolve, reject) => {
-              return 'nightmare';
-            });
-          }).should.be.rejected;
-      });
-    });
   });
 
   describe('manipulation', function () {
     var nightmare;
 
     beforeEach(function() {
-      nightmare = Nightmare();
+      nightmare = Nightmare({useXpath: true});
     });
 
     afterEach(function*() {
       yield nightmare.end();
-    });
-
-    it('should inject javascript onto the page', function*() {
-      var globalNumber = yield nightmare
-        .goto(fixture('manipulation'))
-        .inject('js', 'test/files/globals.js')
-        .evaluate(function () {
-          return globalNumber;
-        });
-      globalNumber.should.equal(7);
-
-      var numAnchors = yield nightmare
-        .goto(fixture('manipulation'))
-        .inject('js', 'test/files/jquery-2.1.1.min.js')
-        .evaluate(function () {
-          return $('h1').length;
-        });
-      numAnchors.should.equal(1);
-    });
-
-    it('should inject javascript onto the page ending with a comment', function*() {
-      var globalNumber = yield nightmare
-        .goto(fixture('manipulation'))
-        .inject('js', 'test/files/globals.js')
-        .evaluate(function () {
-          return globalNumber;
-        });
-      globalNumber.should.equal(7);
-
-      var numAnchors = yield nightmare
-        .goto(fixture('manipulation'))
-        .inject('js', 'test/files/jquery-1.9.0.min.js')
-        .evaluate(function () {
-          return $('h1').length;
-        });
-      numAnchors.should.equal(1);
-    });
-
-    it('should inject css onto the page', function*() {
-      var color = yield nightmare
-        .goto(fixture('manipulation'))
-        .inject('js', 'test/files/jquery-2.1.1.min.js')
-        .inject('css', 'test/files/test.css')
-        .evaluate(function () {
-          return $('body').css('background-color');
-        });
-      color.should.equal('rgb(255, 0, 0)');
-    });
-
-    it('should not inject unsupported types onto the page', function*() {
-      var color = yield nightmare
-        .goto(fixture('manipulation'))
-        .inject('js', 'test/files/jquery-2.1.1.min.js')
-        .inject('pdf', 'test/files/test.css')
-        .evaluate(function () {
-          return $('body').css('background-color');
-        });
-      color.should.not.equal('rgb(255, 0, 0)');
     });
 
     it('should type', function*() {
@@ -915,7 +2569,7 @@ describe('Nightmare', function () {
           if (type === 'log') events--;
         })
         .goto(fixture('manipulation'))
-        .type('input[type=search]', input)
+        .type('//input[@type="search"]', input)
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
@@ -925,42 +2579,42 @@ describe('Nightmare', function () {
     });
 
     it('should type integer', function* () {
-        var input = 10;
-        var events = input.toString().length * 3;
+      var input = 10;
+      var events = input.toString().length * 3;
 
-        var value = yield nightmare
-          .on('console', function (type, input, message) {
-            if (type === 'log') events--;
-          })
-          .goto(fixture('manipulation'))
-          .type('input[type=search]', input)
-          .evaluate(function() {
-            return document.querySelector('input[type=search]').value;
-          });
+      var value = yield nightmare
+        .on('console', function (type, input, message) {
+          if (type === 'log') events--;
+        })
+        .goto(fixture('manipulation'))
+        .type('//input[@type="search"]', input)
+        .evaluate(function() {
+          return document.querySelector('input[type=search]').value;
+        });
 
-        value.should.equal('10');
-        events.should.equal(0);
+      value.should.equal('10');
+      events.should.equal(0);
     });
 
 
     it('should type object', function* () {
-        var input = {
-          foo: 'bar'
-        };
-        var events = input.toString().length * 3;
+      var input = {
+        foo: 'bar'
+      };
+      var events = input.toString().length * 3;
 
-        var value = yield nightmare
-          .on('console', function (type, input, message) {
-            if (type === 'log') events--;
-          })
-          .goto(fixture('manipulation'))
-          .type('input[type=search]', input)
-          .evaluate(function() {
-            return document.querySelector('input[type=search]').value;
-          });
+      var value = yield nightmare
+        .on('console', function (type, input, message) {
+          if (type === 'log') events--;
+        })
+        .goto(fixture('manipulation'))
+        .type('//input[@type="search"]', input)
+        .evaluate(function() {
+          return document.querySelector('input[type=search]').value;
+        });
 
-        value.should.equal('[object Object]');
-        events.should.equal(0);
+      value.should.equal('[object Object]');
+      events.should.equal(0);
     });
 
     it('should clear inputs', function*() {
@@ -972,8 +2626,8 @@ describe('Nightmare', function () {
           if (type === 'log') events--;
         })
         .goto(fixture('manipulation'))
-        .type('input[type=search]', input)
-        .type('input[type=search]')
+        .type('//input[@type="search"]', input)
+        .type('//input[@type="search"]')
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
@@ -983,49 +2637,49 @@ describe('Nightmare', function () {
     });
 
     it('should support inserting text', function*() {
-      var input = 'nightmare insert typing'
+      var input = 'nightmare insert typing';
 
       var value = yield nightmare
         .goto(fixture('manipulation'))
-        .insert('input[type=search]', input)
+        .insert('//input[@type="search"]', input)
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
 
       value.should.equal('nightmare insert typing');
-    })
+    });
 
     it('should support clearing inserted text', function*() {
 
       var value = yield nightmare
         .goto(fixture('manipulation'))
-        .insert('input[type=search]')
+        .insert('//input[@type="search"]')
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
 
       value.should.equal('');
-    })
+    });
 
     it('should not type in a nonexistent selector', function(){
       return nightmare
         .goto(fixture('manipulation'))
-        .type('does-not-exist', 'nightmare')
+        .type('//[@class="does-not-exist"]', 'nightmare')
         .should.be.rejected;
     });
 
     it('should not insert in a nonexistent selector', function(){
       return nightmare
         .goto(fixture('manipulation'))
-        .insert('does-not-exist', 'nightmare')
+        .insert('//[@class="does-not-exist"]', 'nightmare')
         .should.be.rejected;
     });
 
     it('should blur the active element when something is clicked', function*() {
       var isBody = yield nightmare
         .goto(fixture('manipulation'))
-        .type('input[type=search]', 'test')
-        .click('p')
+        .type('//input[@type="search"]', 'test')
+        .click('//p')
         .evaluate(function() {
           return document.activeElement === document.body;
         });
@@ -1035,35 +2689,21 @@ describe('Nightmare', function () {
     it('should allow for clicking on elements with attribute selectors', function*() {
       yield nightmare
         .goto(fixture('manipulation'))
-        .click('div[data-test="test"]')
-    });
-
-    it('should not allow for code injection with .click()', function(done){
-      var exception;
-      nightmare
-        .goto(fixture('manipulation'))
-        .click('"]\'); document.title = \'injected title\'; (\'"')
-        .catch((e) => exception = e)
-        .then(()=> nightmare.title())
-        .then((title) => {
-          exception.should.exist;
-          title.should.equal('Manipulation');
-          done();
-        });
+        .click('//div[@data-test="test"]')
     });
 
     it('should not fail if selector no longer exists to blur after typing', function*() {
       yield nightmare
         .on('console', function(){ console.log(arguments)})
         .goto(fixture('manipulation'))
-        .type('input#disappears', 'nightmare');
+        .type('//input[@id="disappears"]', 'nightmare');
     });
 
     it('should type and click', function*() {
       var title = yield nightmare
         .goto(fixture('manipulation'))
-        .type('input[type=search]', 'nightmare')
-        .click('button[type=submit]')
+        .type('//input[@type="search"]', 'nightmare')
+        .click('//button[@type="submit"]')
         .wait(500)
         .title();
 
@@ -1073,10 +2713,10 @@ describe('Nightmare', function () {
     it('should type and click several times', function*() {
       var title = yield nightmare
         .goto(fixture('manipulation'))
-        .type('input[type=search]', 'github nightmare')
-        .click('button[type=submit]')
+        .type('//input[@type="search"]', 'github nightmare')
+        .click('//button[@type="submit"]')
         .wait(500)
-        .click('a')
+        .click('//a')
         .wait(500)
         .title();
       title.should.equal('Manipulation - Result - Nightmare');
@@ -1085,7 +2725,7 @@ describe('Nightmare', function () {
     it('should checkbox', function*() {
       var checkbox = yield nightmare
         .goto(fixture('manipulation'))
-        .check('input[type=checkbox]')
+        .check('//input[@type="checkbox"]')
         .evaluate(function () {
           return document.querySelector('input[type=checkbox]').checked;
         });
@@ -1095,8 +2735,8 @@ describe('Nightmare', function () {
     it('should uncheck', function*() {
       var checkbox = yield nightmare
         .goto(fixture('manipulation'))
-        .check('input[type=checkbox]')
-        .uncheck('input[type=checkbox]')
+        .check('//input[@type="checkbox"]')
+        .uncheck('//input[@type="checkbox"]')
         .evaluate(function () {
           return document.querySelector('input[type=checkbox]').checked;
         });
@@ -1106,44 +2746,17 @@ describe('Nightmare', function () {
     it('should select', function*() {
       var select = yield nightmare
         .goto(fixture('manipulation'))
-        .select('select', 'b')
+        .select('//select', '//option[@value="b"]')
         .evaluate(function () {
           return document.querySelector('select').value;
         });
       select.should.equal('b');
     });
 
-    it('should scroll to specified position', function*() {
-      // start at the top
-      var coordinates = yield nightmare
-        .viewport(320, 320)
-        .goto(fixture('manipulation'))
-        .evaluate(function () {
-          return {
-            top: document.body.scrollTop,
-            left: document.body.scrollLeft
-          };
-        });
-      coordinates.top.should.equal(0);
-      coordinates.left.should.equal(0);
-
-      // scroll down a bit
-      coordinates = yield nightmare
-        .scrollTo(100, 50)
-        .evaluate(function () {
-          return {
-            top: document.body.scrollTop,
-            left: document.body.scrollLeft
-          };
-        });
-      coordinates.top.should.equal(100);
-      coordinates.left.should.equal(50);
-    });
-
     it('should hover over an element', function*() {
       var color = yield nightmare
         .goto(fixture('manipulation'))
-        .mouseover('h1')
+        .mouseover('//h1')
         .evaluate(function () {
           var element = document.querySelector('h1');
           return element.style.background;
@@ -1154,7 +2767,7 @@ describe('Nightmare', function () {
     it('should mousedown on an element', function*() {
       var color = yield nightmare
         .goto(fixture('manipulation'))
-        .mousedown('h1')
+        .mousedown('//h1')
         .evaluate(function () {
           var element = document.querySelector('h1');
           return element.style.background;
@@ -1162,1193 +2775,6 @@ describe('Nightmare', function () {
       color.should.equal('rgb(255, 0, 0)');
     });
   });
-
-  describe('cookies', function() {
-    var nightmare;
-
-    beforeEach(function() {
-      nightmare = Nightmare({webPreferences: {partition: 'test-partition'}})
-        .goto(fixture('cookie'));
-    });
-
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('.set(name, value) & .get(name)', function*() {
-      var cookies = nightmare.cookies
-
-      yield cookies.set('hi', 'hello')
-      var cookie = yield cookies.get('hi')
-
-      cookie.name.should.equal('hi')
-      cookie.value.should.equal('hello')
-      cookie.path.should.equal('/')
-      cookie.secure.should.equal(false)
-    })
-
-    it('.set(obj) & .get(name)', function*() {
-      var cookies = nightmare.cookies
-
-      yield cookies.set({
-        name: 'nightmare',
-        value: 'rocks',
-        path: '/cookie'
-      })
-      var cookie = yield cookies.get('nightmare')
-
-      cookie.name.should.equal('nightmare')
-      cookie.value.should.equal('rocks')
-      cookie.path.should.equal('/cookie')
-      cookie.secure.should.equal(false)
-    })
-
-    it('.set([cookie1, cookie2]) & .get()', function*() {
-      var cookies = nightmare.cookies
-
-      yield cookies.set([
-        {
-          name: 'hi',
-          value: 'hello',
-          path: '/'
-        },
-        {
-          name: 'nightmare',
-          value: 'rocks',
-          path: '/cookie'
-        }
-      ])
-
-      var cookies = yield cookies.get()
-      cookies.length.should.equal(2)
-
-      // sort in case they come in a different order
-      cookies = cookies.sort(function (a, b) {
-        if (a.name > b.name) return 1
-        if (a.name < b.name) return -1
-        return 0
-      })
-
-      cookies[0].name.should.equal('hi')
-      cookies[0].value.should.equal('hello')
-      cookies[0].path.should.equal('/')
-      cookies[0].secure.should.equal(false)
-
-      cookies[1].name.should.equal('nightmare')
-      cookies[1].value.should.equal('rocks')
-      cookies[1].path.should.equal('/cookie')
-      cookies[1].secure.should.equal(false)
-    })
-
-    it('.set([cookie1, cookie2]) & .get(query)', function*() {
-      var cookies = nightmare.cookies
-
-      yield cookies.set([
-        {
-          name: 'hi',
-          value: 'hello',
-          path: '/'
-        },
-        {
-          name: 'nightmare',
-          value: 'rocks',
-          path: '/cookie'
-        }
-      ])
-
-      var cookies = yield cookies.get({ path: '/cookie'})
-      cookies.length.should.equal(1)
-
-      cookies[0].name.should.equal('nightmare')
-      cookies[0].value.should.equal('rocks')
-      cookies[0].path.should.equal('/cookie')
-      cookies[0].secure.should.equal(false)
-    })
-
-    it('.set([cookie]) & .clear(name) & .get(query)', function*() {
-      var cookies = nightmare.cookies
-
-      yield cookies.set([
-        {
-          name: 'hi',
-          value: 'hello',
-          path: '/'
-        },
-        {
-          name: 'nightmare',
-          value: 'rocks',
-          path: '/cookie'
-        }
-      ])
-
-      yield cookies.clear('nightmare');
-
-      var cookies = yield cookies.get({ path: '/cookie' });
-
-      cookies.length.should.equal(0);
-    });
-
-    it('.set([cookie]) & .clear() & .get()', function*() {
-      var cookies = nightmare.cookies
-
-      yield cookies.set([
-        {
-          name: 'hi',
-          value: 'hello',
-          path: '/'
-        },
-        {
-          name: 'nightmare',
-          value: 'rocks',
-          path: '/cookie'
-        }
-      ])
-
-      yield cookies.clear();
-
-      var cookies = yield cookies.get();
-
-      cookies.length.should.equal(0);
-    })
-
-    it('.set([cookie]) & .clearAll() & .get()', function*() {
-      yield nightmare.cookies.set([
-        {
-          name: 'hi',
-          value: 'hello',
-          path: '/'
-        },
-        {
-          name: 'nightmare',
-          value: 'rocks',
-          path: '/cookie'
-        }
-      ]);
-
-      yield nightmare.goto(fixture('simple'));
-
-      yield nightmare.cookies.set([
-        {
-          name: 'hi',
-          value: 'hello',
-          path: '/'
-        },
-        {
-          name: 'nightmare',
-          value: 'rocks',
-          path: '/cookie'
-        }
-      ]);
-
-
-      yield nightmare.cookies.clearAll();
-
-      var cookies = yield nightmare.cookies.get();
-      cookies.length.should.equal(0);
-
-      yield nightmare.goto(fixture('cookie'))
-
-      cookies = yield nightmare.cookies.get();
-      cookies.length.should.equal(0);
-    })
-  });
-
-  describe('rendering', function () {
-    var nightmare;
-
-    before(function(done) {
-      mkdirp(tmp_dir, done)
-    })
-
-    after(function(done) {
-      rimraf(tmp_dir, done)
-    })
-
-    beforeEach(function() {
-      nightmare = Nightmare();
-    });
-
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('should take a screenshot', function*() {
-      yield nightmare
-        .goto('https://github.com/')
-        .screenshot(tmp_dir+'/test.png');
-      var stats = fs.statSync(tmp_dir+'/test.png');
-      stats.size.should.be.at.least(1000);
-    });
-
-    it('should buffer a screenshot', function*() {
-      var image = yield nightmare
-        .goto('https://github.com')
-        .screenshot();
-      Buffer.isBuffer(image).should.be.true;
-      image.length.should.be.at.least(1000);
-    });
-
-    it('should take a clipped screenshot', function*() {
-      yield nightmare
-        .goto('https://github.com/')
-        .screenshot(tmp_dir+'/test-clipped.png', {
-          x: 200,
-          y: 100,
-          width: 100,
-          height: 100
-        });
-      var stats = fs.statSync(tmp_dir+'/test.png');
-      var statsClipped = fs.statSync(tmp_dir+'/test-clipped.png');
-      statsClipped.size.should.be.at.least(300);
-      stats.size.should.be.at.least(10*statsClipped.size);
-    });
-
-    it('should buffer a clipped screenshot', function*() {
-      var image = yield nightmare
-        .goto('https://github.com')
-        .screenshot({
-          x: 200,
-          y: 100,
-          width: 100,
-          height: 100
-        });
-      Buffer.isBuffer(image).should.be.true;
-      image.length.should.be.at.least(300);
-    });
-
-    // repeat this test 3 times, since the concern here is non-determinism in
-    // the timing accuracy of screenshots -- it might pass once, but likely not
-    // several times in a row.
-    for (var i = 0; i < 3; i++) {
-      it('should screenshot an up-to-date image of the page (' + i + ')', function*() {
-        var image = yield nightmare
-          .goto('about:blank')
-          .viewport(100, 100)
-          .evaluate(function() { document.body.style.background = '#900'; })
-          .evaluate(function() { document.body.style.background = '#090'; })
-          .screenshot();
-
-        var png = new PNG();
-        var imageData = yield png.parse.bind(png, image);
-        var firstPixel = Array.from(imageData.data.slice(0, 3));
-        firstPixel.should.deep.equal([0, 153, 0]);
-      });
-    }
-
-    it('should screenshot an an idle page', function*() {
-      var image = yield nightmare
-        .goto('about:blank')
-        .viewport(100, 100)
-        .evaluate(function() { document.body.style.background = '#900'; })
-        .evaluate(function() { document.body.style.background = '#090'; })
-        .wait(1000)
-        .screenshot();
-
-      var png = new PNG();
-      var imageData = yield png.parse.bind(png, image);
-      var firstPixel = Array.from(imageData.data.slice(0, 3));
-      firstPixel.should.deep.equal([0, 153, 0]);
-    });
-
-    it('should not subscribe to frames until necessary', function() {
-      var didSubscribe = false;
-      var FrameManager = require('../lib/frame-manager.js');
-      var manager = FrameManager({
-        webContents: {
-          beginFrameSubscription: function() { didSubscribe = true; },
-          endFrameSubscription: function() {},
-          executeJavaScript: function() {}
-        }
-      });
-      didSubscribe.should.be.false;
-    });
-
-    it('should load jquery correctly', function*() {
-      var loaded = yield nightmare
-        .goto(fixture('rendering'))
-        .wait(2000)
-        .evaluate(function() {
-          return !!window.jQuery;
-        });
-      loaded.should.be.at.least(true);
-    });
-
-    it('should render fonts correctly', function*() {
-      yield nightmare
-        .goto(fixture('rendering'))
-        .wait(2000)
-        .screenshot(tmp_dir+'/font-rendering.png');
-      var stats = fs.statSync(tmp_dir+'/font-rendering.png');
-      stats.size.should.be.at.least(1000);
-    });
-
-    it('should save as html', function*() {
-      yield nightmare
-        .goto(fixture('manipulation'))
-        .html(tmp_dir+'/test.html');
-      var stats = fs.statSync(tmp_dir+'/test.html');
-      stats.should.be.ok;
-    });
-
-    it('should render a PDF', function*() {
-      yield nightmare
-        .goto(fixture('manipulation'))
-        .pdf(tmp_dir+'/test.pdf');
-      var stats = fs.statSync(tmp_dir+'/test.pdf');
-      stats.size.should.be.at.least(1000);
-    });
-
-    it('should accept options to render a PDF', function*() {
-      yield nightmare
-        .goto(fixture('manipulation'))
-        .pdf(tmp_dir+'/test2.pdf', {printBackground: false});
-      var stats = fs.statSync(tmp_dir+'/test2.pdf');
-      stats.size.should.be.at.least(1000);
-    });
-
-    it('should return a buffer from a PDF with no path', function*() {
-      var buf = yield nightmare
-        .goto(fixture('manipulation'))
-        .pdf({printBackground: false});
-
-      var isBuffer = Buffer.isBuffer(buf);
-
-      buf.length.should.be.at.least(1000);
-      isBuffer.should.be.true;
-    });
-  });
-
-  describe('referer', function() {
-    var nightmare;
-
-    beforeEach(function() {
-      nightmare = Nightmare({webPreferences: {partition: 'test-partition'}});
-    });
-
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('should return referer from headers', function*() {
-      var referer = 'http://my-referer.tld/';
-      var returnedReferer = yield nightmare
-        .goto(fixture('referer'), {
-          'Referer': referer
-        })
-        .evaluate(function () {
-          return document.body.innerText;
-        })
-        ;
-
-      referer.should.be.equal(returnedReferer.trim());
-    })
-  });
-
-  describe('events', function () {
-    var nightmare;
-
-    beforeEach(function() {
-      nightmare = Nightmare();
-    });
-
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('should fire an event on page load complete', function*() {
-      var fired = false;
-      nightmare
-        .on('did-finish-load', function () {
-          fired = true;
-        });
-      yield nightmare
-        .goto(fixture('events'));
-      fired.should.be.true;
-    });
-
-    it('should fire an event on javascript error', function*() {
-      var fired = false;
-      nightmare
-        .on('page', function (type, errorMessage, errorStack) {
-          if (type === 'error') {
-            fired = true;
-          }
-        });
-      yield nightmare
-        .goto(fixture('events'));
-      fired.should.be.true;
-    });
-
-    it('should fire an event on javascript console.log', function*() {
-      var log = '';
-
-      nightmare.on('console', function (type, str) {
-        if (type === 'log') log = str
-      });
-
-      yield nightmare.goto(fixture('events'));
-      log.should.equal('my log');
-
-      yield nightmare.click('button')
-      log.should.equal('clicked');
-
-    });
-
-    it('should fire an event on page load failure', function*() {
-      var fired = false;
-      nightmare
-        .on('did-fail-load', function () {
-          fired = true;
-        });
-      try {
-        yield nightmare
-          .goto('https://alskdjfasdfuuu.com');
-      }
-      catch(error) {}
-      fired.should.be.true;
-    });
-
-    it('should fire an event on javascript window.alert', function*(){
-      var alert = '';
-      nightmare.on('page', function(type, message){
-        if (type === 'alert') {
-          alert = message;
-        }
-      });
-
-      yield nightmare
-        .goto(fixture('events'))
-        .evaluate(function(){
-          alert('my alert');
-        });
-      alert.should.equal('my alert');
-    });
-
-    it('should fire an event on javascript window.prompt', function*(){
-      var prompt = '';
-      var response = ''
-      nightmare.on('page', function(type, message, res){
-        if (type === 'prompt') {
-          prompt = message;
-          response = res
-        }
-      });
-
-      yield nightmare
-        .goto(fixture('events'))
-        .evaluate(function(){
-          prompt('my prompt', 'hello!');
-        });
-      prompt.should.equal('my prompt');
-      response.should.equal('hello!');
-    });
-
-    it('should fire an event on javascript window.confirm', function*(){
-      var confirm = '';
-      var response = ''
-      nightmare.on('page', function(type, message, res){
-        if (type === 'confirm') {
-          confirm = message;
-          response = res
-        }
-      });
-
-      yield nightmare
-        .goto(fixture('events'))
-        .evaluate(function(){
-          confirm('my confirm', 'hello!');
-        });
-      confirm.should.equal('my confirm');
-      response.should.equal('hello!');
-    });
-
-    it('should only fire once when using once', function*() {
-      var events = 0;
-      nightmare.once('page', function(type, message) {
-        events++;
-      });
-
-      yield nightmare
-        .goto(fixture('events'))
-      events.should.equal(1);
-    });
-
-    it('should remove event listener', function*() {
-      var events = 0;
-      var handler = function(type, message) {
-        if (type === 'alert') {
-          events++;
-        }
-      };
-
-      nightmare.on('page', handler);
-
-      yield nightmare
-        .goto(fixture('events'))
-        .evaluate(function(){
-          alert('alert one');
-        });
-
-      nightmare.removeListener('page', handler);
-
-      yield nightmare
-        .evaluate(function(){
-          alert('alert two');
-        });
-
-      events.should.equal(1);
-    });
-  });
-
-  describe('options', function () {
-    var nightmare;
-    var server;
-
-    before(function(done) {
-      // set up an HTTPS server using self-signed certificates -- Nightmare
-      // will only be able to talk to it if 'ignore-certificate-errors' is set.
-      server = https.createServer({
-        key: fs.readFileSync(path.join(__dirname, 'files', 'server.key')),
-        cert: fs.readFileSync(path.join(__dirname, 'files', 'server.crt'))
-      }, function(request, response) {
-        response.end('ok\n');
-      }).listen(0, 'localhost', function() {
-        var address = server.address();
-        server.url = `https://${address.address}:${address.port}`;
-        done();
-      });
-    });
-
-    after(function() {
-      server.close();
-      server = null;
-    });
-
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('should set useragent', function* () {
-      nightmare = new Nightmare();
-      var useragent = yield nightmare
-        .useragent('firefox')
-        .goto(fixture('options'))
-        .evaluate(function () {
-          return window.navigator.userAgent;
-        });
-      useragent.should.eql('firefox');
-    });
-
-    it('should wait and fail with waitTimeout', function() {
-      nightmare = Nightmare({waitTimeout: 254});
-      return nightmare
-        .goto(fixture('navigation'))
-        .wait('foobar')
-        .should.be.rejected;
-    });
-
-    it('should wait and fail with waitTimeout and a ms wait time', function() {
-      nightmare = Nightmare({waitTimeout: 254});
-      return nightmare
-        .goto(fixture('navigation'))
-        .wait(1000)
-        .should.be.rejected;
-    });
-
-    it('should wait and fail with waitTimeout with queued functions', function() {
-      nightmare = Nightmare({waitTimeout: 254});
-      return nightmare
-        .goto(fixture('navigation'))
-        .wait('foobar')
-        .exists('baz')
-        .should.be.rejected;
-    });
-
-    it('should set authentication', function*() {
-      nightmare = Nightmare();
-      var data = yield nightmare
-        .authentication('my', 'auth')
-        .goto(fixture('auth'))
-        .evaluate(function () {
-          return JSON.parse(document.querySelector('pre').innerHTML);
-        });
-      data.should.eql({ name: 'my', pass: 'auth' });
-    });
-
-    it('should fail on authentication failure', function*() {
-      nightmare = Nightmare();
-      var data = yield nightmare
-        .authentication('my', 'wrong')
-        .goto(fixture('auth'))
-        .should.be.rejected;
-    });
-
-    it('should be able to update authentication', function*(){
-      nightmare = Nightmare();
-      var data = yield nightmare
-        .authentication('my', 'auth')
-        .goto(fixture('auth'))
-        .authentication('my2', 'auth2')
-        .goto(fixture('auth2'))
-        .evaluate(function () {
-          return JSON.parse(document.querySelector('pre').innerHTML);
-        });
-      data.should.eql({ name: 'my2', pass: 'auth2' });
-    });
-
-    it('should set viewport', function*() {
-      var size = { width: 400, height: 300, useContentSize: true };
-      nightmare = Nightmare(size);
-      var result = yield nightmare
-        .goto(fixture('options'))
-        .evaluate(function () {
-          return {
-            width: window.innerWidth,
-            height: window.innerHeight
-          };
-        });
-      result.width.should.eql(size.width);
-      result.height.should.eql(size.height);
-    });
-
-    it('should set a single header', function*() {
-      nightmare = Nightmare();
-      var headers = yield nightmare
-        .header('X-Nightmare-Header', 'hello world')
-        .goto(fixture('headers'))
-        .evaluate(function () {
-          return JSON.parse(document.querySelector('pre').innerHTML);
-        });
-      headers['x-nightmare-header'].should.equal('hello world');
-    });
-
-    it('should set all headers', function*() {
-      nightmare = Nightmare();
-      var headers = yield nightmare
-        .header({ 'X-Foo': 'foo', 'X-Bar': 'bar'})
-        .goto(fixture('headers'))
-        .evaluate(function () {
-          return JSON.parse(document.querySelector('pre').innerHTML);
-        });
-      headers['x-foo'].should.equal('foo');
-      headers['x-bar'].should.equal('bar');
-    });
-
-    it('should set headers for that request', function*() {
-      nightmare = Nightmare();
-      var headers = yield nightmare
-        .goto(fixture('headers'), { 'X-Nightmare-Header': 'hello world' })
-        .evaluate(function () {
-          return JSON.parse(document.querySelector('pre').innerHTML);
-        });
-      headers['x-nightmare-header'].should.equal('hello world');
-    });
-
-    it('should allow webPreferences settings', function*() {
-      nightmare = Nightmare({webPreferences: {webSecurity: false}});
-      var result = yield nightmare
-        .goto(fixture('options'))
-        .evaluate(function () {
-          return document.getElementById('example-iframe').contentDocument;
-        });
-
-      result.should.be.ok;
-    });
-
-    it('should be constructable with paths', function*() {
-      nightmare = Nightmare({ paths:{ userData : __dirname } });
-      nightmare.should.be.ok;
-    });
-
-    it('should be constructable with switches', function*() {
-      nightmare = Nightmare({
-        switches: {
-          // empty string and non-string values all represent no value
-          'ignore-certificate-errors': null,
-          'touch-events': ''
-        }
-      });
-      nightmare.should.be.ok;
-      var touchEvents = yield nightmare
-        .goto(server.url)
-        .evaluate(function() {
-          return 'ontouchstart' in window;
-        });
-      touchEvents.should.be.true;
-    });
-
-    it('should support switches with values', function*() {
-      nightmare = Nightmare({ switches: { 'force-device-scale-factor': '5' } });
-      nightmare.should.be.ok;
-      var scaleFactor = yield nightmare
-        .goto('about:blank')
-        .evaluate(function() {
-          return window.devicePixelRatio;
-        });
-      scaleFactor.should.equal(5);
-    });
-
-    it('should allow to use external Electron', function*() {
-      nightmare = Nightmare({ electronPath: require('electron') });
-      nightmare.should.be.ok;
-    });
-
-    it('should allow to use external Promise', function*() {
-      nightmare = Nightmare({ Promise: require('bluebird') });
-      nightmare.should.be.ok;
-      const thenPromise = nightmare.goto('about:blank').then();
-      thenPromise.should.be.an.instanceof(require('bluebird'));
-      yield thenPromise;
-      const catchPromise = nightmare.goto('about:blank').catch();
-      catchPromise.should.be.an.instanceof(require('bluebird'));
-      yield catchPromise;
-      const endPromise = nightmare.goto('about:blank').end().then();
-      endPromise.constructor.should.equal(require('bluebird'));
-      endPromise.should.be.an.instanceof(require('bluebird'));
-      yield endPromise;
-    });
-  });
-
-  describe('Nightmare.Promise', function() {
-    var nightmare;
-    afterEach(function*() {
-      // `withDeprecationTracking()` messes w/ prototype constructor references
-      Nightmare.Promise = require('..').Promise = Promise;
-      yield nightmare.end();
-    });
-
-    it('should default to native Promise', function*() {
-      Nightmare.Promise.should.equal(Promise);
-      nightmare = Nightmare();
-      nightmare.should.be.ok;
-      var thenPromise = nightmare.goto('about:blank').then();
-      thenPromise.should.be.an.instanceof(Promise);
-      yield thenPromise;
-    });
-
-    it('should override default Promise library', function*() {
-      // `withDeprecationTracking()` messes w/ prototype constructor references
-      Nightmare.Promise = require('..').Promise = require('bluebird');
-      Nightmare.Promise.should.equal(require('bluebird'));
-      nightmare = Nightmare();
-      nightmare.should.be.ok;
-      var thenPromise = nightmare.goto('about:blank').then();
-      thenPromise.should.be.an.instanceof(require('bluebird'));
-      yield thenPromise;
-    });
-
-    it('should not override per-instance Promise library', function*() {
-      Nightmare.Promise.should.equal(Promise);
-      nightmare = Nightmare({ Promise: require('bluebird') });
-      nightmare.should.be.ok;
-      var thenPromise = nightmare.goto('about:blank').then();
-      thenPromise.should.not.be.an.instanceof(Promise);
-      thenPromise.should.be.an.instanceof(require('bluebird'));
-      yield thenPromise;
-    });
-  })
-
-  describe('Nightmare.action(name, fn)', function() {
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('should support custom actions', function*() {
-      Nightmare.action('size', function (done) {
-        this.evaluate_now(function() {
-          var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
-          var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
-          return {
-            height: h,
-            width: w
-          }
-        }, done)
-      })
-
-      nightmare = new Nightmare();
-
-      var size = yield nightmare
-        .goto(fixture('simple'))
-        .size()
-
-      size.height.should.be.a('number')
-      size.width.should.be.a('number')
-    })
-
-    it('should support custom namespaces', function*() {
-      Nightmare.action('style', {
-        background: function (done) {
-          this.evaluate_now(function () {
-            return window.getComputedStyle(document.body, null).backgroundColor
-          }, done)
-        },
-        color: function (done) {
-          this.evaluate_now(function () {
-            return window.getComputedStyle(document.body, null).color
-          }, done)
-        }
-      })
-
-      nightmare = Nightmare()
-      yield nightmare.goto(fixture('simple'))
-      var background = yield nightmare.style.background()
-      var color = yield nightmare.style.color()
-
-      background.should.equal('rgba(0, 0, 0, 0)')
-      color.should.equal('rgb(0, 0, 0)')
-    })
-
-    it('should support extending Electron', function*(){
-      Nightmare.action('bind',
-        function(ns, options, parent, win, renderer, done) {
-          var sliced = require('sliced');
-          parent.on('bind', function(name) {
-            if (renderer.listeners(name)
-              .length == 0) {
-              renderer.on(name, function() {
-                parent.emit.apply(parent, [name].concat(sliced(arguments, 1)))
-              });
-            }
-            parent.emit('bind');
-          });
-          done();
-        },
-        function() {
-          var name = arguments[0],
-            handler, done;
-          if (arguments.length == 2) {
-            done = arguments[1];
-          } else if (arguments.length == 3) {
-            handler = arguments[1];
-            done = arguments[2];
-          }
-          if (handler) {
-            this.child.on(name, handler);
-          }
-          this.child.once('bind', done);
-          this.child.emit('bind', name);
-        });
-
-      var eventResults;
-      nightmare = new Nightmare();
-      yield nightmare
-        .goto('http://example.com')
-        .on('sample-event', function() {
-          eventResults = arguments;
-        })
-        .bind('sample-event')
-        .evaluate(function() {
-          ipc.send('sample-event', 'sample', 3, {
-            sample: 'sample'
-          });
-        });
-
-      eventResults.length.should.equal(3);
-      eventResults[0].should.equal('sample');
-      eventResults[1].should.equal(3);
-      eventResults[2].sample.should.equal('sample');
-    });
-
-    it('should allow env variables', function*() {
-      Nightmare.action('envtest',
-        function (name, options, parent, win, renderer, done) {
-          parent.respondTo('envtest', function(done){
-            done(null, process.env);
-          });
-          done();
-        },
-        function(done) {
-          this.child.call('envtest', done);
-        }
-      );
-      nightmare = Nightmare({
-        env: {
-          TZ: 'UTC'
-        }
-      });
-      nightmare.should.be.ok;
-      var envTest = yield nightmare
-        .goto('about:bank')
-        .envtest();
-      envTest.should.be.ok;
-      envTest.should.have.property('TZ', 'UTC');
-    });
-  })
-
-  describe('Nightmare.use', function() {
-    beforeEach(function() {
-      nightmare = Nightmare();
-    });
-
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('should support extending nightmare', function*() {
-      var tagName = yield nightmare
-        .goto(fixture('simple'))
-        .use(select('h1'))
-
-      tagName.should.equal('H1')
-
-      function select (tagname) {
-        return function (nightmare) {
-          nightmare.evaluate(function (tagname) {
-            return document.querySelector(tagname).tagName
-          }, tagname)
-        }
-      }
-    })
-  })
-
-  describe('custom preload script', function() {
-    beforeEach(function() {
-      nightmare = Nightmare();
-    });
-
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    it('should support passing your own preload script in', function*() {
-      var nightmare = Nightmare({
-        webPreferences: {
-          preload: path.join(__dirname, 'fixtures', 'preload', 'index.js')
-        }
-      })
-
-      var value = yield nightmare
-        .goto(fixture('preload'))
-        .evaluate(function() {
-          return window.preload
-        })
-
-      value.should.equal('custom')
-    })
-  })
-
-  describe('devtools', function(){
-    beforeEach(function() {
-      Nightmare.action('waitForDevTools',
-        function(ns, options, parent, win, renderer, done){
-          parent.on('waitForDevTools', function() {
-            function opened() { parent.emit('waitForDevTools', null, true); }
-            if (win.webContents.isDevToolsOpened()) {
-              return opened();
-            }
-            win.webContents.once('devtools-opened', opened);
-          });
-          done();
-        },
-        function(done){
-          this.child.once('waitForDevTools', done);
-          this.child.emit('waitForDevTools');
-        });
-      nightmare = Nightmare({show:true, openDevTools:true});
-
-    });
-
-    afterEach(function*(){
-      yield nightmare.end();
-    });
-
-    it('should open devtools', function*(){
-      var devToolsOpen = yield nightmare
-        .goto(fixture('simple'))
-        .waitForDevTools();
-
-      devToolsOpen.should.be.true;
-    });
-  });
-
-  describe('ipc', function(){
-    beforeEach(function() {
-      Nightmare.action('test',
-        function(_, __, parent, ___, ____, done) {
-          parent.respondTo('test', function(arg1, done) {
-            done.progress('one');
-            done.progress('two');
-            if (arg1 === 'error') {
-              return done('Error!');
-            }
-            else {
-              done(null, `Got ${arg1}`);
-            }
-          });
-          done();
-        },
-        function(options, done) {
-          var channel = this.child.call('test', options.arg || options, done);
-          if (options.onData) { channel.on('data', options.onData); }
-          if (options.onEnd) { channel.on('end', options.onEnd); }
-        });
-      Nightmare.action('noImplementation',
-        function(done) {
-          this.child.call('noImplementation', done);
-        });
-      nightmare = Nightmare();
-    });
-
-    afterEach(function*(){
-      yield nightmare.end();
-    });
-
-    it('should only make one IPC instance per process', function() {
-      var processStub = {send: function() {}, on: function(){}};
-      var ipc1 = IPC(processStub);
-      var ipc2 = IPC(processStub);
-      ipc1.should.equal(ipc2);
-    });
-
-    it('should support basic call-response', function*() {
-      var result = yield nightmare.test('x');
-      result.should.equal('Got x');
-    });
-
-    it('should support errors across IPC', function(done) {
-      nightmare.test('error').then(
-        function() {
-          done(new Error('Action succeeded when it should have errored!'));
-        },
-        function() {
-          done();
-        });
-    });
-
-    it('should stream progress', function*() {
-      var progress = [];
-      yield nightmare.test({
-        arg: 'x',
-        onData: (data) => progress.push(data),
-        onEnd: (error, data) => progress.push([error, data])
-      });
-      progress.should.deep.equal(['one', 'two', [null, 'Got x']]);
-    });
-
-    it('should trigger error if no responder is registered', function(done) {
-      nightmare.noImplementation().then(
-        function() {
-          done(new Error('Action succeeded when it should have errored!'));
-        },
-        function() {
-          done();
-        });
-    });
-
-    it('should log a warning when replacing a responder', function*() {
-      Nightmare.action('uhoh',
-        function(_, __, parent, ___, ____, done) {
-          parent.respondTo('test', function(done) {
-            done();
-          });
-          done();
-        },
-        function(done) {
-          this.child.call('test', done);
-        });
-
-      var logged = false;
-      var instance = Nightmare();
-      instance._queue.splice(1, 0, [function(done) {
-        this.child.on('nightmare:ipc:debug', function(message) {
-          if (message.toLowerCase().indexOf('replacing') > -1) {
-            logged = true;
-          }
-        });
-        done();
-      }, []]);
-
-      yield instance
-        .goto('about:blank')
-        .end();
-      logged.should.be.true;
-    });
-  });
-
-  describe('partitioning', function(){
-    afterEach(function*() {
-      yield nightmare.end();
-    });
-
-    // The default behavior for nightmare is to use a non-persistent partition name
-    it('should not persist between instances by default', function *() {
-      nightmare = Nightmare();
-      yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          window.localStorage.setItem('testing', 'This string should not persist between instances.')
-        })
-        .end();
-
-      nightmare = Nightmare();
-      var value = yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          return window.localStorage.getItem('testing') || ''
-        });
-
-      value.should.equal('');
-    })
-
-    // Setting the partition to null we default to the electron default behavior
-    // which is to use a persistent storage between instances.
-    it('should persist between instances if partition is null', function *() {
-      nightmare = Nightmare({ webPreferences: { partition: null } });
-      yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          window.localStorage.setItem('testing', 'This string should persist between instances.')
-        })
-        .end();
-
-      nightmare = Nightmare({ webPreferences: { partition: null } });
-      var value = yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          return window.localStorage.getItem('testing') || ''
-        });
-
-      value.should.equal('This string should persist between instances.');
-    });
-
-    it('should not persist between instances if partition name doesnt start with "persist:"', function *(){
-      nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
-      yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          window.localStorage.setItem('testing', 'This string not should persist between instances.')
-        })
-        .end();
-
-      nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
-      var value = yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          return window.localStorage.getItem('testing') || ''
-        });
-
-      value.should.equal('');
-    });
-
-    it('should persist between instances if partition starts with "persist:"', function *() {
-      nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
-      yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          window.localStorage.setItem('testing', 'This string should persist between instances.')
-        })
-        .end();
-
-      nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
-      var value = yield nightmare
-        .goto(fixture('simple'))
-        .evaluate(function() {
-          return window.localStorage.getItem('testing') || ''
-        });
-
-      value.should.equal('This string should persist between instances.');
-    });
-  })
 });
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -40,2336 +40,7 @@ process.setMaxListeners(0);
 
 var base = 'http://localhost:7500/';
 
-// describe('Nightmare', function () {
-//   before(function (done) {
-//     server.listen(7500, done);
-//     Nightmare = withDeprecationTracking(Nightmare);
-//   });
-//
-//   after(function() {
-//     Nightmare.assertNoDeprecations();
-//   });
-//
-//   it('should be constructable', function*() {
-//     var nightmare = Nightmare();
-//     nightmare.should.be.ok;
-//     yield nightmare.end();
-//   });
-//
-//   it('should have version information', function*(){
-//     var nightmare = Nightmare();
-//     var versions = yield nightmare.engineVersions();
-//     nightmare.engineVersions.electron.should.be.ok;
-//     nightmare.engineVersions.chrome.should.be.ok;
-//
-//     versions.electron.should.be.ok;
-//     versions.chrome.should.be.ok;
-//
-//     Nightmare.version.should.be.ok;
-//     yield nightmare.end();
-//   });
-//
-//   it('should kill its electron process when it is killed', function(done) {
-//     var child = child_process.fork(
-//       path.join(__dirname, 'files', 'nightmare-unended.js'));
-//
-//     child.once('message', function(electronPid) {
-//       child.once('exit', function() {
-//         try {
-//           electronPid.should.not.be.a.process;
-//         }
-//         catch(error) {
-//           // if the test failed, clean up the still-running process
-//           process.kill(electronPid, 'SIGINT');
-//           throw error;
-//         }
-//         done();
-//       });
-//       child.kill();
-//     });
-//   });
-//
-//   it('should gracefully handle electron being killed', function(done) {
-//     var child = child_process.fork(
-//       path.join(__dirname, 'files', 'nightmare-unended.js'));
-//
-//     child.once('message', function(electronPid) {
-//       process.kill(electronPid, 'SIGINT');
-//       child.once('exit', function(){
-//         electronPid.should.not.be.a.process;
-//         done();
-//       });
-//     });
-//   });
-//
-//   it('should end gracefully if the chain has not been started', function(done) {
-//     var child = child_process.fork(
-//       path.join(__dirname, 'files', 'nightmare-created.js'));
-//
-//     child.once('message', function() {
-//       child.once('exit', function(code) {
-//         code.should.equal(0);
-//         done();
-//       });
-//       child.kill();
-//     });
-//   });
-//
-//   it('should exit with a non-zero code on uncaughtExecption', function(done) {
-//     var child = child_process.fork(
-//       path.join(__dirname, 'files', 'nightmare-error.js'), [], {silent: true});
-//
-//       child.once('exit', function(code) {
-//         code.should.not.equal(0);
-//         done();
-//       });
-//   });
-//
-//   it('should provide a .catch function', function(done) {
-//     var nightmare = Nightmare();
-//
-//     nightmare
-//       .goto('about:blank')
-//       .evaluate(function() {
-//         throw new Error('Test');
-//       })
-//       .catch(function(err) {
-//         done();
-//       });
-//   });
-//
-//   it('should allow ending more than once', function(done){
-//     var nightmare = Nightmare();
-//     nightmare.goto(fixture('navigation'))
-//       .end()
-//       .then(() => nightmare.end())
-//       .then(() => done());
-//   });
-//
-//   it('should allow end with a callback', function(done){
-//     var nightmare = Nightmare();
-//     nightmare.goto(fixture('navigation'))
-//       .end(() => done());
-//   });
-//
-//   it('should allow end with a callback to be thenable', function(done){
-//     var nightmare = Nightmare();
-//     nightmare.goto(fixture('navigation'))
-//       .end(() => 'nightmare')
-//       .then((str) => {
-//         str.should.equal('nightmare');
-//         done();
-//       });
-//   });
-//
-//   it('should kill electron process when halted', function () {
-//     var nightmare = Nightmare();
-//
-//     const check1 = nightmare.goto(fixture('navigation'))
-//       .wait(1000)
-//       .wait(500)
-//       .end()
-//       .then(() => {})
-//       .should.be.rejectedWith('Nightmare Halted');
-//
-//     const electronPid = nightmare.proc.pid;
-//
-//     const check2 = new Promise((resolve, reject) => {
-//       nightmare.halt('Nightmare Halted', () => {
-//         electronPid.should.not.be.a.process;
-//         resolve();
-//       });
-//     });
-//
-//     return Promise.all([check1, check2]);
-//   });
-//  
-//   it('should successfully end on pages setting onunload or onbeforeunload', function(done) {
-//     var nightmare = Nightmare();
-//     nightmare.goto(fixture('unload'))
-//       .end()
-//       .then(() => done());
-//   });
-//
-//   it('should successfully end on pages binding unload or beforeunload', function(done) {
-//     var nightmare = Nightmare();
-//     nightmare.goto(fixture('unload/add-event-listener.html'))
-//       .end()
-//       .then(() => done());
-//   });
-//
-//   it('should provide useful errors for .click', function(done) {
-//     var nightmare = Nightmare();
-//
-//     nightmare
-//       .goto('about:blank')
-//       .click('a.not-here')
-//       .catch(function (error) {
-//         error.should.include('a.not-here');
-//         done();
-//       });
-//   });
-//
-//   it('should provide useful errors for .mousedown', function(done) {
-//     var nightmare = Nightmare();
-//
-//     nightmare
-//       .goto('about:blank')
-//       .mousedown('a.not-here')
-//       .catch(function (error) {
-//         error.should.include('a.not-here');
-//         done();
-//       });
-//   });
-//
-//   it('should provide useful errors for .mouseup', function(done) {
-//     var nightmare = Nightmare();
-//
-//     nightmare
-//       .goto('about:blank')
-//       .mouseup('a.not-here')
-//       .catch(function (error) {
-//         error.should.include('a.not-here');
-//         done();
-//       });
-//   });
-//
-//   it('should provide useful errors for .mouseover', function(done) {
-//     var nightmare = Nightmare();
-//
-//     nightmare
-//       .goto('about:blank')
-//       .mouseover('a.not-here')
-//       .catch(function (error) {
-//         error.should.include('a.not-here');
-//         done();
-//       });
-//   });
-//
-//   describe('navigation', function () {
-//     var nightmare;
-//
-//     beforeEach(function() {
-//       nightmare = Nightmare({
-//         webPreferences: {partition: 'test-partition' + Math.random()},
-//         loadTimeout: 45 * 1000,
-//         waitTimeout: 5 * 1000,
-//       });
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//       Nightmare.resetActions();
-//     });
-//
-//     it('should return data about the response', function*() {
-//       var data = yield nightmare.goto(fixture('navigation'));
-//       data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
-//     });
-//
-//     it('should reject with a useful message when no URL', function() {
-//       return nightmare.goto(undefined).then(
-//         function() {throw new Error('goto(undefined) didn’t cause an error');},
-//         function(error) {
-//           error.should.include('url');
-//         }
-//       );
-//     });
-//
-//     it('should reject with a useful message for an empty URL', function() {
-//       return nightmare.goto('').then(
-//         function() {throw new Error('goto(undefined) didn’t cause an error');},
-//         function(error) {
-//           error.should.include('url');
-//         }
-//       );
-//     });
-//
-//     it('should click on a link and then go back', function*() {
-//       var title = yield nightmare
-//         .goto(fixture('navigation'))
-//         .click('a')
-//         .title()
-//
-//       title.should.equal('A')
-//
-//       var title = yield nightmare
-//         .back()
-//         .title()
-//
-//       title.should.equal('Navigation')
-//     });
-//
-//     it('should work for links that dont go anywhere', function*() {
-//       var title = yield nightmare
-//         .goto(fixture('navigation'))
-//         .click('a')
-//         .title()
-//
-//       title.should.equal('A')
-//
-//       var title = yield nightmare
-//         .click('.d')
-//         .title()
-//
-//       title.should.equal('A')
-//     })
-//
-//     it('should click on a link, go back, and then go forward', function*() {
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .click('a')
-//         .back()
-//         .forward();
-//     });
-//
-//     it('should refresh the page', function*() {
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .refresh();
-//     });
-//
-//     it('should wait until element is present', function*() {
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .wait('a');
-//     });
-//
-//     it('should soft timeout if element does not appear', function*() {
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .wait('ul', 150);
-//     });
-//
-//     it('should wait until element is present with a modified poll interval', function*() {
-//       nightmare = Nightmare({
-//         pollInterval: 50
-//       });
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .wait('a');
-//     });
-//
-//     it('should escape the css selector correctly when waiting for an element', function*() {
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .wait('#escaping\\:test');
-//     });
-//
-//     it('should wait until the evaluate fn returns true', function*() {
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .wait(function () {
-//           var text = document.querySelector('a').textContent;
-//           return (text === 'A');
-//         });
-//     });
-//
-//     it('should wait until the evaluate fn with arguments returns true', function*() {
-//       yield nightmare
-//         .goto(fixture('navigation'))
-//         .wait(function (expectedA, expectedB) {
-//           var textA = document.querySelector('a.a').textContent;
-//           var textB = document.querySelector('a.b').textContent;
-//           return (expectedA === textA && expectedB === textB);
-//         }, 'A', 'B');
-//     });
-//
-//     describe('asynchronous wait', function(){
-//       it('should wait until the evaluate fn with arguments returns true with a callback', function*() {
-//         yield nightmare
-//           .goto(fixture('navigation'))
-//           .wait(function (expectedA, expectedB, done) {
-//             setTimeout(() => {
-//               var textA = document.querySelector('a.a').textContent;
-//               var textB = document.querySelector('a.b').textContent;
-//               done(null, expectedA === textA && expectedB === textB);
-//             }, 2000);
-//           }, 'A', 'B');
-//       });
-//
-//       it('should wait until the evaluate fn with arguments returns true with a promise', function*() {
-//         yield nightmare
-//           .goto(fixture('navigation'))
-//           .wait(function (expectedA, expectedB) {
-//             return new Promise(function(resolve) {
-//               setTimeout(() => {
-//                 var textA = document.querySelector('a.a').textContent;
-//                 var textB = document.querySelector('a.b').textContent;
-//                 resolve(expectedA === textA && expectedB === textB);
-//               }, 2000);
-//             });
-//           }, 'A', 'B');
-//       });
-//
-//       it('should reject timeout on wait', function*() {
-//         yield nightmare
-//           .goto(fixture('navigation'))
-//           .wait(function (done) {
-//             //never call done
-//           }).should.be.rejected;
-//       });
-//
-//       it('should run multiple times before timeout on wait', function*() {
-//         yield nightmare
-//           .goto(fixture('navigation'))
-//           .wait(function (done) {
-//             setTimeout(() => done(null, false), 500);
-//           }).should.be.rejected;
-//       });
-//     });
-//
-//     it('should fail if navigation target is invalid', function() {
-//       return nightmare.goto('http://this-is-not-a-real-domain.tld')
-//         .then(
-//           function() {
-//             throw new Error('Navigation to an invalid domain succeeded');
-//           }, function(error) {
-//             error.should.contain.keys('message', 'code', 'url');
-//             error.code.should.be.a('number');
-//           });
-//     });
-//
-//     it('should fail if navigation target is a malformed URL', function(done) {
-//       nightmare.goto('somewhere out there')
-//         .then(function() {
-//           done(new Error('Navigation to an invalid domain succeeded'));
-//         })
-//         .catch(function(error) {
-//           done();
-//         });
-//     });
-//
-//     it('should fail if navigating to an unknown protocol', function(done) {
-//       nightmare.goto('fake-protocol://blahblahblah')
-//         .then(function() {
-//           done(new Error('Navigation to an invalid protocol succeeded'));
-//         })
-//         .catch(function(error) {
-//           done();
-//         });
-//     });
-//
-//     it('should not fail if the URL loads but a resource fails', function() {
-//       return nightmare.goto(fixture('navigation/invalid-image'));
-//     });
-//
-//     it('should not fail if a child frame fails', function() {
-//       return nightmare.goto(fixture('navigation/invalid-frame'));
-//     });
-//
-//     it('should return correct data when child frames are present', function*() {
-//       var data = yield nightmare.goto(fixture('navigation/valid-frame'));
-//       data.should.have.property('url');
-//       data.url.should.equal(fixture('navigation/valid-frame'));
-//     });
-//
-//     it('should not fail if response was a valid error (e.g. 404)', function() {
-//       return nightmare.goto(fixture('navigation/not-a-real-page'));
-//     });
-//
-//     it('should fail if the response dies in flight', function(done) {
-//       nightmare.goto(fixture('do-not-respond'))
-//         .then(function() {
-//           done(new Error('Navigation succeeded but server connection died'));
-//         })
-//         .catch(function(error) {
-//           done();
-//         });
-//     });
-//
-//     it('should not fail for a redirect', function() {
-//       return nightmare.goto(fixture('redirect?url=%2Fnavigation'));
-//     });
-//
-//     it('should fail for a redirect to an invalid URL', function(done) {
-//       nightmare.goto(
-//         fixture('redirect?url=http%3A%2F%2Fthis-is-not-a-real-domain.tld'))
-//         .then(function() {
-//           done(new Error('Navigation succeeded with redirect to bad location'));
-//         })
-//         .catch(function(error) {
-//           done();
-//         });
-//     });
-//
-//     it('should succeed properly if request handler is present', function() {
-//       Nightmare.action(
-//         'monitorRequest',
-//         function(name, options, parent, win, renderer, done) {
-//           win.webContents.session.webRequest.onBeforeRequest(
-//             ['*://localhost:*'],
-//             function(details, callback) {
-//               callback({cancel: false});
-//             }
-//           );
-//           done();
-//         },
-//         function(done) {
-//           done();
-//           return this;
-//         });
-//
-//       return Nightmare({webPreferences: {partition: 'test-partition'}})
-//         .goto(fixture('navigation'))
-//         .end();
-//     });
-//
-//     it('should fail properly if request handler is present', function(done) {
-//       Nightmare.action(
-//         'monitorRequest',
-//         function(name, options, parent, win, renderer, done) {
-//           win.webContents.session.webRequest.onBeforeRequest(
-//             ['*://localhost:*'],
-//             function(details, callback) {
-//               callback({cancel: false});
-//             }
-//           );
-//           done();
-//         },
-//         function(done) {
-//           done();
-//           return this;
-//         });
-//
-//       Nightmare({webPreferences: {partition: 'test-partition'}})
-//         .goto('http://this-is-not-a-real-domain.tld')
-//         .then(function() {
-//           done(new Error('Navigation to an invalid domain succeeded'));
-//         })
-//         .catch(function(error) {
-//           done();
-//         });
-//     });
-//
-//     it('should support javascript URLs', function*() {
-//       var gotoResult = yield nightmare
-//         .goto(fixture('navigation'))
-//         .goto('javascript:void(document.querySelector(".a").textContent="LINK");');
-//       gotoResult.should.be.an('object');
-//
-//       var linkText = yield nightmare
-//         .evaluate(function() {
-//           return document.querySelector('.a').textContent;
-//         });
-//       linkText.should.equal('LINK');
-//     });
-//
-//     it('should support javascript URLs that load pages', function*() {
-//       var data = yield nightmare
-//         .goto(fixture('navigation'))
-//         .goto(`javascript:window.location='${fixture('navigation/a.html')}'`);
-//       data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
-//       data.url.should.equal(fixture('navigation/a.html'));
-//
-//       var linkText = yield nightmare
-//         .evaluate(function() {
-//           return document.querySelector('.d').textContent;
-//         });
-//       linkText.should.equal('D');
-//     });
-//
-//     it('should fail immediately/not time out for 304 statuses', function() {
-//       return Nightmare({gotoTimeout: 500})
-//         .goto(fixture('not-modified'))
-//         .end()
-//         .then(function() {
-//           throw new Error('Navigating to a 304 should return an error');
-//         },
-//         function(error) {
-//           if (error.code === -7) {
-//             throw new Error('Navigating to a 304 should not time out');
-//           }
-//         });
-//     });
-//
-//     it('should not time out for aborted loads', function() {
-//       Nightmare.action(
-//         'abortRequests',
-//         function(name, options, parent, win, renderer, done) {
-//           win.webContents.session.webRequest.onBeforeRequest(
-//             ['*://localhost:*'],
-//             function(details, callback) {
-//               setTimeout(() => win.webContents.stop(), 0);
-//               callback({cancel: false});
-//             }
-//           );
-//           done();
-//         },
-//         function() {
-//           done();
-//         });
-//
-//       return Nightmare({gotoTimeout: 500})
-//         .goto(fixture('navigation'))
-//         .end()
-//         .then(function() {
-//           throw new Error('An aborted page load should return an error');
-//         },
-//         function(error) {
-//           if (error.code === -7) {
-//             throw new Error('Aborting a page load should not time out');
-//           }
-//         });
-//     });
-//
-//     describe('timeouts', function() {
-//       it('should time out after 30 seconds of loading', function() {
-//         // allow this test to go particularly long
-//         this.timeout(40000);
-//         return nightmare.goto(fixture('wait')).should.be.rejected
-//           .then(function(error) {
-//             error.code.should.equal(-7);
-//           });
-//       });
-//
-//       it('should allow custom goto timeout on the constructor', function() {
-//         var startTime = Date.now();
-//         return Nightmare({gotoTimeout: 1000}).goto(fixture('wait')).end()
-//           .should.be.rejected
-//           .then(function(error) {
-//             // allow a few extra seconds for browser startup
-//             (startTime - Date.now()).should.be.below(3000);
-//           });
-//       });
-//
-//       it('should allow a timeout to succeed if DOM loaded', function() {
-//         return Nightmare({gotoTimeout: 1000})
-//           .goto(fixture('navigation/hanging-resources.html'))
-//           .end()
-//           .then(function(data) {
-//             data.details.should.include('1000 ms');
-//           });
-//       });
-//
-//       it('should allow actions on a hanging page', function() {
-//         return Nightmare({gotoTimeout: 500})
-//           .goto(fixture('navigation/hanging-resources.html'))
-//           .evaluate(() => document.title)
-//           .end()
-//           .then(function(title) {
-//             title.should.equal('Hanging resource load');
-//           });
-//       });
-//
-//       it('should allow loading a new page after timing out', function() {
-//         nightmare.end().then();
-//         nightmare = Nightmare({gotoTimeout: 1000});
-//         return nightmare.goto(fixture('wait')).should.be.rejected
-//           .then(function() {
-//             return nightmare.goto(fixture('navigation'));
-//           });
-//       });
-//
-//       it('should allow for timeouts for non-goto loads', function*() { // ###
-//         this.timeout(40000);
-//         var nightmare = Nightmare({loadTimeout: 30000});
-//         yield nightmare
-//           .goto(fixture('navigation'))
-//           .click('#never-ends');
-//
-//         yield nightmare.end();
-//       });
-//     });
-//   });
-//
-//   describe('evaluation', function () {
-//     var nightmare;
-//
-//     beforeEach(function() {
-//       nightmare = Nightmare();
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should get the title', function*() {
-//       var title = yield nightmare
-//         .goto(fixture('evaluation'))
-//         .title();
-//       title.should.eql('Evaluation');
-//     });
-//
-//     it('should get the url', function*() {
-//       var url = yield nightmare
-//         .goto(fixture('evaluation'))
-//         .url();
-//       url.should.have.string(fixture('evaluation'));
-//     });
-//
-//     it('should get the path', function*() {
-//       var path = yield nightmare
-//         .goto(fixture('evaluation'))
-//         .path();
-//       var formalUrl = fixture('evaluation') + '/';
-//
-//       formalUrl.should.have.string(path);
-//     });
-//
-//     it('should check if the selector exists', function*() {
-//       // existent element
-//       var exists = yield nightmare
-//         .goto(fixture('evaluation'))
-//         .exists('h1.title');
-//       exists.should.be.true;
-//
-//       // non-existent element
-//       exists = yield nightmare.exists('a.blahblahblah');
-//       exists.should.be.false;
-//     });
-//
-//     it('should check if an element is visible', function*() {
-//       // visible element
-//       var visible = yield nightmare
-//         .goto(fixture('evaluation'))
-//         .visible('h1.title');
-//       visible.should.be.true;
-//
-//       // hidden element
-//       visible = yield nightmare
-//         .visible('.hidden');
-//       visible.should.be.false;
-//
-//         // non-existent element
-//       visible = yield nightmare
-//         .visible('#asdfasdfasdf');
-//       visible.should.be.false;
-//     });
-//
-//     it('should check if an element is visible', function*() {
-//       // visible element
-//       var visible = yield nightmare
-//         .goto(fixture('evaluation'))
-//         .visible('h1.title');
-//       visible.should.be.true;
-//
-//       // hidden element
-//       visible = yield nightmare
-//         .visible('.hidden');
-//       visible.should.be.false;
-//
-//       // non-existent element
-//       visible = yield nightmare
-//         .visible('#asdfasdfasdf');
-//       visible.should.be.false;
-//     });
-//
-//     it('should evaluate javascript on the page, with parameters', function*() {
-//       var title = yield nightmare
-//         .goto(fixture('evaluation'))
-//         .evaluate(function (parameter) {
-//           return document.title + ' -- ' + parameter;
-//         }, 'testparameter');
-//       title.should.equal('Evaluation -- testparameter');
-//     });
-//
-//     it('should capture invalid evaluate fn', function() {
-//       return nightmare
-//         .goto(fixture('evaluation'))
-//         .evaluate('not_a_function')
-//         .should.be.rejected;
-//     });
-//
-//     describe('asynchronous', function(){
-//       it('should allow for asynchronous evaluation with a callback', function*() {
-//         var asyncValue = yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function(done) {
-//             setTimeout(() => done(null, 'nightmare'), 1000);
-//           });
-//
-//           asyncValue.should.equal('nightmare');
-//       });
-//       it('should allow for arguments with asynchronous evaluation with a callback', function*() {
-//         var asyncValue = yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function(str, done) {
-//             setTimeout(() => done(null, str), 1000);
-//           }, 'nightmare');
-//
-//           asyncValue.should.equal('nightmare');
-//       });
-//
-//       it('should allow for errors in asynchronous evaluation with a callback', function*() {
-//         yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function(done) {
-//             setTimeout(() => done(new Error('nightmare')), 1000);
-//           }).should.be.rejected;
-//       });
-//
-//       it('should allow for timeouts in asynchronous evaluation with a callback', function*() {
-//         this.timeout(40000);
-//         yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function(done) {
-//             //don't call done
-//           }).should.be.rejected;
-//       });
-//
-//       it('should allow for asynchronous evaluation with a promise', function*() {
-//         var asyncValue =  yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function() {
-//             return new Promise(resolve => {
-//               setTimeout(() => resolve('nightmare'), 1000);
-//             });
-//           })
-//
-//           asyncValue.should.equal('nightmare');
-//       });
-//
-//       it('should allow for arguments with asynchronous evaluation with a promise', function*() {
-//         var asyncValue =  yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function(str) {
-//             return new Promise(resolve => {
-//               setTimeout(() => resolve(str), 1000);
-//             });
-//           }, 'nightmare')
-//
-//           asyncValue.should.equal('nightmare');
-//       });
-//
-//       it('should allow for errors in asynchronous evaluation with a promise', function*() {
-//         yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function() {
-//             return new Promise((resolve, reject) => {
-//               setTimeout(() => reject(new Error('nightmare')), 1000);
-//             });
-//           }).should.be.rejected;
-//       });
-//
-//       it('should allow for timeouts in asynchronous evaluation with a promise', function*() {
-//         this.timeout(40000);
-//         yield nightmare
-//           .goto(fixture('evaluation'))
-//           .evaluate(function() {
-//             return new Promise((resolve, reject) => {
-//               return 'nightmare';
-//             });
-//           }).should.be.rejected;
-//       });
-//     });
-//   });
-//
-//   describe('manipulation', function () {
-//     var nightmare;
-//
-//     beforeEach(function() {
-//       nightmare = Nightmare();
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should inject javascript onto the page', function*() {
-//       var globalNumber = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .inject('js', 'test/files/globals.js')
-//         .evaluate(function () {
-//           return globalNumber;
-//         });
-//       globalNumber.should.equal(7);
-//
-//       var numAnchors = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .inject('js', 'test/files/jquery-2.1.1.min.js')
-//         .evaluate(function () {
-//           return $('h1').length;
-//         });
-//       numAnchors.should.equal(1);
-//     });
-//
-//     it('should inject javascript onto the page ending with a comment', function*() {
-//       var globalNumber = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .inject('js', 'test/files/globals.js')
-//         .evaluate(function () {
-//           return globalNumber;
-//         });
-//       globalNumber.should.equal(7);
-//
-//       var numAnchors = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .inject('js', 'test/files/jquery-1.9.0.min.js')
-//         .evaluate(function () {
-//           return $('h1').length;
-//         });
-//       numAnchors.should.equal(1);
-//     });
-//
-//     it('should inject css onto the page', function*() {
-//       var color = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .inject('js', 'test/files/jquery-2.1.1.min.js')
-//         .inject('css', 'test/files/test.css')
-//         .evaluate(function () {
-//           return $('body').css('background-color');
-//         });
-//       color.should.equal('rgb(255, 0, 0)');
-//     });
-//
-//     it('should not inject unsupported types onto the page', function*() {
-//       var color = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .inject('js', 'test/files/jquery-2.1.1.min.js')
-//         .inject('pdf', 'test/files/test.css')
-//         .evaluate(function () {
-//           return $('body').css('background-color');
-//         });
-//       color.should.not.equal('rgb(255, 0, 0)');
-//     });
-//
-//     it('should type', function*() {
-//       var input = 'nightmare'
-//       var events = input.length * 3
-//
-//       var value = yield nightmare
-//         .on('console', function (type, input, message) {
-//           if (type === 'log') events--;
-//         })
-//         .goto(fixture('manipulation'))
-//         .type('input[type=search]', input)
-//         .evaluate(function() {
-//           return document.querySelector('input[type=search]').value;
-//         });
-//
-//       value.should.equal('nightmare');
-//       events.should.equal(0);
-//     });
-//
-//     it('should type integer', function* () {
-//         var input = 10;
-//         var events = input.toString().length * 3;
-//
-//         var value = yield nightmare
-//           .on('console', function (type, input, message) {
-//             if (type === 'log') events--;
-//           })
-//           .goto(fixture('manipulation'))
-//           .type('input[type=search]', input)
-//           .evaluate(function() {
-//             return document.querySelector('input[type=search]').value;
-//           });
-//
-//         value.should.equal('10');
-//         events.should.equal(0);
-//     });
-//
-//
-//     it('should type object', function* () {
-//         var input = {
-//           foo: 'bar'
-//         };
-//         var events = input.toString().length * 3;
-//
-//         var value = yield nightmare
-//           .on('console', function (type, input, message) {
-//             if (type === 'log') events--;
-//           })
-//           .goto(fixture('manipulation'))
-//           .type('input[type=search]', input)
-//           .evaluate(function() {
-//             return document.querySelector('input[type=search]').value;
-//           });
-//
-//         value.should.equal('[object Object]');
-//         events.should.equal(0);
-//     });
-//
-//     it('should clear inputs', function*() {
-//       var input = 'nightmare'
-//       var events = input.length * 3
-//
-//       var value = yield nightmare
-//         .on('console', function (type, input, message) {
-//           if (type === 'log') events--;
-//         })
-//         .goto(fixture('manipulation'))
-//         .type('input[type=search]', input)
-//         .type('input[type=search]')
-//         .evaluate(function() {
-//           return document.querySelector('input[type=search]').value;
-//         });
-//
-//       value.should.equal('');
-//       events.should.equal(0);
-//     });
-//
-//     it('should support inserting text', function*() {
-//       var input = 'nightmare insert typing'
-//
-//       var value = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .insert('input[type=search]', input)
-//         .evaluate(function() {
-//           return document.querySelector('input[type=search]').value;
-//         });
-//
-//       value.should.equal('nightmare insert typing');
-//     })
-//
-//     it('should support clearing inserted text', function*() {
-//
-//       var value = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .insert('input[type=search]')
-//         .evaluate(function() {
-//           return document.querySelector('input[type=search]').value;
-//         });
-//
-//       value.should.equal('');
-//     })
-//
-//     it('should not type in a nonexistent selector', function(){
-//       return nightmare
-//         .goto(fixture('manipulation'))
-//         .type('does-not-exist', 'nightmare')
-//         .should.be.rejected;
-//     });
-//
-//     it('should not insert in a nonexistent selector', function(){
-//       return nightmare
-//         .goto(fixture('manipulation'))
-//         .insert('does-not-exist', 'nightmare')
-//         .should.be.rejected;
-//     });
-//
-//     it('should blur the active element when something is clicked', function*() {
-//       var isBody = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .type('input[type=search]', 'test')
-//         .click('p')
-//         .evaluate(function() {
-//           return document.activeElement === document.body;
-//         });
-//       isBody.should.be.true;
-//     });
-//
-//     it('should allow for clicking on elements with attribute selectors', function*() {
-//       yield nightmare
-//         .goto(fixture('manipulation'))
-//         .click('div[data-test="test"]')
-//     });
-//
-//     it('should not allow for code injection with .click()', function(done){
-//       var exception;
-//       nightmare
-//         .goto(fixture('manipulation'))
-//         .click('"]\'); document.title = \'injected title\'; (\'"')
-//         .catch((e) => exception = e)
-//         .then(()=> nightmare.title())
-//         .then((title) => {
-//           exception.should.exist;
-//           title.should.equal('Manipulation');
-//           done();
-//         });
-//     });
-//
-//     it('should not fail if selector no longer exists to blur after typing', function*() {
-//       yield nightmare
-//         .on('console', function(){ console.log(arguments)})
-//         .goto(fixture('manipulation'))
-//         .type('input#disappears', 'nightmare');
-//     });
-//
-//     it('should type and click', function*() {
-//       var title = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .type('input[type=search]', 'nightmare')
-//         .click('button[type=submit]')
-//         .wait(500)
-//         .title();
-//
-//       title.should.equal('Manipulation - Results');
-//     });
-//
-//     it('should type and click several times', function*() {
-//       var title = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .type('input[type=search]', 'github nightmare')
-//         .click('button[type=submit]')
-//         .wait(500)
-//         .click('a')
-//         .wait(500)
-//         .title();
-//       title.should.equal('Manipulation - Result - Nightmare');
-//     });
-//
-//     it('should checkbox', function*() {
-//       var checkbox = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .check('input[type=checkbox]')
-//         .evaluate(function () {
-//           return document.querySelector('input[type=checkbox]').checked;
-//         });
-//       checkbox.should.be.true;
-//     });
-//
-//     it('should uncheck', function*() {
-//       var checkbox = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .check('input[type=checkbox]')
-//         .uncheck('input[type=checkbox]')
-//         .evaluate(function () {
-//           return document.querySelector('input[type=checkbox]').checked;
-//         });
-//       checkbox.should.be.false;
-//     });
-//
-//     it('should select', function*() {
-//       var select = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .select('select', 'b')
-//         .evaluate(function () {
-//           return document.querySelector('select').value;
-//         });
-//       select.should.equal('b');
-//     });
-//
-//     it('should scroll to specified position', function*() {
-//       // start at the top
-//       var coordinates = yield nightmare
-//         .viewport(320, 320)
-//         .goto(fixture('manipulation'))
-//         .evaluate(function () {
-//           return {
-//             top: document.body.scrollTop,
-//             left: document.body.scrollLeft
-//           };
-//         });
-//       coordinates.top.should.equal(0);
-//       coordinates.left.should.equal(0);
-//
-//       // scroll down a bit
-//       coordinates = yield nightmare
-//         .scrollTo(100, 50)
-//         .evaluate(function () {
-//           return {
-//             top: document.body.scrollTop,
-//             left: document.body.scrollLeft
-//           };
-//         });
-//       coordinates.top.should.equal(100);
-//       coordinates.left.should.equal(50);
-//     });
-//
-//     it('should hover over an element', function*() {
-//       var color = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .mouseover('h1')
-//         .evaluate(function () {
-//           var element = document.querySelector('h1');
-//           return element.style.background;
-//         });
-//       color.should.equal('rgb(102, 255, 102)');
-//     });
-//
-//     it('should mousedown on an element', function*() {
-//       var color = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .mousedown('h1')
-//         .evaluate(function () {
-//           var element = document.querySelector('h1');
-//           return element.style.background;
-//         });
-//       color.should.equal('rgb(255, 0, 0)');
-//     });
-//   });
-//
-//   describe('cookies', function() {
-//     var nightmare;
-//
-//     beforeEach(function() {
-//       nightmare = Nightmare({webPreferences: {partition: 'test-partition'}})
-//         .goto(fixture('cookie'));
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('.set(name, value) & .get(name)', function*() {
-//       var cookies = nightmare.cookies
-//
-//       yield cookies.set('hi', 'hello')
-//       var cookie = yield cookies.get('hi')
-//
-//       cookie.name.should.equal('hi')
-//       cookie.value.should.equal('hello')
-//       cookie.path.should.equal('/')
-//       cookie.secure.should.equal(false)
-//     })
-//
-//     it('.set(obj) & .get(name)', function*() {
-//       var cookies = nightmare.cookies
-//
-//       yield cookies.set({
-//         name: 'nightmare',
-//         value: 'rocks',
-//         path: '/cookie'
-//       })
-//       var cookie = yield cookies.get('nightmare')
-//
-//       cookie.name.should.equal('nightmare')
-//       cookie.value.should.equal('rocks')
-//       cookie.path.should.equal('/cookie')
-//       cookie.secure.should.equal(false)
-//     })
-//
-//     it('.set([cookie1, cookie2]) & .get()', function*() {
-//       var cookies = nightmare.cookies
-//
-//       yield cookies.set([
-//         {
-//           name: 'hi',
-//           value: 'hello',
-//           path: '/'
-//         },
-//         {
-//           name: 'nightmare',
-//           value: 'rocks',
-//           path: '/cookie'
-//         }
-//       ])
-//
-//       var cookies = yield cookies.get()
-//       cookies.length.should.equal(2)
-//
-//       // sort in case they come in a different order
-//       cookies = cookies.sort(function (a, b) {
-//         if (a.name > b.name) return 1
-//         if (a.name < b.name) return -1
-//         return 0
-//       })
-//
-//       cookies[0].name.should.equal('hi')
-//       cookies[0].value.should.equal('hello')
-//       cookies[0].path.should.equal('/')
-//       cookies[0].secure.should.equal(false)
-//
-//       cookies[1].name.should.equal('nightmare')
-//       cookies[1].value.should.equal('rocks')
-//       cookies[1].path.should.equal('/cookie')
-//       cookies[1].secure.should.equal(false)
-//     })
-//
-//     it('.set([cookie1, cookie2]) & .get(query)', function*() {
-//       var cookies = nightmare.cookies
-//
-//       yield cookies.set([
-//         {
-//           name: 'hi',
-//           value: 'hello',
-//           path: '/'
-//         },
-//         {
-//           name: 'nightmare',
-//           value: 'rocks',
-//           path: '/cookie'
-//         }
-//       ])
-//
-//       var cookies = yield cookies.get({ path: '/cookie'})
-//       cookies.length.should.equal(1)
-//
-//       cookies[0].name.should.equal('nightmare')
-//       cookies[0].value.should.equal('rocks')
-//       cookies[0].path.should.equal('/cookie')
-//       cookies[0].secure.should.equal(false)
-//     })
-//
-//     it('.set([cookie]) & .clear(name) & .get(query)', function*() {
-//       var cookies = nightmare.cookies
-//
-//       yield cookies.set([
-//         {
-//           name: 'hi',
-//           value: 'hello',
-//           path: '/'
-//         },
-//         {
-//           name: 'nightmare',
-//           value: 'rocks',
-//           path: '/cookie'
-//         }
-//       ])
-//
-//       yield cookies.clear('nightmare');
-//
-//       var cookies = yield cookies.get({ path: '/cookie' });
-//
-//       cookies.length.should.equal(0);
-//     });
-//
-//     it('.set([cookie]) & .clear() & .get()', function*() {
-//       var cookies = nightmare.cookies
-//
-//       yield cookies.set([
-//         {
-//           name: 'hi',
-//           value: 'hello',
-//           path: '/'
-//         },
-//         {
-//           name: 'nightmare',
-//           value: 'rocks',
-//           path: '/cookie'
-//         }
-//       ])
-//
-//       yield cookies.clear();
-//
-//       var cookies = yield cookies.get();
-//
-//       cookies.length.should.equal(0);
-//     })
-//
-//     it('.set([cookie]) & .clearAll() & .get()', function*() {
-//       yield nightmare.cookies.set([
-//         {
-//           name: 'hi',
-//           value: 'hello',
-//           path: '/'
-//         },
-//         {
-//           name: 'nightmare',
-//           value: 'rocks',
-//           path: '/cookie'
-//         }
-//       ]);
-//
-//       yield nightmare.goto(fixture('simple'));
-//
-//       yield nightmare.cookies.set([
-//         {
-//           name: 'hi',
-//           value: 'hello',
-//           path: '/'
-//         },
-//         {
-//           name: 'nightmare',
-//           value: 'rocks',
-//           path: '/cookie'
-//         }
-//       ]);
-//
-//
-//       yield nightmare.cookies.clearAll();
-//
-//       var cookies = yield nightmare.cookies.get();
-//       cookies.length.should.equal(0);
-//
-//       yield nightmare.goto(fixture('cookie'))
-//
-//       cookies = yield nightmare.cookies.get();
-//       cookies.length.should.equal(0);
-//     })
-//   });
-//
-//   describe('rendering', function () {
-//     var nightmare;
-//
-//     before(function(done) {
-//       mkdirp(tmp_dir, done)
-//     })
-//
-//     after(function(done) {
-//       rimraf(tmp_dir, done)
-//     })
-//
-//     beforeEach(function() {
-//       nightmare = Nightmare();
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should take a screenshot', function*() {
-//       yield nightmare
-//         .goto('https://github.com/')
-//         .screenshot(tmp_dir+'/test.png');
-//       var stats = fs.statSync(tmp_dir+'/test.png');
-//       stats.size.should.be.at.least(1000);
-//     });
-//
-//     it('should buffer a screenshot', function*() {
-//       var image = yield nightmare
-//         .goto('https://github.com')
-//         .screenshot();
-//       Buffer.isBuffer(image).should.be.true;
-//       image.length.should.be.at.least(1000);
-//     });
-//
-//     it('should take a clipped screenshot', function*() {
-//       yield nightmare
-//         .goto('https://github.com/')
-//         .screenshot(tmp_dir+'/test-clipped.png', {
-//           x: 200,
-//           y: 100,
-//           width: 100,
-//           height: 100
-//         });
-//       var stats = fs.statSync(tmp_dir+'/test.png');
-//       var statsClipped = fs.statSync(tmp_dir+'/test-clipped.png');
-//       statsClipped.size.should.be.at.least(300);
-//       stats.size.should.be.at.least(10*statsClipped.size);
-//     });
-//
-//     it('should buffer a clipped screenshot', function*() {
-//       var image = yield nightmare
-//         .goto('https://github.com')
-//         .screenshot({
-//           x: 200,
-//           y: 100,
-//           width: 100,
-//           height: 100
-//         });
-//       Buffer.isBuffer(image).should.be.true;
-//       image.length.should.be.at.least(300);
-//     });
-//
-//     // repeat this test 3 times, since the concern here is non-determinism in
-//     // the timing accuracy of screenshots -- it might pass once, but likely not
-//     // several times in a row.
-//     for (var i = 0; i < 3; i++) {
-//       it('should screenshot an up-to-date image of the page (' + i + ')', function*() {
-//         var image = yield nightmare
-//           .goto('about:blank')
-//           .viewport(100, 100)
-//           .evaluate(function() { document.body.style.background = '#900'; })
-//           .evaluate(function() { document.body.style.background = '#090'; })
-//           .screenshot();
-//
-//         var png = new PNG();
-//         var imageData = yield png.parse.bind(png, image);
-//         var firstPixel = Array.from(imageData.data.slice(0, 3));
-//         firstPixel.should.deep.equal([0, 153, 0]);
-//       });
-//     }
-//
-//     it('should screenshot an an idle page', function*() {
-//       var image = yield nightmare
-//         .goto('about:blank')
-//         .viewport(100, 100)
-//         .evaluate(function() { document.body.style.background = '#900'; })
-//         .evaluate(function() { document.body.style.background = '#090'; })
-//         .wait(1000)
-//         .screenshot();
-//
-//       var png = new PNG();
-//       var imageData = yield png.parse.bind(png, image);
-//       var firstPixel = Array.from(imageData.data.slice(0, 3));
-//       firstPixel.should.deep.equal([0, 153, 0]);
-//     });
-//
-//     it('should not subscribe to frames until necessary', function() {
-//       var didSubscribe = false;
-//       var FrameManager = require('../lib/frame-manager.js');
-//       var manager = FrameManager({
-//         webContents: {
-//           beginFrameSubscription: function() { didSubscribe = true; },
-//           endFrameSubscription: function() {},
-//           executeJavaScript: function() {}
-//         }
-//       });
-//       didSubscribe.should.be.false;
-//     });
-//
-//     it('should load jquery correctly', function*() {
-//       var loaded = yield nightmare
-//         .goto(fixture('rendering'))
-//         .wait(2000)
-//         .evaluate(function() {
-//           return !!window.jQuery;
-//         });
-//       loaded.should.be.at.least(true);
-//     });
-//
-//     it('should render fonts correctly', function*() {
-//       yield nightmare
-//         .goto(fixture('rendering'))
-//         .wait(2000)
-//         .screenshot(tmp_dir+'/font-rendering.png');
-//       var stats = fs.statSync(tmp_dir+'/font-rendering.png');
-//       stats.size.should.be.at.least(1000);
-//     });
-//
-//     it('should save as html', function*() {
-//       yield nightmare
-//         .goto(fixture('manipulation'))
-//         .html(tmp_dir+'/test.html');
-//       var stats = fs.statSync(tmp_dir+'/test.html');
-//       stats.should.be.ok;
-//     });
-//
-//     it('should render a PDF', function*() {
-//       yield nightmare
-//         .goto(fixture('manipulation'))
-//         .pdf(tmp_dir+'/test.pdf');
-//       var stats = fs.statSync(tmp_dir+'/test.pdf');
-//       stats.size.should.be.at.least(1000);
-//     });
-//
-//     it('should accept options to render a PDF', function*() {
-//       yield nightmare
-//         .goto(fixture('manipulation'))
-//         .pdf(tmp_dir+'/test2.pdf', {printBackground: false});
-//       var stats = fs.statSync(tmp_dir+'/test2.pdf');
-//       stats.size.should.be.at.least(1000);
-//     });
-//
-//     it('should return a buffer from a PDF with no path', function*() {
-//       var buf = yield nightmare
-//         .goto(fixture('manipulation'))
-//         .pdf({printBackground: false});
-//
-//       var isBuffer = Buffer.isBuffer(buf);
-//
-//       buf.length.should.be.at.least(1000);
-//       isBuffer.should.be.true;
-//     });
-//   });
-//
-//   describe('referer', function() {
-//     var nightmare;
-//
-//     beforeEach(function() {
-//       nightmare = Nightmare({webPreferences: {partition: 'test-partition'}});
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should return referer from headers', function*() {
-//       var referer = 'http://my-referer.tld/';
-//       var returnedReferer = yield nightmare
-//         .goto(fixture('referer'), {
-//           'Referer': referer
-//         })
-//         .evaluate(function () {
-//           return document.body.innerText;
-//         })
-//         ;
-//
-//       referer.should.be.equal(returnedReferer.trim());
-//     })
-//   });
-//
-//   describe('events', function () {
-//     var nightmare;
-//
-//     beforeEach(function() {
-//       nightmare = Nightmare();
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should fire an event on page load complete', function*() {
-//       var fired = false;
-//       nightmare
-//         .on('did-finish-load', function () {
-//           fired = true;
-//         });
-//       yield nightmare
-//         .goto(fixture('events'));
-//       fired.should.be.true;
-//     });
-//
-//     it('should fire an event on javascript error', function*() {
-//       var fired = false;
-//       nightmare
-//         .on('page', function (type, errorMessage, errorStack) {
-//           if (type === 'error') {
-//             fired = true;
-//           }
-//         });
-//       yield nightmare
-//         .goto(fixture('events'));
-//       fired.should.be.true;
-//     });
-//
-//     it('should fire an event on javascript console.log', function*() {
-//       var log = '';
-//
-//       nightmare.on('console', function (type, str) {
-//         if (type === 'log') log = str
-//       });
-//
-//       yield nightmare.goto(fixture('events'));
-//       log.should.equal('my log');
-//
-//       yield nightmare.click('button')
-//       log.should.equal('clicked');
-//
-//     });
-//
-//     it('should fire an event on page load failure', function*() {
-//       var fired = false;
-//       nightmare
-//         .on('did-fail-load', function () {
-//           fired = true;
-//         });
-//       try {
-//         yield nightmare
-//           .goto('https://alskdjfasdfuuu.com');
-//       }
-//       catch(error) {}
-//       fired.should.be.true;
-//     });
-//
-//     it('should fire an event on javascript window.alert', function*(){
-//       var alert = '';
-//       nightmare.on('page', function(type, message){
-//         if (type === 'alert') {
-//           alert = message;
-//         }
-//       });
-//
-//       yield nightmare
-//         .goto(fixture('events'))
-//         .evaluate(function(){
-//           alert('my alert');
-//         });
-//       alert.should.equal('my alert');
-//     });
-//
-//     it('should fire an event on javascript window.prompt', function*(){
-//       var prompt = '';
-//       var response = ''
-//       nightmare.on('page', function(type, message, res){
-//         if (type === 'prompt') {
-//           prompt = message;
-//           response = res
-//         }
-//       });
-//
-//       yield nightmare
-//         .goto(fixture('events'))
-//         .evaluate(function(){
-//           prompt('my prompt', 'hello!');
-//         });
-//       prompt.should.equal('my prompt');
-//       response.should.equal('hello!');
-//     });
-//
-//     it('should fire an event on javascript window.confirm', function*(){
-//       var confirm = '';
-//       var response = ''
-//       nightmare.on('page', function(type, message, res){
-//         if (type === 'confirm') {
-//           confirm = message;
-//           response = res
-//         }
-//       });
-//
-//       yield nightmare
-//         .goto(fixture('events'))
-//         .evaluate(function(){
-//           confirm('my confirm', 'hello!');
-//         });
-//       confirm.should.equal('my confirm');
-//       response.should.equal('hello!');
-//     });
-//
-//     it('should only fire once when using once', function*() {
-//       var events = 0;
-//       nightmare.once('page', function(type, message) {
-//         events++;
-//       });
-//
-//       yield nightmare
-//         .goto(fixture('events'))
-//       events.should.equal(1);
-//     });
-//
-//     it('should remove event listener', function*() {
-//       var events = 0;
-//       var handler = function(type, message) {
-//         if (type === 'alert') {
-//           events++;
-//         }
-//       };
-//
-//       nightmare.on('page', handler);
-//
-//       yield nightmare
-//         .goto(fixture('events'))
-//         .evaluate(function(){
-//           alert('alert one');
-//         });
-//
-//       nightmare.removeListener('page', handler);
-//
-//       yield nightmare
-//         .evaluate(function(){
-//           alert('alert two');
-//         });
-//
-//       events.should.equal(1);
-//     });
-//   });
-//
-//   describe('options', function () {
-//     var nightmare;
-//     var server;
-//
-//     before(function(done) {
-//       // set up an HTTPS server using self-signed certificates -- Nightmare
-//       // will only be able to talk to it if 'ignore-certificate-errors' is set.
-//       server = https.createServer({
-//         key: fs.readFileSync(path.join(__dirname, 'files', 'server.key')),
-//         cert: fs.readFileSync(path.join(__dirname, 'files', 'server.crt'))
-//       }, function(request, response) {
-//         response.end('ok\n');
-//       }).listen(0, 'localhost', function() {
-//         var address = server.address();
-//         server.url = `https://${address.address}:${address.port}`;
-//         done();
-//       });
-//     });
-//
-//     after(function() {
-//       server.close();
-//       server = null;
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should set useragent', function* () {
-//       nightmare = new Nightmare();
-//       var useragent = yield nightmare
-//         .useragent('firefox')
-//         .goto(fixture('options'))
-//         .evaluate(function () {
-//           return window.navigator.userAgent;
-//         });
-//       useragent.should.eql('firefox');
-//     });
-//
-//     it('should wait and fail with waitTimeout', function() {
-//       nightmare = Nightmare({waitTimeout: 254});
-//       return nightmare
-//         .goto(fixture('navigation'))
-//         .wait('foobar')
-//         .should.be.rejected;
-//     });
-//
-//     it('should wait and fail with waitTimeout and a ms wait time', function() {
-//       nightmare = Nightmare({waitTimeout: 254});
-//       return nightmare
-//         .goto(fixture('navigation'))
-//         .wait(1000)
-//         .should.be.rejected;
-//     });
-//
-//     it('should wait and fail with waitTimeout with queued functions', function() {
-//       nightmare = Nightmare({waitTimeout: 254});
-//       return nightmare
-//         .goto(fixture('navigation'))
-//         .wait('foobar')
-//         .exists('baz')
-//         .should.be.rejected;
-//     });
-//
-//     it('should set authentication', function*() {
-//       nightmare = Nightmare();
-//       var data = yield nightmare
-//         .authentication('my', 'auth')
-//         .goto(fixture('auth'))
-//         .evaluate(function () {
-//           return JSON.parse(document.querySelector('pre').innerHTML);
-//         });
-//       data.should.eql({ name: 'my', pass: 'auth' });
-//     });
-//
-//     it('should fail on authentication failure', function*() {
-//       nightmare = Nightmare();
-//       var data = yield nightmare
-//         .authentication('my', 'wrong')
-//         .goto(fixture('auth'))
-//         .should.be.rejected;
-//     });
-//
-//     it('should be able to update authentication', function*(){
-//       nightmare = Nightmare();
-//       var data = yield nightmare
-//         .authentication('my', 'auth')
-//         .goto(fixture('auth'))
-//         .authentication('my2', 'auth2')
-//         .goto(fixture('auth2'))
-//         .evaluate(function () {
-//           return JSON.parse(document.querySelector('pre').innerHTML);
-//         });
-//       data.should.eql({ name: 'my2', pass: 'auth2' });
-//     });
-//
-//     it('should set viewport', function*() {
-//       var size = { width: 400, height: 300, useContentSize: true };
-//       nightmare = Nightmare(size);
-//       var result = yield nightmare
-//         .goto(fixture('options'))
-//         .evaluate(function () {
-//           return {
-//             width: window.innerWidth,
-//             height: window.innerHeight
-//           };
-//         });
-//       result.width.should.eql(size.width);
-//       result.height.should.eql(size.height);
-//     });
-//
-//     it('should set a single header', function*() {
-//       nightmare = Nightmare();
-//       var headers = yield nightmare
-//         .header('X-Nightmare-Header', 'hello world')
-//         .goto(fixture('headers'))
-//         .evaluate(function () {
-//           return JSON.parse(document.querySelector('pre').innerHTML);
-//         });
-//       headers['x-nightmare-header'].should.equal('hello world');
-//     });
-//
-//     it('should set all headers', function*() {
-//       nightmare = Nightmare();
-//       var headers = yield nightmare
-//         .header({ 'X-Foo': 'foo', 'X-Bar': 'bar'})
-//         .goto(fixture('headers'))
-//         .evaluate(function () {
-//           return JSON.parse(document.querySelector('pre').innerHTML);
-//         });
-//       headers['x-foo'].should.equal('foo');
-//       headers['x-bar'].should.equal('bar');
-//     });
-//
-//     it('should set headers for that request', function*() {
-//       nightmare = Nightmare();
-//       var headers = yield nightmare
-//         .goto(fixture('headers'), { 'X-Nightmare-Header': 'hello world' })
-//         .evaluate(function () {
-//           return JSON.parse(document.querySelector('pre').innerHTML);
-//         });
-//       headers['x-nightmare-header'].should.equal('hello world');
-//     });
-//
-//     it('should allow webPreferences settings', function*() {
-//       nightmare = Nightmare({webPreferences: {webSecurity: false}});
-//       var result = yield nightmare
-//         .goto(fixture('options'))
-//         .evaluate(function () {
-//           return document.getElementById('example-iframe').contentDocument;
-//         });
-//
-//       result.should.be.ok;
-//     });
-//
-//     it('should be constructable with paths', function*() {
-//       nightmare = Nightmare({ paths:{ userData : __dirname } });
-//       nightmare.should.be.ok;
-//     });
-//
-//     it('should be constructable with switches', function*() {
-//       nightmare = Nightmare({
-//         switches: {
-//           // empty string and non-string values all represent no value
-//           'ignore-certificate-errors': null,
-//           'touch-events': ''
-//         }
-//       });
-//       nightmare.should.be.ok;
-//       var touchEvents = yield nightmare
-//         .goto(server.url)
-//         .evaluate(function() {
-//           return 'ontouchstart' in window;
-//         });
-//       touchEvents.should.be.true;
-//     });
-//
-//     it('should support switches with values', function*() {
-//       nightmare = Nightmare({ switches: { 'force-device-scale-factor': '5' } });
-//       nightmare.should.be.ok;
-//       var scaleFactor = yield nightmare
-//         .goto('about:blank')
-//         .evaluate(function() {
-//           return window.devicePixelRatio;
-//         });
-//       scaleFactor.should.equal(5);
-//     });
-//
-//     it('should allow to use external Electron', function*() {
-//       nightmare = Nightmare({ electronPath: require('electron') });
-//       nightmare.should.be.ok;
-//     });
-//
-//     it('should allow to use external Promise', function*() {
-//       nightmare = Nightmare({ Promise: require('bluebird') });
-//       nightmare.should.be.ok;
-//       const thenPromise = nightmare.goto('about:blank').then();
-//       thenPromise.should.be.an.instanceof(require('bluebird'));
-//       yield thenPromise;
-//       const catchPromise = nightmare.goto('about:blank').catch();
-//       catchPromise.should.be.an.instanceof(require('bluebird'));
-//       yield catchPromise;
-//       const endPromise = nightmare.goto('about:blank').end().then();
-//       endPromise.constructor.should.equal(require('bluebird'));
-//       endPromise.should.be.an.instanceof(require('bluebird'));
-//       yield endPromise;
-//     });
-//   });
-//
-//   describe('Nightmare.Promise', function() {
-//     var nightmare;
-//     afterEach(function*() {
-//       // `withDeprecationTracking()` messes w/ prototype constructor references
-//       Nightmare.Promise = require('..').Promise = Promise;
-//       yield nightmare.end();
-//     });
-//
-//     it('should default to native Promise', function*() {
-//       Nightmare.Promise.should.equal(Promise);
-//       nightmare = Nightmare();
-//       nightmare.should.be.ok;
-//       var thenPromise = nightmare.goto('about:blank').then();
-//       thenPromise.should.be.an.instanceof(Promise);
-//       yield thenPromise;
-//     });
-//
-//     it('should override default Promise library', function*() {
-//       // `withDeprecationTracking()` messes w/ prototype constructor references
-//       Nightmare.Promise = require('..').Promise = require('bluebird');
-//       Nightmare.Promise.should.equal(require('bluebird'));
-//       nightmare = Nightmare();
-//       nightmare.should.be.ok;
-//       var thenPromise = nightmare.goto('about:blank').then();
-//       thenPromise.should.be.an.instanceof(require('bluebird'));
-//       yield thenPromise;
-//     });
-//
-//     it('should not override per-instance Promise library', function*() {
-//       Nightmare.Promise.should.equal(Promise);
-//       nightmare = Nightmare({ Promise: require('bluebird') });
-//       nightmare.should.be.ok;
-//       var thenPromise = nightmare.goto('about:blank').then();
-//       thenPromise.should.not.be.an.instanceof(Promise);
-//       thenPromise.should.be.an.instanceof(require('bluebird'));
-//       yield thenPromise;
-//     });
-//   })
-//
-//   describe('Nightmare.action(name, fn)', function() {
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should support custom actions', function*() {
-//       Nightmare.action('size', function (done) {
-//         this.evaluate_now(function() {
-//           var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
-//           var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
-//           return {
-//             height: h,
-//             width: w
-//           }
-//         }, done)
-//       })
-//
-//       nightmare = new Nightmare();
-//
-//       var size = yield nightmare
-//         .goto(fixture('simple'))
-//         .size()
-//
-//       size.height.should.be.a('number')
-//       size.width.should.be.a('number')
-//     })
-//
-//     it('should support custom namespaces', function*() {
-//       Nightmare.action('style', {
-//         background: function (done) {
-//           this.evaluate_now(function () {
-//             return window.getComputedStyle(document.body, null).backgroundColor
-//           }, done)
-//         },
-//         color: function (done) {
-//           this.evaluate_now(function () {
-//             return window.getComputedStyle(document.body, null).color
-//           }, done)
-//         }
-//       })
-//
-//       nightmare = Nightmare()
-//       yield nightmare.goto(fixture('simple'))
-//       var background = yield nightmare.style.background()
-//       var color = yield nightmare.style.color()
-//
-//       background.should.equal('rgba(0, 0, 0, 0)')
-//       color.should.equal('rgb(0, 0, 0)')
-//     })
-//
-//     it('should support extending Electron', function*(){
-//       Nightmare.action('bind',
-//         function(ns, options, parent, win, renderer, done) {
-//           var sliced = require('sliced');
-//           parent.on('bind', function(name) {
-//             if (renderer.listeners(name)
-//               .length == 0) {
-//               renderer.on(name, function() {
-//                 parent.emit.apply(parent, [name].concat(sliced(arguments, 1)))
-//               });
-//             }
-//             parent.emit('bind');
-//           });
-//           done();
-//         },
-//         function() {
-//           var name = arguments[0],
-//             handler, done;
-//           if (arguments.length == 2) {
-//             done = arguments[1];
-//           } else if (arguments.length == 3) {
-//             handler = arguments[1];
-//             done = arguments[2];
-//           }
-//           if (handler) {
-//             this.child.on(name, handler);
-//           }
-//           this.child.once('bind', done);
-//           this.child.emit('bind', name);
-//         });
-//
-//       var eventResults;
-//       nightmare = new Nightmare();
-//       yield nightmare
-//         .goto('http://example.com')
-//         .on('sample-event', function() {
-//           eventResults = arguments;
-//         })
-//         .bind('sample-event')
-//         .evaluate(function() {
-//           ipc.send('sample-event', 'sample', 3, {
-//             sample: 'sample'
-//           });
-//         });
-//
-//       eventResults.length.should.equal(3);
-//       eventResults[0].should.equal('sample');
-//       eventResults[1].should.equal(3);
-//       eventResults[2].sample.should.equal('sample');
-//     });
-//
-//     it('should allow env variables', function*() {
-//       Nightmare.action('envtest',
-//         function (name, options, parent, win, renderer, done) {
-//           parent.respondTo('envtest', function(done){
-//             done(null, process.env);
-//           });
-//           done();
-//         },
-//         function(done) {
-//           this.child.call('envtest', done);
-//         }
-//       );
-//       nightmare = Nightmare({
-//         env: {
-//           TZ: 'UTC'
-//         }
-//       });
-//       nightmare.should.be.ok;
-//       var envTest = yield nightmare
-//         .goto('about:bank')
-//         .envtest();
-//       envTest.should.be.ok;
-//       envTest.should.have.property('TZ', 'UTC');
-//     });
-//   })
-//
-//   describe('Nightmare.use', function() {
-//     beforeEach(function() {
-//       nightmare = Nightmare();
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should support extending nightmare', function*() {
-//       var tagName = yield nightmare
-//         .goto(fixture('simple'))
-//         .use(select('h1'))
-//
-//       tagName.should.equal('H1')
-//
-//       function select (tagname) {
-//         return function (nightmare) {
-//           nightmare.evaluate(function (tagname) {
-//             return document.querySelector(tagname).tagName
-//           }, tagname)
-//         }
-//       }
-//     })
-//   })
-//
-//   describe('custom preload script', function() {
-//     beforeEach(function() {
-//       nightmare = Nightmare();
-//     });
-//
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     it('should support passing your own preload script in', function*() {
-//       var nightmare = Nightmare({
-//         webPreferences: {
-//           preload: path.join(__dirname, 'fixtures', 'preload', 'index.js')
-//         }
-//       })
-//
-//       var value = yield nightmare
-//         .goto(fixture('preload'))
-//         .evaluate(function() {
-//           return window.preload
-//         })
-//
-//       value.should.equal('custom')
-//     })
-//   })
-//
-//   describe('devtools', function(){
-//     beforeEach(function() {
-//       Nightmare.action('waitForDevTools',
-//         function(ns, options, parent, win, renderer, done){
-//           parent.on('waitForDevTools', function() {
-//             function opened() { parent.emit('waitForDevTools', null, true); }
-//             if (win.webContents.isDevToolsOpened()) {
-//               return opened();
-//             }
-//             win.webContents.once('devtools-opened', opened);
-//           });
-//           done();
-//         },
-//         function(done){
-//           this.child.once('waitForDevTools', done);
-//           this.child.emit('waitForDevTools');
-//         });
-//       nightmare = Nightmare({show:true, openDevTools:true});
-//
-//     });
-//
-//     afterEach(function*(){
-//       yield nightmare.end();
-//     });
-//
-//     it('should open devtools', function*(){
-//       var devToolsOpen = yield nightmare
-//         .goto(fixture('simple'))
-//         .waitForDevTools();
-//
-//       devToolsOpen.should.be.true;
-//     });
-//   });
-//
-//   describe('ipc', function(){
-//     beforeEach(function() {
-//       Nightmare.action('test',
-//         function(_, __, parent, ___, ____, done) {
-//           parent.respondTo('test', function(arg1, done) {
-//             done.progress('one');
-//             done.progress('two');
-//             if (arg1 === 'error') {
-//               return done('Error!');
-//             }
-//             else {
-//               done(null, `Got ${arg1}`);
-//             }
-//           });
-//           done();
-//         },
-//         function(options, done) {
-//           var channel = this.child.call('test', options.arg || options, done);
-//           if (options.onData) { channel.on('data', options.onData); }
-//           if (options.onEnd) { channel.on('end', options.onEnd); }
-//         });
-//       Nightmare.action('noImplementation',
-//         function(done) {
-//           this.child.call('noImplementation', done);
-//         });
-//       nightmare = Nightmare();
-//     });
-//
-//     afterEach(function*(){
-//       yield nightmare.end();
-//     });
-//
-//     it('should only make one IPC instance per process', function() {
-//       var processStub = {send: function() {}, on: function(){}};
-//       var ipc1 = IPC(processStub);
-//       var ipc2 = IPC(processStub);
-//       ipc1.should.equal(ipc2);
-//     });
-//
-//     it('should support basic call-response', function*() {
-//       var result = yield nightmare.test('x');
-//       result.should.equal('Got x');
-//     });
-//
-//     it('should support errors across IPC', function(done) {
-//       nightmare.test('error').then(
-//         function() {
-//           done(new Error('Action succeeded when it should have errored!'));
-//         },
-//         function() {
-//           done();
-//         });
-//     });
-//
-//     it('should stream progress', function*() {
-//       var progress = [];
-//       yield nightmare.test({
-//         arg: 'x',
-//         onData: (data) => progress.push(data),
-//         onEnd: (error, data) => progress.push([error, data])
-//       });
-//       progress.should.deep.equal(['one', 'two', [null, 'Got x']]);
-//     });
-//
-//     it('should trigger error if no responder is registered', function(done) {
-//       nightmare.noImplementation().then(
-//         function() {
-//           done(new Error('Action succeeded when it should have errored!'));
-//         },
-//         function() {
-//           done();
-//         });
-//     });
-//
-//     it('should log a warning when replacing a responder', function*() {
-//       Nightmare.action('uhoh',
-//         function(_, __, parent, ___, ____, done) {
-//           parent.respondTo('test', function(done) {
-//             done();
-//           });
-//           done();
-//         },
-//         function(done) {
-//           this.child.call('test', done);
-//         });
-//
-//       var logged = false;
-//       var instance = Nightmare();
-//       instance._queue.splice(1, 0, [function(done) {
-//         this.child.on('nightmare:ipc:debug', function(message) {
-//           if (message.toLowerCase().indexOf('replacing') > -1) {
-//             logged = true;
-//           }
-//         });
-//         done();
-//       }, []]);
-//
-//       yield instance
-//         .goto('about:blank')
-//         .end();
-//       logged.should.be.true;
-//     });
-//   });
-//
-//   describe('partitioning', function(){
-//     afterEach(function*() {
-//       yield nightmare.end();
-//     });
-//
-//     // The default behavior for nightmare is to use a non-persistent partition name
-//     it('should not persist between instances by default', function *() {
-//       nightmare = Nightmare();
-//       yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           window.localStorage.setItem('testing', 'This string should not persist between instances.')
-//         })
-//         .end();
-//
-//       nightmare = Nightmare();
-//       var value = yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           return window.localStorage.getItem('testing') || ''
-//         });
-//
-//       value.should.equal('');
-//     })
-//
-//     // Setting the partition to null we default to the electron default behavior
-//     // which is to use a persistent storage between instances.
-//     it('should persist between instances if partition is null', function *() {
-//       nightmare = Nightmare({ webPreferences: { partition: null } });
-//       yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           window.localStorage.setItem('testing', 'This string should persist between instances.')
-//         })
-//         .end();
-//
-//       nightmare = Nightmare({ webPreferences: { partition: null } });
-//       var value = yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           return window.localStorage.getItem('testing') || ''
-//         });
-//
-//       value.should.equal('This string should persist between instances.');
-//     });
-//
-//     it('should not persist between instances if partition name doesnt start with "persist:"', function *(){
-//       nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
-//       yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           window.localStorage.setItem('testing', 'This string not should persist between instances.')
-//         })
-//         .end();
-//
-//       nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
-//       var value = yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           return window.localStorage.getItem('testing') || ''
-//         });
-//
-//       value.should.equal('');
-//     });
-//
-//     it('should persist between instances if partition starts with "persist:"', function *() {
-//       nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
-//       yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           window.localStorage.setItem('testing', 'This string should persist between instances.')
-//         })
-//         .end();
-//
-//       nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
-//       var value = yield nightmare
-//         .goto(fixture('simple'))
-//         .evaluate(function() {
-//           return window.localStorage.getItem('testing') || ''
-//         });
-//
-//       value.should.equal('This string should persist between instances.');
-//     });
-//   })
-// });
-
-describe('Nightmare with xpath selector', function () {
+describe('Nightmare', function () {
   before(function (done) {
     server.listen(7500, done);
     Nightmare = withDeprecationTracking(Nightmare);
@@ -2379,50 +50,198 @@ describe('Nightmare with xpath selector', function () {
     Nightmare.assertNoDeprecations();
   });
 
-  it('should provide useful errors for .click', function(done) {
-    var nightmare = Nightmare({useXpath: true});
+  it('should be constructable', function*() {
+    var nightmare = Nightmare();
+    nightmare.should.be.ok;
+    yield nightmare.end();
+  });
+
+  it('should have version information', function*(){
+    var nightmare = Nightmare();
+    var versions = yield nightmare.engineVersions();
+    nightmare.engineVersions.electron.should.be.ok;
+    nightmare.engineVersions.chrome.should.be.ok;
+
+    versions.electron.should.be.ok;
+    versions.chrome.should.be.ok;
+
+    Nightmare.version.should.be.ok;
+    yield nightmare.end();
+  });
+
+  it('should kill its electron process when it is killed', function(done) {
+    var child = child_process.fork(
+      path.join(__dirname, 'files', 'nightmare-unended.js'));
+
+    child.once('message', function(electronPid) {
+      child.once('exit', function() {
+        try {
+          electronPid.should.not.be.a.process;
+        }
+        catch(error) {
+          // if the test failed, clean up the still-running process
+          process.kill(electronPid, 'SIGINT');
+          throw error;
+        }
+        done();
+      });
+      child.kill();
+    });
+  });
+
+  it('should gracefully handle electron being killed', function(done) {
+    var child = child_process.fork(
+      path.join(__dirname, 'files', 'nightmare-unended.js'));
+
+    child.once('message', function(electronPid) {
+      process.kill(electronPid, 'SIGINT');
+      child.once('exit', function(){
+        electronPid.should.not.be.a.process;
+        done();
+      });
+    });
+  });
+
+  it('should end gracefully if the chain has not been started', function(done) {
+    var child = child_process.fork(
+      path.join(__dirname, 'files', 'nightmare-created.js'));
+
+    child.once('message', function() {
+      child.once('exit', function(code) {
+        code.should.equal(0);
+        done();
+      });
+      child.kill();
+    });
+  });
+
+  it('should exit with a non-zero code on uncaughtExecption', function(done) {
+    var child = child_process.fork(
+      path.join(__dirname, 'files', 'nightmare-error.js'), [], {silent: true});
+
+      child.once('exit', function(code) {
+        code.should.not.equal(0);
+        done();
+      });
+  });
+
+  it('should provide a .catch function', function(done) {
+    var nightmare = Nightmare();
 
     nightmare
       .goto('about:blank')
-      .click('//a[@class="not-here"]')
+      .evaluate(function() {
+        throw new Error('Test');
+      })
+      .catch(function(err) {
+        done();
+      });
+  });
+
+  it('should allow ending more than once', function(done){
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('navigation'))
+      .end()
+      .then(() => nightmare.end())
+      .then(() => done());
+  });
+
+  it('should allow end with a callback', function(done){
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('navigation'))
+      .end(() => done());
+  });
+
+  it('should allow end with a callback to be thenable', function(done){
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('navigation'))
+      .end(() => 'nightmare')
+      .then((str) => {
+        str.should.equal('nightmare');
+        done();
+      });
+  });
+
+  it('should kill electron process when halted', function () {
+    var nightmare = Nightmare();
+
+    const check1 = nightmare.goto(fixture('navigation'))
+      .wait(1000)
+      .wait(500)
+      .end()
+      .then(() => {})
+      .should.be.rejectedWith('Nightmare Halted');
+
+    const electronPid = nightmare.proc.pid;
+
+    const check2 = new Promise((resolve, reject) => {
+      nightmare.halt('Nightmare Halted', () => {
+        electronPid.should.not.be.a.process;
+        resolve();
+      });
+    });
+
+    return Promise.all([check1, check2]);
+  });
+  
+  it('should successfully end on pages setting onunload or onbeforeunload', function(done) {
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('unload'))
+      .end()
+      .then(() => done());
+  });
+
+  it('should successfully end on pages binding unload or beforeunload', function(done) {
+    var nightmare = Nightmare();
+    nightmare.goto(fixture('unload/add-event-listener.html'))
+      .end()
+      .then(() => done());
+  });
+
+  it('should provide useful errors for .click', function(done) {
+    var nightmare = Nightmare();
+
+    nightmare
+      .goto('about:blank')
+      .click('a.not-here')
       .catch(function (error) {
-        error.should.include('//a[@class="not-here"]');
+        error.should.include('a.not-here');
         done();
       });
   });
 
   it('should provide useful errors for .mousedown', function(done) {
-    var nightmare = Nightmare({useXpath: true});
+    var nightmare = Nightmare();
 
     nightmare
       .goto('about:blank')
-      .mousedown('//a[@class="not-here"]')
+      .mousedown('a.not-here')
       .catch(function (error) {
-        error.should.include('//a[@class="not-here"]');
+        error.should.include('a.not-here');
         done();
       });
   });
 
   it('should provide useful errors for .mouseup', function(done) {
-    var nightmare = Nightmare({useXpath: true});
+    var nightmare = Nightmare();
 
     nightmare
       .goto('about:blank')
-      .mouseup('//a[@class="not-here"]')
+      .mouseup('a.not-here')
       .catch(function (error) {
-        error.should.include('//a[@class="not-here"]');
+        error.should.include('a.not-here');
         done();
       });
   });
 
   it('should provide useful errors for .mouseover', function(done) {
-    var nightmare = Nightmare({useXpath: true});
+    var nightmare = Nightmare();
 
     nightmare
       .goto('about:blank')
-      .mouseover('//a[@class="not-here"]')
+      .mouseover('a.not-here')
       .catch(function (error) {
-        error.should.include('//a[@class="not-here"]');
+        error.should.include('a.not-here');
         done();
       });
   });
@@ -2435,7 +254,6 @@ describe('Nightmare with xpath selector', function () {
         webPreferences: {partition: 'test-partition' + Math.random()},
         loadTimeout: 45 * 1000,
         waitTimeout: 5 * 1000,
-        useXpath: true
       });
     });
 
@@ -2444,17 +262,40 @@ describe('Nightmare with xpath selector', function () {
       Nightmare.resetActions();
     });
 
+    it('should return data about the response', function*() {
+      var data = yield nightmare.goto(fixture('navigation'));
+      data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
+    });
+
+    it('should reject with a useful message when no URL', function() {
+      return nightmare.goto(undefined).then(
+        function() {throw new Error('goto(undefined) didn’t cause an error');},
+        function(error) {
+          error.should.include('url');
+        }
+      );
+    });
+
+    it('should reject with a useful message for an empty URL', function() {
+      return nightmare.goto('').then(
+        function() {throw new Error('goto(undefined) didn’t cause an error');},
+        function(error) {
+          error.should.include('url');
+        }
+      );
+    });
+
     it('should click on a link and then go back', function*() {
       var title = yield nightmare
         .goto(fixture('navigation'))
-        .click('//a')
-        .title();
+        .click('a')
+        .title()
 
-      title.should.equal('A');
+      title.should.equal('A')
 
       var title = yield nightmare
         .back()
-        .title();
+        .title()
 
       title.should.equal('Navigation')
     });
@@ -2462,14 +303,14 @@ describe('Nightmare with xpath selector', function () {
     it('should work for links that dont go anywhere', function*() {
       var title = yield nightmare
         .goto(fixture('navigation'))
-        .click('//a')
-        .title();
+        .click('a')
+        .title()
 
-      title.should.equal('A');
+      title.should.equal('A')
 
       var title = yield nightmare
-        .click('//a[@class="d"]')
-        .title();
+        .click('.d')
+        .title()
 
       title.should.equal('A')
     })
@@ -2477,55 +318,404 @@ describe('Nightmare with xpath selector', function () {
     it('should click on a link, go back, and then go forward', function*() {
       yield nightmare
         .goto(fixture('navigation'))
-        .click('//a')
+        .click('a')
         .back()
         .forward();
+    });
+
+    it('should refresh the page', function*() {
+      yield nightmare
+        .goto(fixture('navigation'))
+        .refresh();
     });
 
     it('should wait until element is present', function*() {
       yield nightmare
         .goto(fixture('navigation'))
-        .wait('//a');
+        .wait('a');
     });
 
     it('should soft timeout if element does not appear', function*() {
       yield nightmare
         .goto(fixture('navigation'))
-        .wait('//ul', 150);
+        .wait('ul', 150);
     });
 
     it('should wait until element is present with a modified poll interval', function*() {
       nightmare = Nightmare({
-        pollInterval: 50,
-        useXpath: true
+        pollInterval: 50
       });
       yield nightmare
         .goto(fixture('navigation'))
-        .wait('//a');
+        .wait('a');
     });
 
+    it('should escape the css selector correctly when waiting for an element', function*() {
+      yield nightmare
+        .goto(fixture('navigation'))
+        .wait('#escaping\\:test');
+    });
+
+    it('should wait until the evaluate fn returns true', function*() {
+      yield nightmare
+        .goto(fixture('navigation'))
+        .wait(function () {
+          var text = document.querySelector('a').textContent;
+          return (text === 'A');
+        });
+    });
+
+    it('should wait until the evaluate fn with arguments returns true', function*() {
+      yield nightmare
+        .goto(fixture('navigation'))
+        .wait(function (expectedA, expectedB) {
+          var textA = document.querySelector('a.a').textContent;
+          var textB = document.querySelector('a.b').textContent;
+          return (expectedA === textA && expectedB === textB);
+        }, 'A', 'B');
+    });
+
+    describe('asynchronous wait', function(){
+      it('should wait until the evaluate fn with arguments returns true with a callback', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (expectedA, expectedB, done) {
+            setTimeout(() => {
+              var textA = document.querySelector('a.a').textContent;
+              var textB = document.querySelector('a.b').textContent;
+              done(null, expectedA === textA && expectedB === textB);
+            }, 2000);
+          }, 'A', 'B');
+      });
+
+      it('should wait until the evaluate fn with arguments returns true with a promise', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (expectedA, expectedB) {
+            return new Promise(function(resolve) {
+              setTimeout(() => {
+                var textA = document.querySelector('a.a').textContent;
+                var textB = document.querySelector('a.b').textContent;
+                resolve(expectedA === textA && expectedB === textB);
+              }, 2000);
+            });
+          }, 'A', 'B');
+      });
+
+      it('should reject timeout on wait', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (done) {
+            //never call done
+          }).should.be.rejected;
+      });
+
+      it('should run multiple times before timeout on wait', function*() {
+        yield nightmare
+          .goto(fixture('navigation'))
+          .wait(function (done) {
+            setTimeout(() => done(null, false), 500);
+          }).should.be.rejected;
+      });
+    });
+
+    it('should fail if navigation target is invalid', function() {
+      return nightmare.goto('http://this-is-not-a-real-domain.tld')
+        .then(
+          function() {
+            throw new Error('Navigation to an invalid domain succeeded');
+          }, function(error) {
+            error.should.contain.keys('message', 'code', 'url');
+            error.code.should.be.a('number');
+          });
+    });
+
+    it('should fail if navigation target is a malformed URL', function(done) {
+      nightmare.goto('somewhere out there')
+        .then(function() {
+          done(new Error('Navigation to an invalid domain succeeded'));
+        })
+        .catch(function(error) {
+          done();
+        });
+    });
+
+    it('should fail if navigating to an unknown protocol', function(done) {
+      nightmare.goto('fake-protocol://blahblahblah')
+        .then(function() {
+          done(new Error('Navigation to an invalid protocol succeeded'));
+        })
+        .catch(function(error) {
+          done();
+        });
+    });
+
+    it('should not fail if the URL loads but a resource fails', function() {
+      return nightmare.goto(fixture('navigation/invalid-image'));
+    });
+
+    it('should not fail if a child frame fails', function() {
+      return nightmare.goto(fixture('navigation/invalid-frame'));
+    });
+
+    it('should return correct data when child frames are present', function*() {
+      var data = yield nightmare.goto(fixture('navigation/valid-frame'));
+      data.should.have.property('url');
+      data.url.should.equal(fixture('navigation/valid-frame'));
+    });
+
+    it('should not fail if response was a valid error (e.g. 404)', function() {
+      return nightmare.goto(fixture('navigation/not-a-real-page'));
+    });
+
+    it('should fail if the response dies in flight', function(done) {
+      nightmare.goto(fixture('do-not-respond'))
+        .then(function() {
+          done(new Error('Navigation succeeded but server connection died'));
+        })
+        .catch(function(error) {
+          done();
+        });
+    });
+
+    it('should not fail for a redirect', function() {
+      return nightmare.goto(fixture('redirect?url=%2Fnavigation'));
+    });
+
+    it('should fail for a redirect to an invalid URL', function(done) {
+      nightmare.goto(
+        fixture('redirect?url=http%3A%2F%2Fthis-is-not-a-real-domain.tld'))
+        .then(function() {
+          done(new Error('Navigation succeeded with redirect to bad location'));
+        })
+        .catch(function(error) {
+          done();
+        });
+    });
+
+    it('should succeed properly if request handler is present', function() {
+      Nightmare.action(
+        'monitorRequest',
+        function(name, options, parent, win, renderer, done) {
+          win.webContents.session.webRequest.onBeforeRequest(
+            ['*://localhost:*'],
+            function(details, callback) {
+              callback({cancel: false});
+            }
+          );
+          done();
+        },
+        function(done) {
+          done();
+          return this;
+        });
+
+      return Nightmare({webPreferences: {partition: 'test-partition'}})
+        .goto(fixture('navigation'))
+        .end();
+    });
+
+    it('should fail properly if request handler is present', function(done) {
+      Nightmare.action(
+        'monitorRequest',
+        function(name, options, parent, win, renderer, done) {
+          win.webContents.session.webRequest.onBeforeRequest(
+            ['*://localhost:*'],
+            function(details, callback) {
+              callback({cancel: false});
+            }
+          );
+          done();
+        },
+        function(done) {
+          done();
+          return this;
+        });
+
+      Nightmare({webPreferences: {partition: 'test-partition'}})
+        .goto('http://this-is-not-a-real-domain.tld')
+        .then(function() {
+          done(new Error('Navigation to an invalid domain succeeded'));
+        })
+        .catch(function(error) {
+          done();
+        });
+    });
+
+    it('should support javascript URLs', function*() {
+      var gotoResult = yield nightmare
+        .goto(fixture('navigation'))
+        .goto('javascript:void(document.querySelector(".a").textContent="LINK");');
+      gotoResult.should.be.an('object');
+
+      var linkText = yield nightmare
+        .evaluate(function() {
+          return document.querySelector('.a').textContent;
+        });
+      linkText.should.equal('LINK');
+    });
+
+    it('should support javascript URLs that load pages', function*() {
+      var data = yield nightmare
+        .goto(fixture('navigation'))
+        .goto(`javascript:window.location='${fixture('navigation/a.html')}'`);
+      data.should.contain.keys('url', 'code', 'method', 'referrer', 'headers');
+      data.url.should.equal(fixture('navigation/a.html'));
+
+      var linkText = yield nightmare
+        .evaluate(function() {
+          return document.querySelector('.d').textContent;
+        });
+      linkText.should.equal('D');
+    });
+
+    it('should fail immediately/not time out for 304 statuses', function() {
+      return Nightmare({gotoTimeout: 500})
+        .goto(fixture('not-modified'))
+        .end()
+        .then(function() {
+          throw new Error('Navigating to a 304 should return an error');
+        },
+        function(error) {
+          if (error.code === -7) {
+            throw new Error('Navigating to a 304 should not time out');
+          }
+        });
+    });
+
+    it('should not time out for aborted loads', function() {
+      Nightmare.action(
+        'abortRequests',
+        function(name, options, parent, win, renderer, done) {
+          win.webContents.session.webRequest.onBeforeRequest(
+            ['*://localhost:*'],
+            function(details, callback) {
+              setTimeout(() => win.webContents.stop(), 0);
+              callback({cancel: false});
+            }
+          );
+          done();
+        },
+        function() {
+          done();
+        });
+
+      return Nightmare({gotoTimeout: 500})
+        .goto(fixture('navigation'))
+        .end()
+        .then(function() {
+          throw new Error('An aborted page load should return an error');
+        },
+        function(error) {
+          if (error.code === -7) {
+            throw new Error('Aborting a page load should not time out');
+          }
+        });
+    });
+
+    describe('timeouts', function() {
+      it('should time out after 30 seconds of loading', function() {
+        // allow this test to go particularly long
+        this.timeout(40000);
+        return nightmare.goto(fixture('wait')).should.be.rejected
+          .then(function(error) {
+            error.code.should.equal(-7);
+          });
+      });
+
+      it('should allow custom goto timeout on the constructor', function() {
+        var startTime = Date.now();
+        return Nightmare({gotoTimeout: 1000}).goto(fixture('wait')).end()
+          .should.be.rejected
+          .then(function(error) {
+            // allow a few extra seconds for browser startup
+            (startTime - Date.now()).should.be.below(3000);
+          });
+      });
+
+      it('should allow a timeout to succeed if DOM loaded', function() {
+        return Nightmare({gotoTimeout: 1000})
+          .goto(fixture('navigation/hanging-resources.html'))
+          .end()
+          .then(function(data) {
+            data.details.should.include('1000 ms');
+          });
+      });
+
+      it('should allow actions on a hanging page', function() {
+        return Nightmare({gotoTimeout: 500})
+          .goto(fixture('navigation/hanging-resources.html'))
+          .evaluate(() => document.title)
+          .end()
+          .then(function(title) {
+            title.should.equal('Hanging resource load');
+          });
+      });
+
+      it('should allow loading a new page after timing out', function() {
+        nightmare.end().then();
+        nightmare = Nightmare({gotoTimeout: 1000});
+        return nightmare.goto(fixture('wait')).should.be.rejected
+          .then(function() {
+            return nightmare.goto(fixture('navigation'));
+          });
+      });
+
+      it('should allow for timeouts for non-goto loads', function*() { // ###
+        this.timeout(40000);
+        var nightmare = Nightmare({loadTimeout: 30000});
+        yield nightmare
+          .goto(fixture('navigation'))
+          .click('#never-ends');
+
+        yield nightmare.end();
+      });
+    });
   });
 
   describe('evaluation', function () {
     var nightmare;
 
     beforeEach(function() {
-      nightmare = Nightmare({useXpath: true});
+      nightmare = Nightmare();
     });
 
     afterEach(function*() {
       yield nightmare.end();
     });
 
+    it('should get the title', function*() {
+      var title = yield nightmare
+        .goto(fixture('evaluation'))
+        .title();
+      title.should.eql('Evaluation');
+    });
+
+    it('should get the url', function*() {
+      var url = yield nightmare
+        .goto(fixture('evaluation'))
+        .url();
+      url.should.have.string(fixture('evaluation'));
+    });
+
+    it('should get the path', function*() {
+      var path = yield nightmare
+        .goto(fixture('evaluation'))
+        .path();
+      var formalUrl = fixture('evaluation') + '/';
+
+      formalUrl.should.have.string(path);
+    });
+
     it('should check if the selector exists', function*() {
       // existent element
       var exists = yield nightmare
         .goto(fixture('evaluation'))
-        .exists('//h1[@class="title"]');
+        .exists('h1.title');
       exists.should.be.true;
 
       // non-existent element
-      exists = yield nightmare.exists('//a[@class="blahblahblah"]');
+      exists = yield nightmare.exists('a.blahblahblah');
       exists.should.be.false;
     });
 
@@ -2533,31 +723,187 @@ describe('Nightmare with xpath selector', function () {
       // visible element
       var visible = yield nightmare
         .goto(fixture('evaluation'))
-        .visible('//h1[@class="title"]');
+        .visible('h1.title');
       visible.should.be.true;
 
       // hidden element
       visible = yield nightmare
-        .visible('//div[@class="hidden"]');
+        .visible('.hidden');
       visible.should.be.false;
 
-      // non-existent element
+        // non-existent element
       visible = yield nightmare
-        .visible('//[@id="asdfasdfasdf"]');
+        .visible('#asdfasdfasdf');
       visible.should.be.false;
     });
 
+    it('should evaluate javascript on the page, with parameters', function*() {
+      var title = yield nightmare
+        .goto(fixture('evaluation'))
+        .evaluate(function (parameter) {
+          return document.title + ' -- ' + parameter;
+        }, 'testparameter');
+      title.should.equal('Evaluation -- testparameter');
+    });
+
+    it('should capture invalid evaluate fn', function() {
+      return nightmare
+        .goto(fixture('evaluation'))
+        .evaluate('not_a_function')
+        .should.be.rejected;
+    });
+
+    describe('asynchronous', function(){
+      it('should allow for asynchronous evaluation with a callback', function*() {
+        var asyncValue = yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(done) {
+            setTimeout(() => done(null, 'nightmare'), 1000);
+          });
+
+          asyncValue.should.equal('nightmare');
+      });
+      it('should allow for arguments with asynchronous evaluation with a callback', function*() {
+        var asyncValue = yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(str, done) {
+            setTimeout(() => done(null, str), 1000);
+          }, 'nightmare');
+
+          asyncValue.should.equal('nightmare');
+      });
+
+      it('should allow for errors in asynchronous evaluation with a callback', function*() {
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(done) {
+            setTimeout(() => done(new Error('nightmare')), 1000);
+          }).should.be.rejected;
+      });
+
+      it('should allow for timeouts in asynchronous evaluation with a callback', function*() {
+        this.timeout(40000);
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(done) {
+            //don't call done
+          }).should.be.rejected;
+      });
+
+      it('should allow for asynchronous evaluation with a promise', function*() {
+        var asyncValue =  yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function() {
+            return new Promise(resolve => {
+              setTimeout(() => resolve('nightmare'), 1000);
+            });
+          })
+
+          asyncValue.should.equal('nightmare');
+      });
+
+      it('should allow for arguments with asynchronous evaluation with a promise', function*() {
+        var asyncValue =  yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function(str) {
+            return new Promise(resolve => {
+              setTimeout(() => resolve(str), 1000);
+            });
+          }, 'nightmare')
+
+          asyncValue.should.equal('nightmare');
+      });
+
+      it('should allow for errors in asynchronous evaluation with a promise', function*() {
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function() {
+            return new Promise((resolve, reject) => {
+              setTimeout(() => reject(new Error('nightmare')), 1000);
+            });
+          }).should.be.rejected;
+      });
+
+      it('should allow for timeouts in asynchronous evaluation with a promise', function*() {
+        this.timeout(40000);
+        yield nightmare
+          .goto(fixture('evaluation'))
+          .evaluate(function() {
+            return new Promise((resolve, reject) => {
+              return 'nightmare';
+            });
+          }).should.be.rejected;
+      });
+    });
   });
 
   describe('manipulation', function () {
     var nightmare;
 
     beforeEach(function() {
-      nightmare = Nightmare({useXpath: true});
+      nightmare = Nightmare();
     });
 
     afterEach(function*() {
       yield nightmare.end();
+    });
+
+    it('should inject javascript onto the page', function*() {
+      var globalNumber = yield nightmare
+        .goto(fixture('manipulation'))
+        .inject('js', 'test/files/globals.js')
+        .evaluate(function () {
+          return globalNumber;
+        });
+      globalNumber.should.equal(7);
+
+      var numAnchors = yield nightmare
+        .goto(fixture('manipulation'))
+        .inject('js', 'test/files/jquery-2.1.1.min.js')
+        .evaluate(function () {
+          return $('h1').length;
+        });
+      numAnchors.should.equal(1);
+    });
+
+    it('should inject javascript onto the page ending with a comment', function*() {
+      var globalNumber = yield nightmare
+        .goto(fixture('manipulation'))
+        .inject('js', 'test/files/globals.js')
+        .evaluate(function () {
+          return globalNumber;
+        });
+      globalNumber.should.equal(7);
+
+      var numAnchors = yield nightmare
+        .goto(fixture('manipulation'))
+        .inject('js', 'test/files/jquery-1.9.0.min.js')
+        .evaluate(function () {
+          return $('h1').length;
+        });
+      numAnchors.should.equal(1);
+    });
+
+    it('should inject css onto the page', function*() {
+      var color = yield nightmare
+        .goto(fixture('manipulation'))
+        .inject('js', 'test/files/jquery-2.1.1.min.js')
+        .inject('css', 'test/files/test.css')
+        .evaluate(function () {
+          return $('body').css('background-color');
+        });
+      color.should.equal('rgb(255, 0, 0)');
+    });
+
+    it('should not inject unsupported types onto the page', function*() {
+      var color = yield nightmare
+        .goto(fixture('manipulation'))
+        .inject('js', 'test/files/jquery-2.1.1.min.js')
+        .inject('pdf', 'test/files/test.css')
+        .evaluate(function () {
+          return $('body').css('background-color');
+        });
+      color.should.not.equal('rgb(255, 0, 0)');
     });
 
     it('should type', function*() {
@@ -2569,7 +915,7 @@ describe('Nightmare with xpath selector', function () {
           if (type === 'log') events--;
         })
         .goto(fixture('manipulation'))
-        .type('//input[@type="search"]', input)
+        .type('input[type=search]', input)
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
@@ -2579,42 +925,42 @@ describe('Nightmare with xpath selector', function () {
     });
 
     it('should type integer', function* () {
-      var input = 10;
-      var events = input.toString().length * 3;
+        var input = 10;
+        var events = input.toString().length * 3;
 
-      var value = yield nightmare
-        .on('console', function (type, input, message) {
-          if (type === 'log') events--;
-        })
-        .goto(fixture('manipulation'))
-        .type('//input[@type="search"]', input)
-        .evaluate(function() {
-          return document.querySelector('input[type=search]').value;
-        });
+        var value = yield nightmare
+          .on('console', function (type, input, message) {
+            if (type === 'log') events--;
+          })
+          .goto(fixture('manipulation'))
+          .type('input[type=search]', input)
+          .evaluate(function() {
+            return document.querySelector('input[type=search]').value;
+          });
 
-      value.should.equal('10');
-      events.should.equal(0);
+        value.should.equal('10');
+        events.should.equal(0);
     });
 
 
     it('should type object', function* () {
-      var input = {
-        foo: 'bar'
-      };
-      var events = input.toString().length * 3;
+        var input = {
+          foo: 'bar'
+        };
+        var events = input.toString().length * 3;
 
-      var value = yield nightmare
-        .on('console', function (type, input, message) {
-          if (type === 'log') events--;
-        })
-        .goto(fixture('manipulation'))
-        .type('//input[@type="search"]', input)
-        .evaluate(function() {
-          return document.querySelector('input[type=search]').value;
-        });
+        var value = yield nightmare
+          .on('console', function (type, input, message) {
+            if (type === 'log') events--;
+          })
+          .goto(fixture('manipulation'))
+          .type('input[type=search]', input)
+          .evaluate(function() {
+            return document.querySelector('input[type=search]').value;
+          });
 
-      value.should.equal('[object Object]');
-      events.should.equal(0);
+        value.should.equal('[object Object]');
+        events.should.equal(0);
     });
 
     it('should clear inputs', function*() {
@@ -2626,8 +972,8 @@ describe('Nightmare with xpath selector', function () {
           if (type === 'log') events--;
         })
         .goto(fixture('manipulation'))
-        .type('//input[@type="search"]', input)
-        .type('//input[@type="search"]')
+        .type('input[type=search]', input)
+        .type('input[type=search]')
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
@@ -2637,49 +983,49 @@ describe('Nightmare with xpath selector', function () {
     });
 
     it('should support inserting text', function*() {
-      var input = 'nightmare insert typing';
+      var input = 'nightmare insert typing'
 
       var value = yield nightmare
         .goto(fixture('manipulation'))
-        .insert('//input[@type="search"]', input)
+        .insert('input[type=search]', input)
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
 
       value.should.equal('nightmare insert typing');
-    });
+    })
 
     it('should support clearing inserted text', function*() {
 
       var value = yield nightmare
         .goto(fixture('manipulation'))
-        .insert('//input[@type="search"]')
+        .insert('input[type=search]')
         .evaluate(function() {
           return document.querySelector('input[type=search]').value;
         });
 
       value.should.equal('');
-    });
+    })
 
     it('should not type in a nonexistent selector', function(){
       return nightmare
         .goto(fixture('manipulation'))
-        .type('//[@class="does-not-exist"]', 'nightmare')
+        .type('does-not-exist', 'nightmare')
         .should.be.rejected;
     });
 
     it('should not insert in a nonexistent selector', function(){
       return nightmare
         .goto(fixture('manipulation'))
-        .insert('//[@class="does-not-exist"]', 'nightmare')
+        .insert('does-not-exist', 'nightmare')
         .should.be.rejected;
     });
 
     it('should blur the active element when something is clicked', function*() {
       var isBody = yield nightmare
         .goto(fixture('manipulation'))
-        .type('//input[@type="search"]', 'test')
-        .click('//p')
+        .type('input[type=search]', 'test')
+        .click('p')
         .evaluate(function() {
           return document.activeElement === document.body;
         });
@@ -2689,21 +1035,35 @@ describe('Nightmare with xpath selector', function () {
     it('should allow for clicking on elements with attribute selectors', function*() {
       yield nightmare
         .goto(fixture('manipulation'))
-        .click('//div[@data-test="test"]')
+        .click('div[data-test="test"]')
+    });
+
+    it('should not allow for code injection with .click()', function(done){
+      var exception;
+      nightmare
+        .goto(fixture('manipulation'))
+        .click('"]\'); document.title = \'injected title\'; (\'"')
+        .catch((e) => exception = e)
+        .then(()=> nightmare.title())
+        .then((title) => {
+          exception.should.exist;
+          title.should.equal('Manipulation');
+          done();
+        });
     });
 
     it('should not fail if selector no longer exists to blur after typing', function*() {
       yield nightmare
         .on('console', function(){ console.log(arguments)})
         .goto(fixture('manipulation'))
-        .type('//input[@id="disappears"]', 'nightmare');
+        .type('input#disappears', 'nightmare');
     });
 
     it('should type and click', function*() {
       var title = yield nightmare
         .goto(fixture('manipulation'))
-        .type('//input[@type="search"]', 'nightmare')
-        .click('//button[@type="submit"]')
+        .type('input[type=search]', 'nightmare')
+        .click('button[type=submit]')
         .wait(500)
         .title();
 
@@ -2713,10 +1073,10 @@ describe('Nightmare with xpath selector', function () {
     it('should type and click several times', function*() {
       var title = yield nightmare
         .goto(fixture('manipulation'))
-        .type('//input[@type="search"]', 'github nightmare')
-        .click('//button[@type="submit"]')
+        .type('input[type=search]', 'github nightmare')
+        .click('button[type=submit]')
         .wait(500)
-        .click('//a')
+        .click('a')
         .wait(500)
         .title();
       title.should.equal('Manipulation - Result - Nightmare');
@@ -2725,7 +1085,7 @@ describe('Nightmare with xpath selector', function () {
     it('should checkbox', function*() {
       var checkbox = yield nightmare
         .goto(fixture('manipulation'))
-        .check('//input[@type="checkbox"]')
+        .check('input[type=checkbox]')
         .evaluate(function () {
           return document.querySelector('input[type=checkbox]').checked;
         });
@@ -2735,8 +1095,8 @@ describe('Nightmare with xpath selector', function () {
     it('should uncheck', function*() {
       var checkbox = yield nightmare
         .goto(fixture('manipulation'))
-        .check('//input[@type="checkbox"]')
-        .uncheck('//input[@type="checkbox"]')
+        .check('input[type=checkbox]')
+        .uncheck('input[type=checkbox]')
         .evaluate(function () {
           return document.querySelector('input[type=checkbox]').checked;
         });
@@ -2746,17 +1106,44 @@ describe('Nightmare with xpath selector', function () {
     it('should select', function*() {
       var select = yield nightmare
         .goto(fixture('manipulation'))
-        .select('//select', '//option[@value="b"]')
+        .select('select', 'b')
         .evaluate(function () {
           return document.querySelector('select').value;
         });
       select.should.equal('b');
     });
 
+    it('should scroll to specified position', function*() {
+      // start at the top
+      var coordinates = yield nightmare
+        .viewport(320, 320)
+        .goto(fixture('manipulation'))
+        .evaluate(function () {
+          return {
+            top: document.body.scrollTop,
+            left: document.body.scrollLeft
+          };
+        });
+      coordinates.top.should.equal(0);
+      coordinates.left.should.equal(0);
+
+      // scroll down a bit
+      coordinates = yield nightmare
+        .scrollTo(100, 50)
+        .evaluate(function () {
+          return {
+            top: document.body.scrollTop,
+            left: document.body.scrollLeft
+          };
+        });
+      coordinates.top.should.equal(100);
+      coordinates.left.should.equal(50);
+    });
+
     it('should hover over an element', function*() {
       var color = yield nightmare
         .goto(fixture('manipulation'))
-        .mouseover('//h1')
+        .mouseover('h1')
         .evaluate(function () {
           var element = document.querySelector('h1');
           return element.style.background;
@@ -2767,7 +1154,7 @@ describe('Nightmare with xpath selector', function () {
     it('should mousedown on an element', function*() {
       var color = yield nightmare
         .goto(fixture('manipulation'))
-        .mousedown('//h1')
+        .mousedown('h1')
         .evaluate(function () {
           var element = document.querySelector('h1');
           return element.style.background;
@@ -2775,6 +1162,1193 @@ describe('Nightmare with xpath selector', function () {
       color.should.equal('rgb(255, 0, 0)');
     });
   });
+
+  describe('cookies', function() {
+    var nightmare;
+
+    beforeEach(function() {
+      nightmare = Nightmare({webPreferences: {partition: 'test-partition'}})
+        .goto(fixture('cookie'));
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('.set(name, value) & .get(name)', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set('hi', 'hello')
+      var cookie = yield cookies.get('hi')
+
+      cookie.name.should.equal('hi')
+      cookie.value.should.equal('hello')
+      cookie.path.should.equal('/')
+      cookie.secure.should.equal(false)
+    })
+
+    it('.set(obj) & .get(name)', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set({
+        name: 'nightmare',
+        value: 'rocks',
+        path: '/cookie'
+      })
+      var cookie = yield cookies.get('nightmare')
+
+      cookie.name.should.equal('nightmare')
+      cookie.value.should.equal('rocks')
+      cookie.path.should.equal('/cookie')
+      cookie.secure.should.equal(false)
+    })
+
+    it('.set([cookie1, cookie2]) & .get()', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ])
+
+      var cookies = yield cookies.get()
+      cookies.length.should.equal(2)
+
+      // sort in case they come in a different order
+      cookies = cookies.sort(function (a, b) {
+        if (a.name > b.name) return 1
+        if (a.name < b.name) return -1
+        return 0
+      })
+
+      cookies[0].name.should.equal('hi')
+      cookies[0].value.should.equal('hello')
+      cookies[0].path.should.equal('/')
+      cookies[0].secure.should.equal(false)
+
+      cookies[1].name.should.equal('nightmare')
+      cookies[1].value.should.equal('rocks')
+      cookies[1].path.should.equal('/cookie')
+      cookies[1].secure.should.equal(false)
+    })
+
+    it('.set([cookie1, cookie2]) & .get(query)', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ])
+
+      var cookies = yield cookies.get({ path: '/cookie'})
+      cookies.length.should.equal(1)
+
+      cookies[0].name.should.equal('nightmare')
+      cookies[0].value.should.equal('rocks')
+      cookies[0].path.should.equal('/cookie')
+      cookies[0].secure.should.equal(false)
+    })
+
+    it('.set([cookie]) & .clear(name) & .get(query)', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ])
+
+      yield cookies.clear('nightmare');
+
+      var cookies = yield cookies.get({ path: '/cookie' });
+
+      cookies.length.should.equal(0);
+    });
+
+    it('.set([cookie]) & .clear() & .get()', function*() {
+      var cookies = nightmare.cookies
+
+      yield cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ])
+
+      yield cookies.clear();
+
+      var cookies = yield cookies.get();
+
+      cookies.length.should.equal(0);
+    })
+
+    it('.set([cookie]) & .clearAll() & .get()', function*() {
+      yield nightmare.cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ]);
+
+      yield nightmare.goto(fixture('simple'));
+
+      yield nightmare.cookies.set([
+        {
+          name: 'hi',
+          value: 'hello',
+          path: '/'
+        },
+        {
+          name: 'nightmare',
+          value: 'rocks',
+          path: '/cookie'
+        }
+      ]);
+
+
+      yield nightmare.cookies.clearAll();
+
+      var cookies = yield nightmare.cookies.get();
+      cookies.length.should.equal(0);
+
+      yield nightmare.goto(fixture('cookie'))
+
+      cookies = yield nightmare.cookies.get();
+      cookies.length.should.equal(0);
+    })
+  });
+
+  describe('rendering', function () {
+    var nightmare;
+
+    before(function(done) {
+      mkdirp(tmp_dir, done)
+    })
+
+    after(function(done) {
+      rimraf(tmp_dir, done)
+    })
+
+    beforeEach(function() {
+      nightmare = Nightmare();
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should take a screenshot', function*() {
+      yield nightmare
+        .goto('https://github.com/')
+        .screenshot(tmp_dir+'/test.png');
+      var stats = fs.statSync(tmp_dir+'/test.png');
+      stats.size.should.be.at.least(1000);
+    });
+
+    it('should buffer a screenshot', function*() {
+      var image = yield nightmare
+        .goto('https://github.com')
+        .screenshot();
+      Buffer.isBuffer(image).should.be.true;
+      image.length.should.be.at.least(1000);
+    });
+
+    it('should take a clipped screenshot', function*() {
+      yield nightmare
+        .goto('https://github.com/')
+        .screenshot(tmp_dir+'/test-clipped.png', {
+          x: 200,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      var stats = fs.statSync(tmp_dir+'/test.png');
+      var statsClipped = fs.statSync(tmp_dir+'/test-clipped.png');
+      statsClipped.size.should.be.at.least(300);
+      stats.size.should.be.at.least(10*statsClipped.size);
+    });
+
+    it('should buffer a clipped screenshot', function*() {
+      var image = yield nightmare
+        .goto('https://github.com')
+        .screenshot({
+          x: 200,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      Buffer.isBuffer(image).should.be.true;
+      image.length.should.be.at.least(300);
+    });
+
+    // repeat this test 3 times, since the concern here is non-determinism in
+    // the timing accuracy of screenshots -- it might pass once, but likely not
+    // several times in a row.
+    for (var i = 0; i < 3; i++) {
+      it('should screenshot an up-to-date image of the page (' + i + ')', function*() {
+        var image = yield nightmare
+          .goto('about:blank')
+          .viewport(100, 100)
+          .evaluate(function() { document.body.style.background = '#900'; })
+          .evaluate(function() { document.body.style.background = '#090'; })
+          .screenshot();
+
+        var png = new PNG();
+        var imageData = yield png.parse.bind(png, image);
+        var firstPixel = Array.from(imageData.data.slice(0, 3));
+        firstPixel.should.deep.equal([0, 153, 0]);
+      });
+    }
+
+    it('should screenshot an an idle page', function*() {
+      var image = yield nightmare
+        .goto('about:blank')
+        .viewport(100, 100)
+        .evaluate(function() { document.body.style.background = '#900'; })
+        .evaluate(function() { document.body.style.background = '#090'; })
+        .wait(1000)
+        .screenshot();
+
+      var png = new PNG();
+      var imageData = yield png.parse.bind(png, image);
+      var firstPixel = Array.from(imageData.data.slice(0, 3));
+      firstPixel.should.deep.equal([0, 153, 0]);
+    });
+
+    it('should not subscribe to frames until necessary', function() {
+      var didSubscribe = false;
+      var FrameManager = require('../lib/frame-manager.js');
+      var manager = FrameManager({
+        webContents: {
+          beginFrameSubscription: function() { didSubscribe = true; },
+          endFrameSubscription: function() {},
+          executeJavaScript: function() {}
+        }
+      });
+      didSubscribe.should.be.false;
+    });
+
+    it('should load jquery correctly', function*() {
+      var loaded = yield nightmare
+        .goto(fixture('rendering'))
+        .wait(2000)
+        .evaluate(function() {
+          return !!window.jQuery;
+        });
+      loaded.should.be.at.least(true);
+    });
+
+    it('should render fonts correctly', function*() {
+      yield nightmare
+        .goto(fixture('rendering'))
+        .wait(2000)
+        .screenshot(tmp_dir+'/font-rendering.png');
+      var stats = fs.statSync(tmp_dir+'/font-rendering.png');
+      stats.size.should.be.at.least(1000);
+    });
+
+    it('should save as html', function*() {
+      yield nightmare
+        .goto(fixture('manipulation'))
+        .html(tmp_dir+'/test.html');
+      var stats = fs.statSync(tmp_dir+'/test.html');
+      stats.should.be.ok;
+    });
+
+    it('should render a PDF', function*() {
+      yield nightmare
+        .goto(fixture('manipulation'))
+        .pdf(tmp_dir+'/test.pdf');
+      var stats = fs.statSync(tmp_dir+'/test.pdf');
+      stats.size.should.be.at.least(1000);
+    });
+
+    it('should accept options to render a PDF', function*() {
+      yield nightmare
+        .goto(fixture('manipulation'))
+        .pdf(tmp_dir+'/test2.pdf', {printBackground: false});
+      var stats = fs.statSync(tmp_dir+'/test2.pdf');
+      stats.size.should.be.at.least(1000);
+    });
+
+    it('should return a buffer from a PDF with no path', function*() {
+      var buf = yield nightmare
+        .goto(fixture('manipulation'))
+        .pdf({printBackground: false});
+
+      var isBuffer = Buffer.isBuffer(buf);
+
+      buf.length.should.be.at.least(1000);
+      isBuffer.should.be.true;
+    });
+  });
+
+  describe('referer', function() {
+    var nightmare;
+
+    beforeEach(function() {
+      nightmare = Nightmare({webPreferences: {partition: 'test-partition'}});
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should return referer from headers', function*() {
+      var referer = 'http://my-referer.tld/';
+      var returnedReferer = yield nightmare
+        .goto(fixture('referer'), {
+          'Referer': referer
+        })
+        .evaluate(function () {
+          return document.body.innerText;
+        })
+        ;
+
+      referer.should.be.equal(returnedReferer.trim());
+    })
+  });
+
+  describe('events', function () {
+    var nightmare;
+
+    beforeEach(function() {
+      nightmare = Nightmare();
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should fire an event on page load complete', function*() {
+      var fired = false;
+      nightmare
+        .on('did-finish-load', function () {
+          fired = true;
+        });
+      yield nightmare
+        .goto(fixture('events'));
+      fired.should.be.true;
+    });
+
+    it('should fire an event on javascript error', function*() {
+      var fired = false;
+      nightmare
+        .on('page', function (type, errorMessage, errorStack) {
+          if (type === 'error') {
+            fired = true;
+          }
+        });
+      yield nightmare
+        .goto(fixture('events'));
+      fired.should.be.true;
+    });
+
+    it('should fire an event on javascript console.log', function*() {
+      var log = '';
+
+      nightmare.on('console', function (type, str) {
+        if (type === 'log') log = str
+      });
+
+      yield nightmare.goto(fixture('events'));
+      log.should.equal('my log');
+
+      yield nightmare.click('button')
+      log.should.equal('clicked');
+
+    });
+
+    it('should fire an event on page load failure', function*() {
+      var fired = false;
+      nightmare
+        .on('did-fail-load', function () {
+          fired = true;
+        });
+      try {
+        yield nightmare
+          .goto('https://alskdjfasdfuuu.com');
+      }
+      catch(error) {}
+      fired.should.be.true;
+    });
+
+    it('should fire an event on javascript window.alert', function*(){
+      var alert = '';
+      nightmare.on('page', function(type, message){
+        if (type === 'alert') {
+          alert = message;
+        }
+      });
+
+      yield nightmare
+        .goto(fixture('events'))
+        .evaluate(function(){
+          alert('my alert');
+        });
+      alert.should.equal('my alert');
+    });
+
+    it('should fire an event on javascript window.prompt', function*(){
+      var prompt = '';
+      var response = ''
+      nightmare.on('page', function(type, message, res){
+        if (type === 'prompt') {
+          prompt = message;
+          response = res
+        }
+      });
+
+      yield nightmare
+        .goto(fixture('events'))
+        .evaluate(function(){
+          prompt('my prompt', 'hello!');
+        });
+      prompt.should.equal('my prompt');
+      response.should.equal('hello!');
+    });
+
+    it('should fire an event on javascript window.confirm', function*(){
+      var confirm = '';
+      var response = ''
+      nightmare.on('page', function(type, message, res){
+        if (type === 'confirm') {
+          confirm = message;
+          response = res
+        }
+      });
+
+      yield nightmare
+        .goto(fixture('events'))
+        .evaluate(function(){
+          confirm('my confirm', 'hello!');
+        });
+      confirm.should.equal('my confirm');
+      response.should.equal('hello!');
+    });
+
+    it('should only fire once when using once', function*() {
+      var events = 0;
+      nightmare.once('page', function(type, message) {
+        events++;
+      });
+
+      yield nightmare
+        .goto(fixture('events'))
+      events.should.equal(1);
+    });
+
+    it('should remove event listener', function*() {
+      var events = 0;
+      var handler = function(type, message) {
+        if (type === 'alert') {
+          events++;
+        }
+      };
+
+      nightmare.on('page', handler);
+
+      yield nightmare
+        .goto(fixture('events'))
+        .evaluate(function(){
+          alert('alert one');
+        });
+
+      nightmare.removeListener('page', handler);
+
+      yield nightmare
+        .evaluate(function(){
+          alert('alert two');
+        });
+
+      events.should.equal(1);
+    });
+  });
+
+  describe('options', function () {
+    var nightmare;
+    var server;
+
+    before(function(done) {
+      // set up an HTTPS server using self-signed certificates -- Nightmare
+      // will only be able to talk to it if 'ignore-certificate-errors' is set.
+      server = https.createServer({
+        key: fs.readFileSync(path.join(__dirname, 'files', 'server.key')),
+        cert: fs.readFileSync(path.join(__dirname, 'files', 'server.crt'))
+      }, function(request, response) {
+        response.end('ok\n');
+      }).listen(0, 'localhost', function() {
+        var address = server.address();
+        server.url = `https://${address.address}:${address.port}`;
+        done();
+      });
+    });
+
+    after(function() {
+      server.close();
+      server = null;
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should set useragent', function* () {
+      nightmare = new Nightmare();
+      var useragent = yield nightmare
+        .useragent('firefox')
+        .goto(fixture('options'))
+        .evaluate(function () {
+          return window.navigator.userAgent;
+        });
+      useragent.should.eql('firefox');
+    });
+
+    it('should wait and fail with waitTimeout', function() {
+      nightmare = Nightmare({waitTimeout: 254});
+      return nightmare
+        .goto(fixture('navigation'))
+        .wait('foobar')
+        .should.be.rejected;
+    });
+
+    it('should wait and fail with waitTimeout and a ms wait time', function() {
+      nightmare = Nightmare({waitTimeout: 254});
+      return nightmare
+        .goto(fixture('navigation'))
+        .wait(1000)
+        .should.be.rejected;
+    });
+
+    it('should wait and fail with waitTimeout with queued functions', function() {
+      nightmare = Nightmare({waitTimeout: 254});
+      return nightmare
+        .goto(fixture('navigation'))
+        .wait('foobar')
+        .exists('baz')
+        .should.be.rejected;
+    });
+
+    it('should set authentication', function*() {
+      nightmare = Nightmare();
+      var data = yield nightmare
+        .authentication('my', 'auth')
+        .goto(fixture('auth'))
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      data.should.eql({ name: 'my', pass: 'auth' });
+    });
+
+    it('should fail on authentication failure', function*() {
+      nightmare = Nightmare();
+      var data = yield nightmare
+        .authentication('my', 'wrong')
+        .goto(fixture('auth'))
+        .should.be.rejected;
+    });
+
+    it('should be able to update authentication', function*(){
+      nightmare = Nightmare();
+      var data = yield nightmare
+        .authentication('my', 'auth')
+        .goto(fixture('auth'))
+        .authentication('my2', 'auth2')
+        .goto(fixture('auth2'))
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      data.should.eql({ name: 'my2', pass: 'auth2' });
+    });
+
+    it('should set viewport', function*() {
+      var size = { width: 400, height: 300, useContentSize: true };
+      nightmare = Nightmare(size);
+      var result = yield nightmare
+        .goto(fixture('options'))
+        .evaluate(function () {
+          return {
+            width: window.innerWidth,
+            height: window.innerHeight
+          };
+        });
+      result.width.should.eql(size.width);
+      result.height.should.eql(size.height);
+    });
+
+    it('should set a single header', function*() {
+      nightmare = Nightmare();
+      var headers = yield nightmare
+        .header('X-Nightmare-Header', 'hello world')
+        .goto(fixture('headers'))
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      headers['x-nightmare-header'].should.equal('hello world');
+    });
+
+    it('should set all headers', function*() {
+      nightmare = Nightmare();
+      var headers = yield nightmare
+        .header({ 'X-Foo': 'foo', 'X-Bar': 'bar'})
+        .goto(fixture('headers'))
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      headers['x-foo'].should.equal('foo');
+      headers['x-bar'].should.equal('bar');
+    });
+
+    it('should set headers for that request', function*() {
+      nightmare = Nightmare();
+      var headers = yield nightmare
+        .goto(fixture('headers'), { 'X-Nightmare-Header': 'hello world' })
+        .evaluate(function () {
+          return JSON.parse(document.querySelector('pre').innerHTML);
+        });
+      headers['x-nightmare-header'].should.equal('hello world');
+    });
+
+    it('should allow webPreferences settings', function*() {
+      nightmare = Nightmare({webPreferences: {webSecurity: false}});
+      var result = yield nightmare
+        .goto(fixture('options'))
+        .evaluate(function () {
+          return document.getElementById('example-iframe').contentDocument;
+        });
+
+      result.should.be.ok;
+    });
+
+    it('should be constructable with paths', function*() {
+      nightmare = Nightmare({ paths:{ userData : __dirname } });
+      nightmare.should.be.ok;
+    });
+
+    it('should be constructable with switches', function*() {
+      nightmare = Nightmare({
+        switches: {
+          // empty string and non-string values all represent no value
+          'ignore-certificate-errors': null,
+          'touch-events': ''
+        }
+      });
+      nightmare.should.be.ok;
+      var touchEvents = yield nightmare
+        .goto(server.url)
+        .evaluate(function() {
+          return 'ontouchstart' in window;
+        });
+      touchEvents.should.be.true;
+    });
+
+    it('should support switches with values', function*() {
+      nightmare = Nightmare({ switches: { 'force-device-scale-factor': '5' } });
+      nightmare.should.be.ok;
+      var scaleFactor = yield nightmare
+        .goto('about:blank')
+        .evaluate(function() {
+          return window.devicePixelRatio;
+        });
+      scaleFactor.should.equal(5);
+    });
+
+    it('should allow to use external Electron', function*() {
+      nightmare = Nightmare({ electronPath: require('electron') });
+      nightmare.should.be.ok;
+    });
+
+    it('should allow to use external Promise', function*() {
+      nightmare = Nightmare({ Promise: require('bluebird') });
+      nightmare.should.be.ok;
+      const thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.be.an.instanceof(require('bluebird'));
+      yield thenPromise;
+      const catchPromise = nightmare.goto('about:blank').catch();
+      catchPromise.should.be.an.instanceof(require('bluebird'));
+      yield catchPromise;
+      const endPromise = nightmare.goto('about:blank').end().then();
+      endPromise.constructor.should.equal(require('bluebird'));
+      endPromise.should.be.an.instanceof(require('bluebird'));
+      yield endPromise;
+    });
+  });
+
+  describe('Nightmare.Promise', function() {
+    var nightmare;
+    afterEach(function*() {
+      // `withDeprecationTracking()` messes w/ prototype constructor references
+      Nightmare.Promise = require('..').Promise = Promise;
+      yield nightmare.end();
+    });
+
+    it('should default to native Promise', function*() {
+      Nightmare.Promise.should.equal(Promise);
+      nightmare = Nightmare();
+      nightmare.should.be.ok;
+      var thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.be.an.instanceof(Promise);
+      yield thenPromise;
+    });
+
+    it('should override default Promise library', function*() {
+      // `withDeprecationTracking()` messes w/ prototype constructor references
+      Nightmare.Promise = require('..').Promise = require('bluebird');
+      Nightmare.Promise.should.equal(require('bluebird'));
+      nightmare = Nightmare();
+      nightmare.should.be.ok;
+      var thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.be.an.instanceof(require('bluebird'));
+      yield thenPromise;
+    });
+
+    it('should not override per-instance Promise library', function*() {
+      Nightmare.Promise.should.equal(Promise);
+      nightmare = Nightmare({ Promise: require('bluebird') });
+      nightmare.should.be.ok;
+      var thenPromise = nightmare.goto('about:blank').then();
+      thenPromise.should.not.be.an.instanceof(Promise);
+      thenPromise.should.be.an.instanceof(require('bluebird'));
+      yield thenPromise;
+    });
+  })
+
+  describe('Nightmare.action(name, fn)', function() {
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should support custom actions', function*() {
+      Nightmare.action('size', function (done) {
+        this.evaluate_now(function() {
+          var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+          var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+          return {
+            height: h,
+            width: w
+          }
+        }, done)
+      })
+
+      nightmare = new Nightmare();
+
+      var size = yield nightmare
+        .goto(fixture('simple'))
+        .size()
+
+      size.height.should.be.a('number')
+      size.width.should.be.a('number')
+    })
+
+    it('should support custom namespaces', function*() {
+      Nightmare.action('style', {
+        background: function (done) {
+          this.evaluate_now(function () {
+            return window.getComputedStyle(document.body, null).backgroundColor
+          }, done)
+        },
+        color: function (done) {
+          this.evaluate_now(function () {
+            return window.getComputedStyle(document.body, null).color
+          }, done)
+        }
+      })
+
+      nightmare = Nightmare()
+      yield nightmare.goto(fixture('simple'))
+      var background = yield nightmare.style.background()
+      var color = yield nightmare.style.color()
+
+      background.should.equal('rgba(0, 0, 0, 0)')
+      color.should.equal('rgb(0, 0, 0)')
+    })
+
+    it('should support extending Electron', function*(){
+      Nightmare.action('bind',
+        function(ns, options, parent, win, renderer, done) {
+          var sliced = require('sliced');
+          parent.on('bind', function(name) {
+            if (renderer.listeners(name)
+              .length == 0) {
+              renderer.on(name, function() {
+                parent.emit.apply(parent, [name].concat(sliced(arguments, 1)))
+              });
+            }
+            parent.emit('bind');
+          });
+          done();
+        },
+        function() {
+          var name = arguments[0],
+            handler, done;
+          if (arguments.length == 2) {
+            done = arguments[1];
+          } else if (arguments.length == 3) {
+            handler = arguments[1];
+            done = arguments[2];
+          }
+          if (handler) {
+            this.child.on(name, handler);
+          }
+          this.child.once('bind', done);
+          this.child.emit('bind', name);
+        });
+
+      var eventResults;
+      nightmare = new Nightmare();
+      yield nightmare
+        .goto('http://example.com')
+        .on('sample-event', function() {
+          eventResults = arguments;
+        })
+        .bind('sample-event')
+        .evaluate(function() {
+          ipc.send('sample-event', 'sample', 3, {
+            sample: 'sample'
+          });
+        });
+
+      eventResults.length.should.equal(3);
+      eventResults[0].should.equal('sample');
+      eventResults[1].should.equal(3);
+      eventResults[2].sample.should.equal('sample');
+    });
+
+    it('should allow env variables', function*() {
+      Nightmare.action('envtest',
+        function (name, options, parent, win, renderer, done) {
+          parent.respondTo('envtest', function(done){
+            done(null, process.env);
+          });
+          done();
+        },
+        function(done) {
+          this.child.call('envtest', done);
+        }
+      );
+      nightmare = Nightmare({
+        env: {
+          TZ: 'UTC'
+        }
+      });
+      nightmare.should.be.ok;
+      var envTest = yield nightmare
+        .goto('about:bank')
+        .envtest();
+      envTest.should.be.ok;
+      envTest.should.have.property('TZ', 'UTC');
+    });
+  })
+
+  describe('Nightmare.use', function() {
+    beforeEach(function() {
+      nightmare = Nightmare();
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should support extending nightmare', function*() {
+      var tagName = yield nightmare
+        .goto(fixture('simple'))
+        .use(select('h1'))
+
+      tagName.should.equal('H1')
+
+      function select (tagname) {
+        return function (nightmare) {
+          nightmare.evaluate(function (tagname) {
+            return document.querySelector(tagname).tagName
+          }, tagname)
+        }
+      }
+    })
+  })
+
+  describe('custom preload script', function() {
+    beforeEach(function() {
+      nightmare = Nightmare();
+    });
+
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    it('should support passing your own preload script in', function*() {
+      var nightmare = Nightmare({
+        webPreferences: {
+          preload: path.join(__dirname, 'fixtures', 'preload', 'index.js')
+        }
+      })
+
+      var value = yield nightmare
+        .goto(fixture('preload'))
+        .evaluate(function() {
+          return window.preload
+        })
+
+      value.should.equal('custom')
+    })
+  })
+
+  describe('devtools', function(){
+    beforeEach(function() {
+      Nightmare.action('waitForDevTools',
+        function(ns, options, parent, win, renderer, done){
+          parent.on('waitForDevTools', function() {
+            function opened() { parent.emit('waitForDevTools', null, true); }
+            if (win.webContents.isDevToolsOpened()) {
+              return opened();
+            }
+            win.webContents.once('devtools-opened', opened);
+          });
+          done();
+        },
+        function(done){
+          this.child.once('waitForDevTools', done);
+          this.child.emit('waitForDevTools');
+        });
+      nightmare = Nightmare({show:true, openDevTools:true});
+
+    });
+
+    afterEach(function*(){
+      yield nightmare.end();
+    });
+
+    it('should open devtools', function*(){
+      var devToolsOpen = yield nightmare
+        .goto(fixture('simple'))
+        .waitForDevTools();
+
+      devToolsOpen.should.be.true;
+    });
+  });
+
+  describe('ipc', function(){
+    beforeEach(function() {
+      Nightmare.action('test',
+        function(_, __, parent, ___, ____, done) {
+          parent.respondTo('test', function(arg1, done) {
+            done.progress('one');
+            done.progress('two');
+            if (arg1 === 'error') {
+              return done('Error!');
+            }
+            else {
+              done(null, `Got ${arg1}`);
+            }
+          });
+          done();
+        },
+        function(options, done) {
+          var channel = this.child.call('test', options.arg || options, done);
+          if (options.onData) { channel.on('data', options.onData); }
+          if (options.onEnd) { channel.on('end', options.onEnd); }
+        });
+      Nightmare.action('noImplementation',
+        function(done) {
+          this.child.call('noImplementation', done);
+        });
+      nightmare = Nightmare();
+    });
+
+    afterEach(function*(){
+      yield nightmare.end();
+    });
+
+    it('should only make one IPC instance per process', function() {
+      var processStub = {send: function() {}, on: function(){}};
+      var ipc1 = IPC(processStub);
+      var ipc2 = IPC(processStub);
+      ipc1.should.equal(ipc2);
+    });
+
+    it('should support basic call-response', function*() {
+      var result = yield nightmare.test('x');
+      result.should.equal('Got x');
+    });
+
+    it('should support errors across IPC', function(done) {
+      nightmare.test('error').then(
+        function() {
+          done(new Error('Action succeeded when it should have errored!'));
+        },
+        function() {
+          done();
+        });
+    });
+
+    it('should stream progress', function*() {
+      var progress = [];
+      yield nightmare.test({
+        arg: 'x',
+        onData: (data) => progress.push(data),
+        onEnd: (error, data) => progress.push([error, data])
+      });
+      progress.should.deep.equal(['one', 'two', [null, 'Got x']]);
+    });
+
+    it('should trigger error if no responder is registered', function(done) {
+      nightmare.noImplementation().then(
+        function() {
+          done(new Error('Action succeeded when it should have errored!'));
+        },
+        function() {
+          done();
+        });
+    });
+
+    it('should log a warning when replacing a responder', function*() {
+      Nightmare.action('uhoh',
+        function(_, __, parent, ___, ____, done) {
+          parent.respondTo('test', function(done) {
+            done();
+          });
+          done();
+        },
+        function(done) {
+          this.child.call('test', done);
+        });
+
+      var logged = false;
+      var instance = Nightmare();
+      instance._queue.splice(1, 0, [function(done) {
+        this.child.on('nightmare:ipc:debug', function(message) {
+          if (message.toLowerCase().indexOf('replacing') > -1) {
+            logged = true;
+          }
+        });
+        done();
+      }, []]);
+
+      yield instance
+        .goto('about:blank')
+        .end();
+      logged.should.be.true;
+    });
+  });
+
+  describe('partitioning', function(){
+    afterEach(function*() {
+      yield nightmare.end();
+    });
+
+    // The default behavior for nightmare is to use a non-persistent partition name
+    it('should not persist between instances by default', function *() {
+      nightmare = Nightmare();
+      yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          window.localStorage.setItem('testing', 'This string should not persist between instances.')
+        })
+        .end();
+
+      nightmare = Nightmare();
+      var value = yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          return window.localStorage.getItem('testing') || ''
+        });
+
+      value.should.equal('');
+    })
+
+    // Setting the partition to null we default to the electron default behavior
+    // which is to use a persistent storage between instances.
+    it('should persist between instances if partition is null', function *() {
+      nightmare = Nightmare({ webPreferences: { partition: null } });
+      yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          window.localStorage.setItem('testing', 'This string should persist between instances.')
+        })
+        .end();
+
+      nightmare = Nightmare({ webPreferences: { partition: null } });
+      var value = yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          return window.localStorage.getItem('testing') || ''
+        });
+
+      value.should.equal('This string should persist between instances.');
+    });
+
+    it('should not persist between instances if partition name doesnt start with "persist:"', function *(){
+      nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
+      yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          window.localStorage.setItem('testing', 'This string not should persist between instances.')
+        })
+        .end();
+
+      nightmare = Nightmare({ webPreferences: { partition: 'nonpersist' } });
+      var value = yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          return window.localStorage.getItem('testing') || ''
+        });
+
+      value.should.equal('');
+    });
+
+    it('should persist between instances if partition starts with "persist:"', function *() {
+      nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
+      yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          window.localStorage.setItem('testing', 'This string should persist between instances.')
+        })
+        .end();
+
+      nightmare = Nightmare({ webPreferences: { partition: 'persist: testing' } });
+      var value = yield nightmare
+        .goto(fixture('simple'))
+        .evaluate(function() {
+          return window.localStorage.getItem('testing') || ''
+        });
+
+      value.should.equal('This string should persist between instances.');
+    });
+  })
 });
 
 /**


### PR DESCRIPTION
Added xpath support by adding `{ useXpath: true }` to the nightmare options.

In my first attempt I created a function to select an element by query selector or xpath, but I could not get that to work with the evaluate_now function which is why I added all the checks on the useXpath in every action which uses document.querySelector.