### PR TITLE
Bump deep-default library to get rid of old lodash prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "description": "A high-level browser automation library.",
   "dependencies": {
     "debug": "^2.2.0",
-    "deep-defaults": "^1.0.3",
+    "deep-defaults": "^1.0.5",
     "defaults": "^1.0.2",
     "electron": "^1.8.4",
     "enqueue": "^1.0.2",


### PR DESCRIPTION
See:
1. https://www.npmjs.com/advisories?search=lodash&version=3.0.1
2. https://github.com/d5/deep-defaults/pull/3