### PR TITLE
fix problems that are rejected when adding child actions with objects.

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -569,7 +569,7 @@ Nightmare.action = function() {
      Nightmare.childActions[name] = childfn;
     } else {
       for(var key in childfn){
-        Nightmare.childActions[name+'.'+key] = childfn;
+        Nightmare.childActions[name+'.'+key] = childfn[key];
       }
     }
   }


### PR DESCRIPTION
I am not good at English, so I use Google translation.

I ran the following code to get cookies for all URLs.
However, it was output as `error: {}` and it did not work.

I investigated and corrected this cause.
If this committed change is correct, please merge.

```js

var Nightmare = require('nightmare');

// Get cookies for all URL
Nightmare.action('cookies', {
  getAll: function (name, options, parent, win, renderer, done) {
    parent.respondTo('cookie.getAll', function (done) {
      win.webContents.session.cookies.get({}, function (err, cookies) {
        if (err) {
          return done(err);
        }
        done(null, cookies);
      });
    });
    done();
  }
},{
  getAll: function (done) {
    this.child.call('cookie.getAll', done);
  }
});

var nightmare = Nightmare({show: true});

nightmare
  .goto('https://accounts.google.com/ServiceLogin#identifier')
  // Sign in
  .cookies.getAll()
  .then(function(cookies) {
    // write file
  })
  .catch(function(err) {
    console.log('error:', err);
  })

```

