### PR TITLE
Use --save-dev instead of --save

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,7 @@ nightmare
 You can run this with:
 
 ```shell
-npm install --save nightmare
+npm install --save-dev nightmare
 node example.js
 ```
 


### PR DESCRIPTION
This is a tests runner so I don't see why people would ever need this in the actual source when users are interacting with it. Won't people pretty much always use this as a dev dependency? I know webpack fixes it all, but people could still find it confusing. :)