### PR TITLE
Added ability to specify the client certificate selected by electron

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -229,6 +229,15 @@ const nightmare = Nightmare({
 });
 ```
 
+#### certificateSubjectName
+A string to determine the client certificate selected by electron. If this options is set, the [`select-client-certificate`](https://github.com/electron/electron/blob/master/docs/api/app.md#event-select-client-certificate) event will be set to loop through the certificateList and find the first certificate that matches `subjectName` on the electron [`Certificate Object`](https://electronjs.org/docs/api/structures/certificate).
+
+```js
+const nightmare = Nightmare({
+  certificateSubjectName: "tester"
+});
+```
+
 #### .engineVersions()
 Gets the versions for Electron and Chromium.
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -105,6 +105,8 @@ function Nightmare(options) {
   }
 
   electronArgs.dock = options.dock || false;
+  
+  electronArgs.certName = options.certName || null;  
 
   attachToProcess(this);
 

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -105,8 +105,7 @@ function Nightmare(options) {
   }
 
   electronArgs.dock = options.dock || false;
-  
-  electronArgs.certName = options.certName || null;  
+  electronArgs.certificateSubjectName = options.certificateSubjectName || null;
 
   attachToProcess(this);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -60,7 +60,7 @@ if (!processArgs.dock && app.dock) {
 }
 
 /**
- * Set client certificate by subjectName if options.certificateSubjectName is defined
+ * Set the client certificate by subjectName if processArgs.certificateSubjectName is defined
  */
 
 if(processArgs.certificateSubjectName) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -59,6 +59,22 @@ if (!processArgs.dock && app.dock) {
   app.dock.hide();
 }
 
+
+app.on ('select-client-certificate', (event, webContents, url, list, callback) => {
+  var subjectName = processArgs.certName;
+
+  if(subjectName) {
+    for(var i = 0; i < list.length; i++) {
+      if(list[i].subjectName === subjectName) {
+        callback(list[i]);
+        return;
+      }
+    }
+  }
+
+  callback (list[0]);
+});
+
 /**
  * Listen for the app being "ready"
  */

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -59,21 +59,23 @@ if (!processArgs.dock && app.dock) {
   app.dock.hide();
 }
 
+/**
+ * Set client certificate by subjectName if options.certificateSubjectName is defined
+ */
 
-app.on ('select-client-certificate', (event, webContents, url, list, callback) => {
-  var subjectName = processArgs.certName;
-
-  if(subjectName) {
+if(processArgs.certificateSubjectName) {
+  app.on ('select-client-certificate', (event, webContents, url, list, callback) => {
     for(var i = 0; i < list.length; i++) {
-      if(list[i].subjectName === subjectName) {
+      if(list[i].subjectName === processArgs.certificateSubjectName) {
         callback(list[i]);
         return;
       }
     }
-  }
 
-  callback (list[0]);
-});
+    // defaults to first if the subject name is not available
+    callback (list[0]);
+  })
+}
 
 /**
  * Listen for the app being "ready"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nightmare-with-cert-support",
-  "version": "2.10.1",
+  "name": "nightmare",
+  "version": "2.10.0",
   "license": "MIT",
   "main": "lib/nightmare.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nightmare",
-  "version": "2.10.0",
+  "name": "nightmare-with-cert-support",
+  "version": "2.10.1",
   "license": "MIT",
   "main": "lib/nightmare.js",
   "scripts": {


### PR DESCRIPTION
I could not find any simple way to access the `select-client-certificate` event on the electron instance via nightmare. This change will allow a nightmare user to select a client certificate by subjectName instead of always relying on the first available client certificate.  