### PR TITLE
Fix Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,9 +86,6 @@ describe('test duckduckgo search results', () => {
 
 You can see examples of every function [in the tests here](https://github.com/segmentio/nightmare/blob/master/test/index.js).
 
-Please note that the examples are using the [mocha-generators](https://www.npmjs.com/package/mocha-generators)
-package for Mocha, which enables the support for generators.
-
 To get started with UI Testing, check out this [quick start guide](https://segment.com/blog/ui-testing-with-nightmare).
 
 ### To install dependencies


### PR DESCRIPTION
The example in `Readme.md` does not use `mocha-generators`.