### PR TITLE
Fix hang on unexpected child process termination

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -378,7 +378,6 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
     return { argument: JSON.stringify(a) };
   });
   var source = template.execute({ src: String(js_fn), args: args});
-  this.currentCallback = done
   this.child.call('javascript', source, done);
   return this;
 };

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -135,7 +135,7 @@ function Nightmare(options) {
 
     this.proc.on('close', (code) => {
       if(!self.ended){
-        handleExit(code, self, noop);
+        handleExit(code, self, this.currentCallback || noop);
       }
     });
 
@@ -377,7 +377,9 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
     return { argument: JSON.stringify(a) };
   });
   var source = template.execute({ src: String(js_fn), args: args});
+  this.currentCallback = done
   this.child.call('javascript', source, done);
+  this.currentCallback = null
   return this;
 };
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -135,7 +135,8 @@ function Nightmare(options) {
 
     this.proc.on('close', (code) => {
       if(!self.ended){
-        handleExit(code, self, this.currentCallback || noop);
+        this._rejectActivePromise(new Error('Execution terminated unexpectedly. Child process exited.'));
+        handleExit(code, self, noop);
       }
     });
 
@@ -379,7 +380,6 @@ Nightmare.prototype.evaluate_now = function(js_fn, done) {
   var source = template.execute({ src: String(js_fn), args: args});
   this.currentCallback = done
   this.child.call('javascript', source, done);
-  this.currentCallback = null
   return this;
 };
 


### PR DESCRIPTION
When the nightmare child process terminates unexpectedly (e.g. the famous "Child Process exited with status null: undefined" error), execution stalls since the current promise is never rejected nor resolved. 

This PR fixes exactly that. The promise will be rejected, the evaluation can be restarted. 

Related to #1039 and #892