### PR TITLE
fix: node 4 by going back to npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ lint: node_modules
 	@./node_modules/.bin/eslint --fix lib/*.js test/*.js 
 
 node_modules: package.json
-	@./node_modules/.bin/yarn
+	@npm install
 
 .PHONY: test lint

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "pngjs": "^2.2.0",
     "prettier": "1.11.0",
     "serve-static": "^1.10.0",
-    "split": "^1.0.0",
-    "yarn": "1.5.1"
+    "split": "^1.0.0"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
This PR takes us back to using NPM for our builds. This should fix node 4, which broke after #1386.