### PR TITLE
refactor: remove window.__nightmare.ipc

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,9 @@ Nightmare is a high-level browser automation library from [Segment](https://segm
 
 The goal is to expose a few simple methods that mimic user actions (like `goto`, `type` and `click`), with an API that feels synchronous for each block of scripting, rather than deeply nested callbacks. It was originally designed for automating tasks across sites that don't have APIs, but is most often used for UI testing and crawling.
 
-Under the covers it uses [Electron](http://electron.atom.io/), which is similar to [PhantomJS](http://phantomjs.org/) but roughly [twice as fast](https://github.com/segmentio/nightmare/issues/484#issuecomment-184519591) and more modern. **[Because Nightmare uses Electron, it is your responsibility to ensure that the webpages loaded by Nightmare are not malicious](https://github.com/electron/electron/blob/master/docs/tutorial/security.md). If you do load a malicious website, that website can execute arbitrary code on your computer.**
+Under the covers it uses [Electron](http://electron.atom.io/), which is similar to [PhantomJS](http://phantomjs.org/) but roughly [twice as fast](https://github.com/segmentio/nightmare/issues/484#issuecomment-184519591) and more modern. 
+
+**We've implemented [many](https://github.com/segmentio/nightmare/issues/1388) of the security recommendations [outlined by Electron](https://github.com/electron/electron/blob/master/docs/tutorial/security.md) to try and keep you safe, but vulnerabilities may exist in Electron that may allow a malicious website to execute code on your company. Avoid visiting untrusted websites.**
 
 [Niffy](https://github.com/segmentio/niffy) is a perceptual diffing tool built on Nightmare. It helps you detect UI changes and bugs across releases of your web app.
 

--- a/Readme.md
+++ b/Readme.md
@@ -793,14 +793,7 @@ const nightmare = Nightmare({
 })
 ```
 
-The only requirement for that script is that you'll need the following prelude:
-
-```js
-window.__nightmare = {}
-__nightmare.ipc = require('electron').ipcRenderer
-```
-
-To benefit of all of nightmare's feedback from the browser, you can instead copy the contents of nightmare's [preload script](lib/preload.js).
+You'll also need to copy the contents of nightmare's [preload script](lib/preload.js) into your custom script to support Nightmare's API.
 
 #### Storage Persistence between nightmare instances
 

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -12,7 +12,7 @@ var minstache = require('minstache')
 
 var execute = `
 (function javascript () {
-  var ipc = (window.__nightmare ? __nightmare.ipc : window[''].nightmare.ipc);
+  var nightmare = window.__nightmare || window[''].nightmare;
   try {
     var fn = ({{!src}}), 
       response, 
@@ -23,9 +23,9 @@ var execute = `
     if(fn.length - 1 == args.length) {
       args.push(((err, v) => {
           if(err) {
-            ipc.send('error', err.message || err.toString());
+            nightmare.reject(err.message || err.toString());
           }
-          ipc.send('response', v);
+          nightmare.resolve(v);
         }));
       fn.apply(null, args);
     } 
@@ -33,17 +33,17 @@ var execute = `
       response = fn.apply(null, args);
       if(response && response.then) {
         response.then((v) => {
-          ipc.send('response', v);
+          nightmare.resolve(v);
         })
         .catch((err) => {
-          ipc.send('error', err)
+          nightmare.reject(err.message || err.toString())
         });
       } else {
-        ipc.send('response', response);
+        nightmare.resolve(response);
       }
     }
   } catch (err) {
-    ipc.send('error', err.message);
+    nightmare.reject(err.message);
   }
 })()
 `
@@ -56,12 +56,12 @@ var execute = `
 
 var inject = `
 (function javascript () {
-  var ipc = (window.__nightmare ? __nightmare.ipc : window[''].nightmare.ipc);
+  var nightmare = window.__nightmare || window[''].nightmare;
   try {
     var response = (function () { {{!src}} \n})()
-    ipc.send('response', response);
+    nightmare.resolve(response);
   } catch (e) {
-    ipc.send('error', e.message);
+    nightmare.reject(e.message);
   }
 })()
 `

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -183,91 +183,55 @@ function Nightmare(options) {
 
     // propogate events through to debugging
     this.child.on('did-finish-load', function() {
-      log(
-        'did-finish-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-finish-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-fail-load', function() {
-      log(
-        'did-fail-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-fail-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-fail-provisional-load', function() {
-      log(
-        'did-fail-provisional-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-fail-provisional-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-frame-finish-load', function() {
-      log(
-        'did-frame-finish-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-frame-finish-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-start-loading', function() {
-      log(
-        'did-start-loading',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-start-loading', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-stop-loading', function() {
-      log(
-        'did-stop-loading',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-stop-loading', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-get-response-details', function() {
-      log(
-        'did-get-response-details',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-get-response-details', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-get-redirect-request', function() {
-      log(
-        'did-get-redirect-request',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-get-redirect-request', JSON.stringify(sliced(arguments)))
     })
     this.child.on('dom-ready', function() {
-      log('dom-ready', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('dom-ready', JSON.stringify(sliced(arguments)))
     })
     this.child.on('page-favicon-updated', function() {
-      log(
-        'page-favicon-updated',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('page-favicon-updated', JSON.stringify(sliced(arguments)))
     })
     this.child.on('new-window', function() {
-      log('new-window', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('new-window', JSON.stringify(sliced(arguments)))
     })
     this.child.on('will-navigate', function() {
-      log(
-        'will-navigate',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('will-navigate', JSON.stringify(sliced(arguments)))
     })
     this.child.on('crashed', function() {
-      log('crashed', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('crashed', JSON.stringify(sliced(arguments)))
     })
     this.child.on('plugin-crashed', function() {
-      log(
-        'plugin-crashed',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('plugin-crashed', JSON.stringify(sliced(arguments)))
     })
     this.child.on('destroyed', function() {
-      log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('destroyed', JSON.stringify(sliced(arguments)))
     })
     this.child.on('media-started-playing', function() {
-      log(
-        'media-started-playing',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('media-started-playing', JSON.stringify(sliced(arguments)))
     })
     this.child.on('media-paused', function() {
-      log('media-paused', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('media-paused', JSON.stringify(sliced(arguments)))
     })
 
     this.child.once('ready', versions => {

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,87 +1,94 @@
 /* eslint-disable no-console */
 
-window.window.__nightmare = {}
-window.__nightmare.ipc = require('electron').ipcRenderer
-window.__nightmare.sliced = require('sliced')
+var ipc = require('electron').ipcRenderer
+var sliced = require('sliced')
+
+function send(_event) {
+  ipc.send.apply(ipc, arguments)
+}
+
+// offer limited access to allow
+// .evaluate() and .inject()
+// to continue to work as expected.
+//
+// TODO: this could be avoided by
+// rewriting the evaluate to
+// use promises instead. But
+// for now this fixes the security
+// issue in: segmentio/nightmare/#1358
+window.__nightmare = {
+  resolve: function(value) {
+    send('response', value)
+  },
+  reject: function(message) {
+    send('error', message)
+  }
+}
 
 // Listen for error events
-window.addEventListener('error', function(e) {
-  window.__nightmare.ipc.send(
-    'page',
-    'error',
-    e.message,
-    (e.error || {}).stack || ''
-  )
+window.addEventListener(
+  'error',
+  function(e) {
+    send('page', 'error', e.message, (e.error || {}).stack || '')
+  },
+  true
+)
+
+// prevent 'unload' and 'beforeunload' from being bound
+var defaultAddEventListener = window.addEventListener
+window.addEventListener = function(type) {
+  if (type === 'unload' || type === 'beforeunload') {
+    return
+  }
+  defaultAddEventListener.apply(window, arguments)
+}
+
+// prevent 'onunload' and 'onbeforeunload' from being set
+Object.defineProperties(window, {
+  onunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  },
+  onbeforeunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  }
 })
-;(function() {
-  // prevent 'unload' and 'beforeunload' from being bound
-  var defaultAddEventListener = window.addEventListener
-  window.addEventListener = function(type) {
-    if (type === 'unload' || type === 'beforeunload') {
-      return
-    }
-    defaultAddEventListener.apply(window, arguments)
-  }
 
-  // prevent 'onunload' and 'onbeforeunload' from being set
-  Object.defineProperties(window, {
-    onunload: {
-      enumerable: true,
-      writable: false,
-      value: null
-    },
-    onbeforeunload: {
-      enumerable: true,
-      writable: false,
-      value: null
-    }
-  })
+// listen for console.log
+var defaultLog = console.log
+console.log = function() {
+  send('console', 'log', sliced(arguments))
+  return defaultLog.apply(this, arguments)
+}
 
-  // listen for console.log
-  var defaultLog = console.log
-  console.log = function() {
-    window.__nightmare.ipc.send(
-      'console',
-      'log',
-      window.__nightmare.sliced(arguments)
-    )
-    return defaultLog.apply(this, arguments)
-  }
+// listen for console.warn
+var defaultWarn = console.warn
+console.warn = function() {
+  send('console', 'warn', sliced(arguments))
+  return defaultWarn.apply(this, arguments)
+}
 
-  // listen for console.warn
-  var defaultWarn = console.warn
-  console.warn = function() {
-    window.__nightmare.ipc.send(
-      'console',
-      'warn',
-      window.__nightmare.sliced(arguments)
-    )
-    return defaultWarn.apply(this, arguments)
-  }
+// listen for console.error
+var defaultError = console.error
+console.error = function() {
+  send('console', 'error', sliced(arguments))
+  return defaultError.apply(this, arguments)
+}
 
-  // listen for console.error
-  var defaultError = console.error
-  console.error = function() {
-    window.__nightmare.ipc.send(
-      'console',
-      'error',
-      window.__nightmare.sliced(arguments)
-    )
-    return defaultError.apply(this, arguments)
-  }
+// overwrite the default alert
+window.alert = function(message) {
+  send('page', 'alert', message)
+}
 
-  // overwrite the default alert
-  window.alert = function(message) {
-    window.__nightmare.ipc.send('page', 'alert', message)
-  }
+// overwrite the default prompt
+window.prompt = function(message, defaultResponse) {
+  send('page', 'prompt', message, defaultResponse)
+}
 
-  // overwrite the default prompt
-  window.prompt = function(message, defaultResponse) {
-    window.__nightmare.ipc.send('page', 'prompt', message, defaultResponse)
-  }
-
-  // overwrite the default confirm
-  window.confirm = function(message, defaultResponse) {
-    window.__nightmare.ipc.send('page', 'confirm', message, defaultResponse)
-  }
-})()
+// overwrite the default confirm
+window.confirm = function(message, defaultResponse) {
+  send('page', 'confirm', message, defaultResponse)
+}

--- a/test/fixtures/preload/index.js
+++ b/test/fixtures/preload/index.js
@@ -1,3 +1,96 @@
-window.__nightmare = {};
-__nightmare.ipc = require('electron').ipcRenderer;
+/* eslint-disable no-console */
+
+var ipc = require('electron').ipcRenderer
+var sliced = require('sliced')
+
+function send(_event) {
+  ipc.send.apply(ipc, arguments)
+}
+
+// offer limited access to allow
+// .evaluate() and .inject()
+// to continue to work as expected.
+//
+// TODO: this could be avoided by
+// rewriting the evaluate to
+// use promises instead. But
+// for now this fixes the security
+// issue in: segmentio/nightmare/#1358
+window.__nightmare = {
+  resolve: function(value) {
+    send('response', value)
+  },
+  reject: function(message) {
+    send('error', message)
+  }
+}
+
+// Listen for error events
+window.addEventListener(
+  'error',
+  function(e) {
+    send('page', 'error', e.message, (e.error || {}).stack || '')
+  },
+  true
+)
+
+// prevent 'unload' and 'beforeunload' from being bound
+var defaultAddEventListener = window.addEventListener
+window.addEventListener = function(type) {
+  if (type === 'unload' || type === 'beforeunload') {
+    return
+  }
+  defaultAddEventListener.apply(window, arguments)
+}
+
+// prevent 'onunload' and 'onbeforeunload' from being set
+Object.defineProperties(window, {
+  onunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  },
+  onbeforeunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  }
+})
+
+// listen for console.log
+var defaultLog = console.log
+console.log = function() {
+  send('console', 'log', sliced(arguments))
+  return defaultLog.apply(this, arguments)
+}
+
+// listen for console.warn
+var defaultWarn = console.warn
+console.warn = function() {
+  send('console', 'warn', sliced(arguments))
+  return defaultWarn.apply(this, arguments)
+}
+
+// listen for console.error
+var defaultError = console.error
+console.error = function() {
+  send('console', 'error', sliced(arguments))
+  return defaultError.apply(this, arguments)
+}
+
+// overwrite the default alert
+window.alert = function(message) {
+  send('page', 'alert', message)
+}
+
+// overwrite the default prompt
+window.prompt = function(message, defaultResponse) {
+  send('page', 'prompt', message, defaultResponse)
+}
+
+// overwrite the default confirm
+window.confirm = function(message, defaultResponse) {
+  send('page', 'confirm', message, defaultResponse)
+}
+
 window.preload = 'custom'

--- a/test/fixtures/security/index.html
+++ b/test/fixtures/security/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Simple</title>
+</head>
+
+<body>
+  <h1>Hello World!</h1>
+</body>
+
+<script type="text/javascript">
+  console.log(typeof ipc, typeof window.ipc, typeof send, typeof window.send)
+</script>
+
+</html>


### PR DESCRIPTION
This is a **BREAKING** change.

This PR greatly restricts access to the IPC. The preload no longer exposes the IPC via `window.__nightmare.ipc`. Instead the IPC is wrapped in a send method that is not accessible to the page. 

Also since the preload script loads first, there's no opportunity for a malicious website to monkey-path that `send(event, data)` method.

For `.evaluate(src)` and `inject(...)`, we do need to be able to access the IPC from the window. For these cases, I've created dedicated methods that only allow the sending of a `response` and `error` event. We should be able to remove this altogether via https://github.com/segmentio/nightmare/issues/1387 but that's out of the scope of this PR.

This PR does break certain types of custom actions that relied on setting up custom events. There's also a bit more work now to setup a custom preload script. For normal, every-day Nightmare usage, this won't break anything but I do recommend we bump a major version to 3.0.0. Please take a look at the tests I changed / removed in the diff to see the details of what's changed.