### PR TITLE
toPng fix

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -474,7 +474,16 @@ app.on('ready', function() {
     // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
     var args = [
       function handleCapture(img) {
-        done(null, img.toPng())
+        if(img.toPng) {
+            done(null, img.toPng());
+
+        } else if(img.toPNG) {
+            // @see https://github.com/electron/electron/blob/master/docs/api/native-image.md#imagetopngoptions
+            done(null, img.toPNG());
+
+        } else {
+            done(new Error('no png method found in electrons image.'));
+        }
       }
     ]
     if (clip) args.unshift(clip)


### PR DESCRIPTION
In electron ^2.0.0 method image .toPng is called .toPNG
see: https://github.com/electron/electron/blob/master/docs/api/native-image.md#imagetopngoptions