### PR TITLE
Raise error when type()/insert() on a non-existent selector

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -246,7 +246,11 @@ exports.mouseout = function(selector, done) {
 var focusSelector = function(done, selector) {
   return this.evaluate_now(
     function(selector) {
-      document.querySelector(selector).focus()
+      var element = document.querySelector(selector)
+      if (!element) {
+        throw new Error('Unable to find element by selector: ' + selector)
+      }
+      element.focus()
     },
     done.bind(this),
     selector


### PR DESCRIPTION
When call type()/insert() on a non-existent selector, the error is a `TypeError: Cannot read property 'focus' of null`
Throw a new Error with the selector so that we can see it in test framework.