### PR TITLE
Bumps the version of electron to 2.0.2

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -127,6 +127,14 @@ app.on('ready', function() {
     win.webContents.setAudioMuted(true)
 
     /**
+     * Sets user agent.
+     */
+
+    if (options.userAgent) {
+      win.webContents.setUserAgent(options.userAgent)
+    }
+
+    /**
      * Pass along web content events
      */
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -474,7 +474,7 @@ app.on('ready', function() {
     // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
     var args = [
       function handleCapture(img) {
-        done(null, img.toPng())
+        done(null, img.toPNG())
       }
     ]
     if (clip) args.unshift(clip)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron": "^1.8.4",
+    "electron": "^2.0.2",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",


### PR DESCRIPTION
With the version bump of electron it introduces some breaking API changes, those were fixed up. Also adjusted the tests a bit to handle the CSP as well as some oddities with the image comparison for the idle case (about:blank w/ a background color change).

This also addresses issues with 1.8+ not working on RaspberryPi. Seems that whatever was done in the builds on electron prior to 2.0.2 seems resolved now for armv7l.