### PR TITLE
fix: properly serialize & unserialize errors across processes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,9 @@ Nightmare is a high-level browser automation library from [Segment](https://segm
 
 The goal is to expose a few simple methods that mimic user actions (like `goto`, `type` and `click`), with an API that feels synchronous for each block of scripting, rather than deeply nested callbacks. It was originally designed for automating tasks across sites that don't have APIs, but is most often used for UI testing and crawling.
 
-Under the covers it uses [Electron](http://electron.atom.io/), which is similar to [PhantomJS](http://phantomjs.org/) but roughly [twice as fast](https://github.com/segmentio/nightmare/issues/484#issuecomment-184519591) and more modern. **[Because Nightmare uses Electron, it is your responsibility to ensure that the webpages loaded by Nightmare are not malicious](https://github.com/electron/electron/blob/master/docs/tutorial/security.md). If you do load a malicious website, that website can execute arbitrary code on your computer.**
+Under the covers it uses [Electron](http://electron.atom.io/), which is similar to [PhantomJS](http://phantomjs.org/) but roughly [twice as fast](https://github.com/segmentio/nightmare/issues/484#issuecomment-184519591) and more modern. 
+
+**We've implemented [many](https://github.com/segmentio/nightmare/issues/1388) of the security recommendations [outlined by Electron](https://github.com/electron/electron/blob/master/docs/tutorial/security.md) to try and keep you safe, but vulnerabilities may exist in Electron that may allow a malicious website to execute code on your company. Avoid visiting untrusted websites.**
 
 [Niffy](https://github.com/segmentio/niffy) is a perceptual diffing tool built on Nightmare. It helps you detect UI changes and bugs across releases of your web app.
 

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -84,13 +84,20 @@ function IPC(process) {
       progress.emit.apply(progress, ['data'].concat(sliced(arguments)))
     })
 
-    emitter.once(`CALL_RESULT_${id}`, function() {
-      progress.emit.apply(progress, ['end'].concat(sliced(arguments)))
+    emitter.once(`CALL_RESULT_${id}`, function(err) {
+      // unserialize errors
+      err = unserializeError(err)
+
+      progress.emit.apply(
+        progress,
+        ['end'].concat(err).concat(sliced(arguments, 1))
+      )
+
       emitter.removeAllListeners(`CALL_DATA_${id}`)
       progress.removeAllListeners()
       progress = undefined
       if (callback) {
-        callback.apply(null, arguments)
+        callback.apply(null, [err].concat(sliced(arguments, 1)))
       }
     })
 
@@ -117,17 +124,18 @@ function IPC(process) {
 
   emitter.on('CALL', function(id, name) {
     var responder = responders[name]
-    var done = function() {
+    var done = function(err) {
+      err = serializeError(err)
       emitter.emit.apply(
         emitter,
-        [`CALL_RESULT_${id}`].concat(sliced(arguments))
+        [`CALL_RESULT_${id}`].concat(err).concat(sliced(arguments, 1))
       )
     }
     done.progress = function() {
       emitter.emit.apply(emitter, [`CALL_DATA_${id}`].concat(sliced(arguments)))
     }
     if (!responder) {
-      return done(`Nothing responds to "${name}"`)
+      return done(new Error(`Nothing responds to "${name}"`))
     }
     try {
       responder.apply(null, sliced(arguments, 2).concat([done]))
@@ -137,4 +145,24 @@ function IPC(process) {
   })
 
   return emitter
+}
+
+function serializeError(err) {
+  if (!(err instanceof Error)) return err
+  return {
+    code: err.code,
+    message: err.message,
+    details: err.detail,
+    stack: err.stack || ''
+  }
+}
+
+function unserializeError(err) {
+  if (!err || !err.message) return err
+  const e = new Error(err.message)
+  e.code = err.code || -1
+  if (err.stack) e.stack = err.stack
+  if (err.details) e.details = err.details
+  if (err.url) e.url = err.url
+  return e
 }

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -22,9 +22,7 @@ var execute = `
 
     if(fn.length - 1 == args.length) {
       args.push(((err, v) => {
-          if(err) {
-            nightmare.reject(err.message || err.toString());
-          }
+          if(err) return nightmare.reject(err);
           nightmare.resolve(v);
         }));
       fn.apply(null, args);
@@ -36,14 +34,14 @@ var execute = `
           nightmare.resolve(v);
         })
         .catch((err) => {
-          nightmare.reject(err.message || err.toString())
+          nightmare.reject(err)
         });
       } else {
         nightmare.resolve(response);
       }
     }
   } catch (err) {
-    nightmare.reject(err.message);
+    nightmare.reject(err);
   }
 })()
 `
@@ -61,7 +59,7 @@ var inject = `
     var response = (function () { {{!src}} \n})()
     nightmare.resolve(response);
   } catch (e) {
-    nightmare.reject(e.message);
+    nightmare.reject(e);
   }
 })()
 `

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -12,7 +12,7 @@ var minstache = require('minstache')
 
 var execute = `
 (function javascript () {
-  var ipc = (window.__nightmare ? __nightmare.ipc : window[''].nightmare.ipc);
+  var nightmare = window.__nightmare || window[''].nightmare;
   try {
     var fn = ({{!src}}), 
       response, 
@@ -23,9 +23,9 @@ var execute = `
     if(fn.length - 1 == args.length) {
       args.push(((err, v) => {
           if(err) {
-            ipc.send('error', err.message || err.toString());
+            nightmare.reject(err.message || err.toString());
           }
-          ipc.send('response', v);
+          nightmare.resolve(v);
         }));
       fn.apply(null, args);
     } 
@@ -33,17 +33,17 @@ var execute = `
       response = fn.apply(null, args);
       if(response && response.then) {
         response.then((v) => {
-          ipc.send('response', v);
+          nightmare.resolve(v);
         })
         .catch((err) => {
-          ipc.send('error', err)
+          nightmare.reject(err.message || err.toString())
         });
       } else {
-        ipc.send('response', response);
+        nightmare.resolve(response);
       }
     }
   } catch (err) {
-    ipc.send('error', err.message);
+    nightmare.reject(err.message);
   }
 })()
 `
@@ -56,12 +56,12 @@ var execute = `
 
 var inject = `
 (function javascript () {
-  var ipc = (window.__nightmare ? __nightmare.ipc : window[''].nightmare.ipc);
+  var nightmare = window.__nightmare || window[''].nightmare;
   try {
     var response = (function () { {{!src}} \n})()
-    ipc.send('response', response);
+    nightmare.resolve(response);
   } catch (e) {
-    ipc.send('error', e.message);
+    nightmare.reject(e.message);
   }
 })()
 `

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -166,9 +166,9 @@ function Nightmare(options) {
       log.apply(log, arguments)
     })
 
