### PR TITLE
Temporarily lock down electron version to v1.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron": "^1.4.4",
+    "electron": "1.7.6",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",


### PR DESCRIPTION
Just a temporary fix while waiting for the electron issue to be fixed. 
https://github.com/segmentio/nightmare/issues/1272

Master is also in this version https://github.com/segmentio/nightmare/blob/master/package.json#L23