### PR TITLE
Added clickWithKeymap function to actions.js

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -291,6 +291,32 @@ Refresh the current page.
 #### .click(selector)
 Clicks the `selector` element once.
 
+#### .clickWithKeymap(selector, keyMap)
+Clicks the `selector` element once while pressing a key specified in the keymap. Keymap should contain the key to press with a true value.
+
+Available keys:
+```js
+{
+  shiftKey: true,
+  altKey: true,
+  ctrlKey: true,
+  mediaKey: true
+}
+```
+Example:
+```js
+nightmare
+  .goto(someUrl)
+  .click('input[type=checkbox].first')
+  .clickWithKeymap('input[type=checkbox].third', {shiftKey: true})
+  .evaluate(function () {
+    return document.querySelectorAll('input[type=checkbox]:checked');
+  })
+  .then((checkboxes) => {
+    Object.keys(checkboxes).length.should.equal(3);
+  });
+```
+
 #### .mousedown(selector)
 Mousedown the `selector` element once.
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -110,6 +110,39 @@ exports.click = function(selector, done) {
 };
 
 /**
+ * Click an element with a key pressed.
+ *
+ * @param {String} selector
+ * @param {Object} keyMap - {ctrlKey: [true, false], altKey, shiftKey, metaKey}
+ * @param {Function} done
+ */
+
+exports.clickWithKeymap = function(selector, keyMap, done) {
+  debug('.click() on ' + selector);
+  keyMap = keyMap || {};
+  this.evaluate_now(function (selector) {
+    document.activeElement.blur();
+    var element = document.querySelector(selector);
+    if (!element) {
+      throw new Error('Unable to find element by selector: ' + selector);
+    }
+    var options = {
+      bubbles: true, 
+      cancelable: true
+    };
+    Object.assign(options, {
+      ctrlKey: keyMap.ctrlKey,
+      altKey: keyMap.altKey, 
+      shiftKey: keyMap.shiftKey, 
+      metaKey: keyMap.metaKey
+    });
+    
+    var event = new MouseEvent('click', options);
+    element.dispatchEvent(event);
+  }, done, selector);
+};
+
+/**
  * Mousedown on an element.
  *
  * @param {String} selector

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -127,16 +127,16 @@ exports.clickWithKeymap = function(selector, keyMap, done) {
       throw new Error('Unable to find element by selector: ' + selector);
     }
     var options = {
-      bubbles: true, 
+      bubbles: true,
       cancelable: true
     };
     Object.assign(options, {
       ctrlKey: keyMap.ctrlKey,
-      altKey: keyMap.altKey, 
-      shiftKey: keyMap.shiftKey, 
+      altKey: keyMap.altKey,
+      shiftKey: keyMap.shiftKey,
       metaKey: keyMap.metaKey
     });
-    
+
     var event = new MouseEvent('click', options);
     element.dispatchEvent(event);
   }, done, selector, keyMap);
@@ -283,7 +283,7 @@ exports.insert = function(selector, text, done) {
       debug('Unable to .insert() into non-existent selector %s', selector);
       return done(err);
     }
-    
+
     var blurDone = blurSelector.bind(this, done, selector);
     if ((text || '') == '') {
       this.evaluate_now(function(selector) {
@@ -476,10 +476,10 @@ function waitfn() {
   var executionTimer;
   var softTimeoutTimer;
   var self = arguments[0];
-  
+
   var args = sliced(arguments);
   var done = args[args.length-1];
-  
+
   var timeoutTimer = setTimeout(function(){
     clearTimeout(executionTimer);
     clearTimeout(softTimeoutTimer);

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -120,7 +120,7 @@ exports.click = function(selector, done) {
 exports.clickWithKeymap = function(selector, keyMap, done) {
   debug('.click() on ' + selector);
   keyMap = keyMap || {};
-  this.evaluate_now(function (selector) {
+  this.evaluate_now(function (selector, keyMap) {
     document.activeElement.blur();
     var element = document.querySelector(selector);
     if (!element) {
@@ -139,7 +139,7 @@ exports.clickWithKeymap = function(selector, keyMap, done) {
     
     var event = new MouseEvent('click', options);
     element.dispatchEvent(event);
-  }, done, selector);
+  }, done, selector, keyMap);
 };
 
 /**

--- a/test/fixtures/manipulation/index.html
+++ b/test/fixtures/manipulation/index.html
@@ -119,35 +119,35 @@
   search.addEventListener('input', function(e) {
     console.log('input', e.which)
   });
-   
+
   var lastClickedBox = 0;
   checkboxes.forEach((checkbox) => {
     checkbox.addEventListener('click', function(e) {
       var clickedBox = 0;
       var checkboxes = document.querySelectorAll('input[type=checkbox]');
       for(var i = 0; i < checkboxes.length; i++){
-       if(checkboxes[i].name === e.target.name){
-         clickedBox = i;
-       }
-     }
-     if(event.shiftKey) {
-         setCheckboxes(lastClickedBox, clickedBox);
-     };
-     lastClickedBox = clickedBox;
-   });
+        if(checkboxes[i].name === e.target.name){
+          clickedBox = i;
+        }
+      }
+      if(event.shiftKey) {
+        setCheckboxes(lastClickedBox, clickedBox);
+      };
+      lastClickedBox = clickedBox;
+    });
   });
-    
+
   function setCheckboxes(end, start) {
     if(start > end) {
-        var temp = start;
-        start = end;
-        end = temp;
+      var temp = start;
+      start = end;
+      end = temp;
     };
 
     var checkboxes = document.querySelectorAll('input[type=checkbox]');
     for(var i = 0; i < checkboxes.length; i++){
       if(i >= start && i <= end){
-        checkboxes[i].setAttrubute('checked', true);
+        checkboxes[i].setAttribute('checked', true);
       }
     }
   }

--- a/test/fixtures/manipulation/index.html
+++ b/test/fixtures/manipulation/index.html
@@ -86,6 +86,7 @@
   <script>
   var h1 = document.getElementsByTagName("h1");
   var search = document.querySelector('input[type=search]')
+  var checkboxes = document.querySelector('input[type=checkbox]')
   var disappears = document.querySelector('#disappears');
 
   disappears.addEventListener('keydown', function(e){
@@ -101,22 +102,52 @@
 
   h1[0].addEventListener("mousedown", function(){
     this.style.background = "#ff0000";
-  })
+  });
 
   h1[0].addEventListener("mouseup", function(){
     this.style.background = "#0000ff";
-  })
+  });
 
   search.addEventListener("keyup", function(e) {
     console.log('keyup', e.which)
-  })
+  });
 
   search.addEventListener("keydown", function(e) {
     console.log('keydown', e.which)
-  })
+  });
 
   search.addEventListener('input', function(e) {
     console.log('input', e.which)
-  })
+  });
+   
+  var lastClickedBox = 0;
+  checkboxes.addEventListener('click', function(e) {
+    var clickedBox = 0;
+    var checkboxes = document.querySelectorAll('input[type=checkbox]');
+    for(var i = 0; i < checkboxes.length; i++){
+      if(checkboxes[i].name === e.target.name){
+        clickedBox = i;
+      }
+    }
+    if(event.shiftKey) {
+        setCheckboxes(lastClickedBox, clickedBox);
+    };
+    lastClickedBox = clickedBox;
+  });
+    
+  function setCheckboxes(end, start) {
+    if(start > end) {
+        var temp = start;
+        start = end;
+        end = temp;
+    };
+
+    var checkboxes = document.querySelectorAll('input[type=checkbox]');
+    for(var i = 0; i < checkboxes.length; i++){
+      if(i >= start && i <= end){
+        checkboxes[i].attrubute('checked', true);
+      }
+    }
+  }
   </script>
 </html>

--- a/test/fixtures/manipulation/index.html
+++ b/test/fixtures/manipulation/index.html
@@ -8,6 +8,9 @@
     <form action="results.html">
       <input type="search" name="q">
       <input type="checkbox" name="advanced">
+      <input type="checkbox" name="cb1">
+      <input type="checkbox" name="cb2">
+      <input type="checkbox" name="cb3">
       <input type='text' id='disappears'>
       <select name="options">
         <option value="a">A</option>

--- a/test/fixtures/manipulation/index.html
+++ b/test/fixtures/manipulation/index.html
@@ -86,7 +86,7 @@
   <script>
   var h1 = document.getElementsByTagName("h1");
   var search = document.querySelector('input[type=search]')
-  var checkboxes = document.querySelector('input[type=checkbox]')
+  var checkboxes = document.querySelectorAll('input[type=checkbox]')
   var disappears = document.querySelector('#disappears');
 
   disappears.addEventListener('keydown', function(e){
@@ -121,18 +121,20 @@
   });
    
   var lastClickedBox = 0;
-  checkboxes.addEventListener('click', function(e) {
-    var clickedBox = 0;
-    var checkboxes = document.querySelectorAll('input[type=checkbox]');
-    for(var i = 0; i < checkboxes.length; i++){
-      if(checkboxes[i].name === e.target.name){
-        clickedBox = i;
-      }
-    }
-    if(event.shiftKey) {
-        setCheckboxes(lastClickedBox, clickedBox);
-    };
-    lastClickedBox = clickedBox;
+  checkboxes.forEach((checkbox) => {
+    checkbox.addEventListener('click', function(e) {
+      var clickedBox = 0;
+      var checkboxes = document.querySelectorAll('input[type=checkbox]');
+      for(var i = 0; i < checkboxes.length; i++){
+       if(checkboxes[i].name === e.target.name){
+         clickedBox = i;
+       }
+     }
+     if(event.shiftKey) {
+         setCheckboxes(lastClickedBox, clickedBox);
+     };
+     lastClickedBox = clickedBox;
+   });
   });
     
   function setCheckboxes(end, start) {
@@ -145,7 +147,7 @@
     var checkboxes = document.querySelectorAll('input[type=checkbox]');
     for(var i = 0; i < checkboxes.length; i++){
       if(i >= start && i <= end){
-        checkboxes[i].attrubute('checked', true);
+        checkboxes[i].setAttrubute('checked', true);
       }
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -183,7 +183,7 @@ describe('Nightmare', function () {
 
     return Promise.all([check1, check2]);
   });
-  
+
   it('should successfully end on pages setting onunload or onbeforeunload', function(done) {
     var nightmare = Nightmare();
     nightmare.goto(fixture('unload'))
@@ -1102,7 +1102,7 @@ describe('Nightmare', function () {
         });
       checkbox.should.be.false;
     });
-    
+
     it('should shift check', function*() {
       var checkboxes = yield nightmare
         .goto(fixture('manipulation'))
@@ -1112,7 +1112,7 @@ describe('Nightmare', function () {
         .evaluate(function () {
           return document.querySelectorAll('input[type=checkbox]:checked');
         });
-     Object.keys(checkboxes).length.should.equal(3);
+      Object.keys(checkboxes).length.should.equal(3);
     });
 
     it('should select', function*() {

--- a/test/index.js
+++ b/test/index.js
@@ -1106,12 +1106,13 @@ describe('Nightmare', function () {
     it('should shift check', function*() {
       var checkboxes = yield nightmare
         .goto(fixture('manipulation'))
+        .uncheck('input[type=checkbox][name=advanced]')
         .check('input[type=checkbox][name=cb1]')
-        .checkWithKeymap('input[type=checkbox][name=cb3]', {shiftKey: true})
+        .clickWithKeymap('input[type=checkbox][name=cb3]', {shiftKey: true})
         .evaluate(function () {
           return document.querySelectorAll('input[type=checkbox]:checked');
         });
-     checkboxes.length.should.equal(3);
+     Object.keys(checkboxes).length.should.equal(3);
     });
 
     it('should select', function*() {

--- a/test/index.js
+++ b/test/index.js
@@ -1085,7 +1085,7 @@ describe('Nightmare', function () {
     it('should checkbox', function*() {
       var checkbox = yield nightmare
         .goto(fixture('manipulation'))
-        .check('input[type=checkbox]')
+        .check('input[type=checkbox][name=advanced]')
         .evaluate(function () {
           return document.querySelector('input[type=checkbox]').checked;
         });
@@ -1095,12 +1095,23 @@ describe('Nightmare', function () {
     it('should uncheck', function*() {
       var checkbox = yield nightmare
         .goto(fixture('manipulation'))
-        .check('input[type=checkbox]')
-        .uncheck('input[type=checkbox]')
+        .check('input[type=checkbox][name=advanced]')
+        .uncheck('input[type=checkbox][name=advanced]')
         .evaluate(function () {
-          return document.querySelector('input[type=checkbox]').checked;
+          return document.querySelector('input[type=checkbox][name=advanced]').checked;
         });
       checkbox.should.be.false;
+    });
+    
+    it('should shift check', function*() {
+      var checkboxes = yield nightmare
+        .goto(fixture('manipulation'))
+        .check('input[type=checkbox][name=cb1]')
+        .checkWithKeymap('input[type=checkbox][name=cb3]', {shiftKey: true})
+        .evaluate(function () {
+          return document.querySelectorAll('input[type=checkbox]:checked');
+        });
+     checkboxes.length.should.equal(3);
     });
 
     it('should select', function*() {


### PR DESCRIPTION
A feature of MouseEvents is to provide access to 4 different keybindings: shift, ctrl, alt, and media. This method exposes those bindings so that a test can perform a mouse click with one of the buttons down. 

The function is called similarly to the `click` event, except it allows a second parameter called `keyMap`. One example use case is if you first check a checkbox, then use `clickWithKeymap` to check the next checkbox while indicating that a key is pressed.

In the example below, the test checks the first checkbox, then clicks `cb3`, skipping `cb2`, however the `shiftKey` is set to `true` in the `keyMap`, so the client-side code will notice a shiftKey property exposed in the UI and will automatically check `cb2`. We use the test to verify that the client-side code acted appropriately.

I chose to implement this as a `click` event rather than a `check` event because it applies to other element types beyond checkboxes. It can apply to table rows for instance.

```
var checkboxes = yield nightmare
  .goto(fixture('manipulation'))
  .check('input[type=checkbox][name=cb1]')
  .clickWithKeymap('input[type=checkbox][name=cb3]', {shiftKey: true})
  .evaluate(function () {
    return document.querySelectorAll('input[type=checkbox]:checked');
  });
  Object.keys(checkboxes).length.should.equal(3);
```