-    this.child.on('uncaughtException', function(stack) {
-      const err = new Error('Nightmare runner error')
-      err.stack = stack
+    this.child.on('uncaughtException', function(err) {
+      const e = new Error('Nightmare runner error: ' + err.message)
+      e.stack = err.stack || ''
 
       const onClose = () => {
         throw err

--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -183,91 +183,55 @@ function Nightmare(options) {
 
     // propogate events through to debugging
     this.child.on('did-finish-load', function() {
-      log(
-        'did-finish-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-finish-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-fail-load', function() {
-      log(
-        'did-fail-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-fail-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-fail-provisional-load', function() {
-      log(
-        'did-fail-provisional-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-fail-provisional-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-frame-finish-load', function() {
-      log(
-        'did-frame-finish-load',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-frame-finish-load', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-start-loading', function() {
-      log(
-        'did-start-loading',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-start-loading', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-stop-loading', function() {
-      log(
-        'did-stop-loading',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-stop-loading', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-get-response-details', function() {
-      log(
-        'did-get-response-details',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-get-response-details', JSON.stringify(sliced(arguments)))
     })
     this.child.on('did-get-redirect-request', function() {
-      log(
-        'did-get-redirect-request',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('did-get-redirect-request', JSON.stringify(sliced(arguments)))
     })
     this.child.on('dom-ready', function() {
-      log('dom-ready', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('dom-ready', JSON.stringify(sliced(arguments)))
     })
     this.child.on('page-favicon-updated', function() {
-      log(
-        'page-favicon-updated',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('page-favicon-updated', JSON.stringify(sliced(arguments)))
     })
     this.child.on('new-window', function() {
-      log('new-window', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('new-window', JSON.stringify(sliced(arguments)))
     })
     this.child.on('will-navigate', function() {
-      log(
-        'will-navigate',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('will-navigate', JSON.stringify(sliced(arguments)))
     })
     this.child.on('crashed', function() {
-      log('crashed', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('crashed', JSON.stringify(sliced(arguments)))
     })
     this.child.on('plugin-crashed', function() {
-      log(
-        'plugin-crashed',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('plugin-crashed', JSON.stringify(sliced(arguments)))
     })
     this.child.on('destroyed', function() {
-      log('destroyed', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('destroyed', JSON.stringify(sliced(arguments)))
     })
     this.child.on('media-started-playing', function() {
-      log(
-        'media-started-playing',
-        JSON.stringify(Array.prototype.slice.call(arguments))
-      )
+      log('media-started-playing', JSON.stringify(sliced(arguments)))
     })
     this.child.on('media-paused', function() {
-      log('media-paused', JSON.stringify(Array.prototype.slice.call(arguments)))
+      log('media-paused', JSON.stringify(sliced(arguments)))
     })
 
     this.child.once('ready', versions => {

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -20,16 +20,16 @@ window.__nightmare = {
   resolve: function(value) {
     send('response', value)
   },
-  reject: function(message) {
-    send('error', message)
+  reject: function(err) {
+    send('error', error(err))
   }
 }
 
 // Listen for error events
 window.addEventListener(
   'error',
-  function(e) {
-    send('page', 'error', e.message, (e.error || {}).stack || '')
+  function(err) {
+    send('page', 'error', error(err))
   },
   true
 )
@@ -91,4 +91,18 @@ window.prompt = function(message, defaultResponse) {
 // overwrite the default confirm
 window.confirm = function(message, defaultResponse) {
   send('page', 'confirm', message, defaultResponse)
+}
+
+/**
+ * Make errors serializeable
+ */
+
+function error(err) {
+  if (!(err instanceof Error)) return err
+  return {
+    code: err.code,
+    message: err.message,
+    details: err.detail,
+    stack: err.stack || ''
+  }
 }

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,87 +1,94 @@
 /* eslint-disable no-console */
 
-window.window.__nightmare = {}
-window.__nightmare.ipc = require('electron').ipcRenderer
-window.__nightmare.sliced = require('sliced')
+var ipc = require('electron').ipcRenderer
+var sliced = require('sliced')
+
+function send(_event) {
+  ipc.send.apply(ipc, arguments)
+}
+
+// offer limited access to allow
+// .evaluate() and .inject()
+// to continue to work as expected.
+//
+// TODO: this could be avoided by
+// rewriting the evaluate to
+// use promises instead. But
+// for now this fixes the security
+// issue in: segmentio/nightmare/#1358
+window.__nightmare = {
+  resolve: function(value) {
+    send('response', value)
+  },
+  reject: function(message) {
+    send('error', message)
+  }
+}
 
 // Listen for error events
-window.addEventListener('error', function(e) {
-  window.__nightmare.ipc.send(
-    'page',
-    'error',
-    e.message,
-    (e.error || {}).stack || ''
-  )
+window.addEventListener(
+  'error',
+  function(e) {
+    send('page', 'error', e.message, (e.error || {}).stack || '')
+  },
+  true
+)
+
+// prevent 'unload' and 'beforeunload' from being bound
+var defaultAddEventListener = window.addEventListener
+window.addEventListener = function(type) {
+  if (type === 'unload' || type === 'beforeunload') {
+    return
+  }
+  defaultAddEventListener.apply(window, arguments)
+}
+
+// prevent 'onunload' and 'onbeforeunload' from being set
+Object.defineProperties(window, {
+  onunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  },
+  onbeforeunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  }
 })
-;(function() {
-  // prevent 'unload' and 'beforeunload' from being bound
-  var defaultAddEventListener = window.addEventListener
-  window.addEventListener = function(type) {
-    if (type === 'unload' || type === 'beforeunload') {
-      return
-    }
-    defaultAddEventListener.apply(window, arguments)
-  }
 
-  // prevent 'onunload' and 'onbeforeunload' from being set
-  Object.defineProperties(window, {
-    onunload: {
-      enumerable: true,
-      writable: false,
-      value: null
-    },
-    onbeforeunload: {
-      enumerable: true,
-      writable: false,
-      value: null
-    }
-  })
+// listen for console.log
+var defaultLog = console.log
+console.log = function() {
+  send('console', 'log', sliced(arguments))
+  return defaultLog.apply(this, arguments)
+}
 
-  // listen for console.log
-  var defaultLog = console.log
-  console.log = function() {
-    window.__nightmare.ipc.send(
-      'console',
-      'log',
-      window.__nightmare.sliced(arguments)
-    )
-    return defaultLog.apply(this, arguments)
-  }
+// listen for console.warn
+var defaultWarn = console.warn
+console.warn = function() {
+  send('console', 'warn', sliced(arguments))
+  return defaultWarn.apply(this, arguments)
+}
 
-  // listen for console.warn
-  var defaultWarn = console.warn
-  console.warn = function() {
-    window.__nightmare.ipc.send(
-      'console',
-      'warn',
-      window.__nightmare.sliced(arguments)
-    )
-    return defaultWarn.apply(this, arguments)
-  }
+// listen for console.error
+var defaultError = console.error
+console.error = function() {
+  send('console', 'error', sliced(arguments))
+  return defaultError.apply(this, arguments)
+}
 
-  // listen for console.error
-  var defaultError = console.error
-  console.error = function() {
-    window.__nightmare.ipc.send(
-      'console',
-      'error',
-      window.__nightmare.sliced(arguments)
-    )
-    return defaultError.apply(this, arguments)
-  }
+// overwrite the default alert
+window.alert = function(message) {
+  send('page', 'alert', message)
+}
 
-  // overwrite the default alert
-  window.alert = function(message) {
-    window.__nightmare.ipc.send('page', 'alert', message)
-  }
+// overwrite the default prompt
+window.prompt = function(message, defaultResponse) {
+  send('page', 'prompt', message, defaultResponse)
+}
 
-  // overwrite the default prompt
-  window.prompt = function(message, defaultResponse) {
-    window.__nightmare.ipc.send('page', 'prompt', message, defaultResponse)
-  }
-
-  // overwrite the default confirm
-  window.confirm = function(message, defaultResponse) {
-    window.__nightmare.ipc.send('page', 'confirm', message, defaultResponse)
-  }
-})()
+// overwrite the default confirm
+window.confirm = function(message, defaultResponse) {
+  send('page', 'confirm', message, defaultResponse)
+}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -22,8 +22,8 @@ const IS_READY = Symbol('isReady')
  * Handle uncaught exceptions in the main electron process
  */
 
-process.on('uncaughtException', function(e) {
-  parent.emit('uncaughtException', e.stack)
+process.on('uncaughtException', function(err) {
+  parent.emit('uncaughtException', err.stack || err.message || String(err))
 })
 
 /**
@@ -206,7 +206,7 @@ app.on('ready', function() {
 
   parent.respondTo('goto', function(url, headers, timeout, done) {
     if (!url || typeof url !== 'string') {
-      return done('goto: `url` must be a non-empty string')
+      return done(new Error('goto: `url` must be a non-empty string'))
     }
 
     var httpReferrer = ''
@@ -285,7 +285,7 @@ app.on('ready', function() {
         cleanup(null, responseData)
       }
 
-      function cleanup(error, data) {
+      function cleanup(err, data) {
         clearTimeout(timer)
         win.webContents.removeListener('did-fail-load', handleFailure)
         win.webContents.removeListener(
@@ -300,7 +300,7 @@ app.on('ready', function() {
         win.webContents.removeListener('did-finish-load', handleFinish)
         setIsReady(true)
         // wait a tick before notifying to resolve race conditions for events
-        setImmediate(() => done(error, data))
+        setImmediate(() => done(err, data))
       }
 
       // In most environments, loadURL handles this logic for us, but in some
@@ -373,23 +373,23 @@ app.on('ready', function() {
    */
 
   parent.respondTo('javascript', function(src, done) {
-    var response = (event, response) => {
-      renderer.removeListener('error', error)
-      renderer.removeListener('log', log)
+    var onresponse = (event, response) => {
+      renderer.removeListener('error', onerror)
+      renderer.removeListener('log', onlog)
       done(null, response)
     }
 
-    var error = (event, error) => {
-      renderer.removeListener('log', log)
-      renderer.removeListener('response', response)
-      done(error)
+    var onerror = (event, err) => {
+      renderer.removeListener('log', onlog)
+      renderer.removeListener('response', onresponse)
+      done(err)
     }
 
-    var log = (event, args) => parent.emit.apply(parent, ['log'].concat(args))
+    var onlog = (event, args) => parent.emit.apply(parent, ['log'].concat(args))
 
-    renderer.once('response', response)
-    renderer.once('error', error)
-    renderer.on('log', log)
+    renderer.once('response', onresponse)
+    renderer.once('error', onerror)
+    renderer.on('log', onlog)
 
     //parent.emit('log', 'about to execute javascript: ' + src);
     win.webContents.executeJavaScript(src)
@@ -490,8 +490,8 @@ app.on('ready', function() {
   parent.respondTo('html', function(path, saveType, done) {
     // https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback
     saveType = saveType || 'HTMLComplete'
-    win.webContents.savePage(path, saveType, function(error) {
-      done(error)
+    win.webContents.savePage(path, saveType, function(err) {
+      done(err)
     })
   })
 
@@ -508,8 +508,8 @@ app.on('ready', function() {
       landscape: false
     })
 
-    win.webContents.printToPDF(options, function(error, data) {
-      if (error) return done(arguments)
+    win.webContents.printToPDF(options, function(err, data) {
+      if (err) return done(err)
       done(null, data)
     })
   })
@@ -527,8 +527,8 @@ app.on('ready', function() {
     )
 
     parent.emit('log', 'getting cookie: ' + JSON.stringify(details))
-    win.webContents.session.cookies.get(details, function(error, cookies) {
-      if (error) return done(error)
+    win.webContents.session.cookies.get(details, function(err, cookies) {
+      if (err) return done(err)
       done(null, details.name ? cookies[0] : cookies)
     })
   })
@@ -549,8 +549,8 @@ app.on('ready', function() {
       )
 
       parent.emit('log', 'setting cookie: ' + JSON.stringify(details))
-      win.webContents.session.cookies.set(details, function(error) {
-        if (error) done(error)
+      win.webContents.session.cookies.set(details, function(err) {
+        if (err) done(err)
         else if (!--pending) done()
       })
     }
@@ -582,8 +582,8 @@ app.on('ready', function() {
       //for each cookie name in cookies,
       for (var i = 0, cookie; (cookie = cookies[i]); i++) {
         //remove the cookie from the url
-        win.webContents.session.cookies.remove(url, cookie, function(error) {
-          if (error) done(error)
+        win.webContents.session.cookies.remove(url, cookie, function(err) {
+          if (err) done(err)
           else if (!--pending) done()
         })
       }
@@ -599,7 +599,10 @@ app.on('ready', function() {
       {
         storages: ['cookies']
       },
-      done
+      function(err) {
+        if (err) return done(err)
+        return done()
+      }
     )
   })
 
@@ -618,8 +621,9 @@ app.on('ready', function() {
       require: require,
       parent: parent
     })
-    fn(name, options, parent, win, renderer, function(error) {
-      done(error)
+    fn(name, options, parent, win, renderer, function(err) {
+      if (err) return done(err)
+      return done()
     })
   })
 

--- a/test/fixtures/preload/index.js
+++ b/test/fixtures/preload/index.js
@@ -1,3 +1,96 @@
-window.__nightmare = {};
-__nightmare.ipc = require('electron').ipcRenderer;
+/* eslint-disable no-console */
+
+var ipc = require('electron').ipcRenderer
+var sliced = require('sliced')
+
+function send(_event) {
+  ipc.send.apply(ipc, arguments)
+}
+
+// offer limited access to allow
+// .evaluate() and .inject()
+// to continue to work as expected.
+//
+// TODO: this could be avoided by
+// rewriting the evaluate to
+// use promises instead. But
+// for now this fixes the security
+// issue in: segmentio/nightmare/#1358
+window.__nightmare = {
+  resolve: function(value) {
+    send('response', value)
+  },
+  reject: function(message) {
+    send('error', message)
+  }
+}
+
+// Listen for error events
+window.addEventListener(
+  'error',
+  function(e) {
+    send('page', 'error', e.message, (e.error || {}).stack || '')
+  },
+  true
+)
+
+// prevent 'unload' and 'beforeunload' from being bound
+var defaultAddEventListener = window.addEventListener
+window.addEventListener = function(type) {
+  if (type === 'unload' || type === 'beforeunload') {
+    return
+  }
+  defaultAddEventListener.apply(window, arguments)
+}
+
+// prevent 'onunload' and 'onbeforeunload' from being set
+Object.defineProperties(window, {
+  onunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  },
+  onbeforeunload: {
+    enumerable: true,
+    writable: false,
+    value: null
+  }
+})
+
+// listen for console.log
+var defaultLog = console.log
+console.log = function() {
+  send('console', 'log', sliced(arguments))
+  return defaultLog.apply(this, arguments)
+}
+
+// listen for console.warn
+var defaultWarn = console.warn
+console.warn = function() {
+  send('console', 'warn', sliced(arguments))
+  return defaultWarn.apply(this, arguments)
+}
+
+// listen for console.error
+var defaultError = console.error
+console.error = function() {
+  send('console', 'error', sliced(arguments))
+  return defaultError.apply(this, arguments)
+}
+
+// overwrite the default alert
+window.alert = function(message) {
+  send('page', 'alert', message)
+}
+
+// overwrite the default prompt
+window.prompt = function(message, defaultResponse) {
+  send('page', 'prompt', message, defaultResponse)
+}
+
+// overwrite the default confirm
+window.confirm = function(message, defaultResponse) {
+  send('page', 'confirm', message, defaultResponse)
+}
+
 window.preload = 'custom'

--- a/test/fixtures/security/index.html
+++ b/test/fixtures/security/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Simple</title>
+</head>
+
+<body>
+  <h1>Hello World!</h1>
+</body>
+
+<script type="text/javascript">
+  console.log(typeof ipc, typeof window.ipc, typeof send, typeof window.send)
+</script>
+
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,9 @@ describe('Nightmare', function() {
       .evaluate(function() {
         throw new Error('Test')
       })
-      .catch(function(_err) {
+      .catch(function(err) {
+        assert.equal(err instanceof Error, true)
+        assert.equal(err.message, 'Test')
         done()
       })
   })
@@ -216,8 +218,9 @@ describe('Nightmare', function() {
     nightmare
       .goto('about:blank')
       .click('a.not-here')
-      .catch(function(error) {
-        error.should.include('a.not-here')
+      .catch(function(err) {
+        assert.equal(err instanceof Error, true)
+        err.message.should.include('a.not-here')
         done()
       })
   })
@@ -228,8 +231,9 @@ describe('Nightmare', function() {
     nightmare
       .goto('about:blank')
       .mousedown('a.not-here')
-      .catch(function(error) {
-        error.should.include('a.not-here')
+      .catch(function(err) {
+        assert.equal(err instanceof Error, true)
+        err.message.should.include('a.not-here')
         done()
       })
   })
@@ -240,8 +244,9 @@ describe('Nightmare', function() {
     nightmare
       .goto('about:blank')
       .mouseup('a.not-here')
-      .catch(function(error) {
-        error.should.include('a.not-here')
+      .catch(function(err) {
+        assert.equal(err instanceof Error, true)
+        err.message.should.include('a.not-here')
         done()
       })
   })
@@ -252,8 +257,9 @@ describe('Nightmare', function() {
     nightmare
       .goto('about:blank')
       .mouseover('a.not-here')
-      .catch(function(error) {
-        error.should.include('a.not-here')
+      .catch(function(err) {
+        assert.equal(err instanceof Error, true)
+        err.message.should.include('a.not-here')
         done()
       })
   })
@@ -284,8 +290,9 @@ describe('Nightmare', function() {
         function() {
           throw new Error('goto(undefined) didn’t cause an error')
         },
-        function(error) {
-          error.should.include('url')
+        function(err) {
+          assert.equal(err instanceof Error, true)
+          err.message.should.include('url')
         }
       )
     })
@@ -295,8 +302,9 @@ describe('Nightmare', function() {
         function() {
           throw new Error('goto(undefined) didn’t cause an error')
         },
-        function(error) {
-          error.should.include('url')
+        function(err) {
+          assert.equal(err instanceof Error, true)
+          err.message.should.include('url')
         }
       )
     })
@@ -435,9 +443,12 @@ describe('Nightmare', function() {
         function() {
           throw new Error('Navigation to an invalid domain succeeded')
         },
-        function(error) {
-          error.should.contain.keys('message', 'code', 'url')
-          error.code.should.be.a('number')
+        function(err) {
+          assert.equal(err instanceof Error, true)
+          assert.equal(err.message, 'navigation error')
+          assert.equal(err.details, 'ERR_NAME_NOT_RESOLVED')
+          assert.equal(err.code, -105)
+          assert.equal(err.url, 'http://this-is-not-a-real-domain.tld/')
         }
       )
     })
@@ -1370,6 +1381,19 @@ describe('Nightmare', function() {
 
       cookies = yield nightmare.cookies.get()
       cookies.length.should.equal(0)
+    })
+
+    it('should return a proper error', function*() {
+      try {
+        yield nightmare.goto(fixture('cookie')).cookies.set({
+          name: 'hi',
+          value: 'there',
+          domain: 'https://www.google.com'
+        })
+        assert.fail("shouldn't have got here")
+      } catch (e) {
+        assert.equal(e.message, 'Setting cookie failed')
+      }
     })
   })
 


### PR DESCRIPTION
This is a **BREAKING** change and builds upon this PR #1390.

This PR fixes #646 and cleans up some of the adhoc error handling we've been doing.

I've chosen to add error serialization & unserialization at the IPC-level. This makes the IPC more opinionated (errors must always come first), but it allows us to transport errors across processes gracefully. Since nightmare already considered errors as the first argument everywhere, I didn't have to change much.

In addition to #1390, this is a breaking change because now promises that are rejected will always return `Error` types, whereas before sometimes we were returning objects, sometimes strings, sometimes `{}`. This is a minor breaking change, but warrants the `3.0.0` bump.

