### PR TITLE
Added option for enable/disable audio

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -76,11 +76,13 @@ app.on('ready', function() {
       alwaysOnTop: true,
       webPreferences: {
         preload: join(__dirname, 'preload.js'),
-        nodeIntegration: false
+        nodeIntegration: false,
+        //default muted browser
+        webaudio: false
       }
     })
 
-    /**
+    /** 
      * Create a new Browser Window
      */
 
@@ -102,9 +104,11 @@ app.on('ready', function() {
 
     /**
      * Window options
+     * default webaudio false, optionally you can set true using webPreferences.webaudio property in Nightmare instance and 
+     * this value is automatically propagated to electron webPreferences.webaudio.
      */
 
-    win.webContents.setAudioMuted(true);
+	  win.webContents.setAudioMuted(!options.webPreferences.webaudio);
 
     /**
      * Pass along web content events


### PR DESCRIPTION
Now you can enable/disable audio using webPreferences.webaudio property in Nightmare instance. Default webaudio was setted to false so nightmare has browser audio muted.

Instance option webPreferences.webaudio is automatically propagated to electron BrowserWindow instance, so if you want more information check https://github.com/electron/electron/blob/master/docs/api/browser-window.md