### PR TITLE
Add mouseout action to complement mouseover

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -300,6 +300,9 @@ Mouseup the `selector` element once.
 #### .mouseover(selector)
 Mouseover the `selector` element once.
 
+#### .mouseout(selector)
+Mouseout the `selector` element once.
+
 #### .type(selector[, text])
 Enters the `text` provided into the `selector` element.  Empty or falsey values provided for `text` will clear the selector's value.
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -170,6 +170,26 @@ exports.mouseover = function(selector, done) {
 };
 
 /**
+ * Release hover from an element.
+ *
+ * @param {String} selector
+ * @param {Function} done
+ */
+
+exports.mouseout = function(selector, done) {
+  debug('.mouseout() on ' + selector);
+  this.evaluate_now(function (selector) {
+    var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
+    var event = document.createEvent('MouseEvent');
+    event.initMouseEvent('mouseout', true, true);
+    element.dispatchEvent(event);
+  }, done, selector);
+};
+
+/**
  * Helper functions for type() and insert() to focus/blur
  * so that we trigger DOM events.
  */

--- a/test/fixtures/manipulation/index.html
+++ b/test/fixtures/manipulation/index.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <h1>Hello World!</h1>
+    <h2>this is nightmare</h2>
     <form action="results.html">
       <input type="search" name="q">
       <input type="checkbox" name="advanced">
@@ -82,6 +83,7 @@
   </body>
   <script>
   var h1 = document.getElementsByTagName("h1");
+  var h2 = document.getElementsByTagName("h2");
   var search = document.querySelector('input[type=search]')
   var disappears = document.querySelector('#disappears');
 
@@ -102,6 +104,14 @@
 
   h1[0].addEventListener("mouseup", function(){
     this.style.background = "#0000ff";
+  })
+
+  h2[0].addEventListener("mouseover", function(){
+    this.style.background = "#00ffff";
+  })
+
+  h2[0].addEventListener("mouseout", function(){
+    this.style.background = "";
   })
 
   search.addEventListener("keyup", function(e) {

--- a/test/index.js
+++ b/test/index.js
@@ -1151,6 +1151,26 @@ describe('Nightmare', function () {
       color.should.equal('rgb(102, 255, 102)');
     });
 
+    it('should release hover from an element', function*() {
+      var hoverColor = 'rgb(0, 255, 255)';
+      var hoveredColor = yield nightmare
+        .goto(fixture('manipulation'))
+        .mouseover('h2')
+        .evaluate(function () {
+          var element = document.querySelector('h2');
+          return element.style.background;
+        });
+      hoveredColor.should.equal(hoverColor);
+
+      var nonHoveredColor = yield nightmare
+        .mouseout('h2')
+        .evaluate(function () {
+          var element = document.querySelector('h2');
+          return element.style.background;
+        });
+      nonHoveredColor.should.not.equal(hoverColor);
+    });
+
     it('should mousedown on an element', function*() {
       var color = yield nightmare
         .goto(fixture('manipulation'))


### PR DESCRIPTION
Particularly useful if invoking multiple `mouseover`s over objects and you want to take a screenshot of each in isolation e.g. tooltips, control hover states etc.

Currently a subsequent `mouseover` does not trigger a `mouseout` on an element that has previously been hovered over causing multiple hovered items to appear at once.  This at least provides low level support to programmatically dismiss those previously hovered items.