### PR TITLE
Update electron version to 1.7.11 to fix CVE-2018-1000006

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron": "1.7.6",
+    "electron": "^1.7.11",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",
@@ -47,6 +47,6 @@
     "split": "^1.0.0"
   },
   "engines": {
-    "node":">=4.0.0"
+    "node": ">=4.0.0"
   }
 }


### PR DESCRIPTION
Updating electron version to 1.7.11 to resolve the critical severity security vulnerability in version range >= 1.7.0,< 1.7.11
cf. [CVE-2018-1000006](https://electronjs.org/blog/protocol-handler-fix)