### PR TITLE
Sanitize what channels are accepted for ipc.send/sendSync

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,5 +1,23 @@
+var ipc = require('electron').ipcRenderer;
+function checkSend(channel)
+{
+  var args = Array.from(arguments).slice(1);
+  if (!['response','page','console','error'].includes(channel))
+    throw new Error();
+  return args;
+}
 window.__nightmare = {};
-__nightmare.ipc = require('electron').ipcRenderer;
+__nightmare.ipc = {
+  send: function(channel)
+  {
+    ipc.send.apply(ipc,[channel].concat(checkSend.apply(null,arguments)));
+  },
+
+  sendSync: function(channel)
+  {
+    ipc.sendSync.apply(ipc,[channel].concat(checkSend.apply(null,arguments)));
+  }
+}
 __nightmare.sliced = require('sliced');
 
 // Listen for error events


### PR DESCRIPTION
Restrict channels for ipc messages from preload.js to ['console','response','error','log']

#1060 

Temp solution until decision made on longer term changes that might be breaking for people using custom preload
