### PR TITLE
Pin Electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron": "^1.4.4",
+    "electron": "1.7.6",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",


### PR DESCRIPTION
This pins the version of Electron used by the project, to prevent issues with the nuked Electron 1.8.0 version (https://github.com/electron/electron/issues/10574#issuecomment-331373344).

This addresses: https://github.com/segmentio/nightmare/issues/1269