### PR TITLE
Add make package necessary for tests to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "express": "4.16.2",
     "husky": "^0.14.3",
+    "make": "^0.8.1",
     "mocha": "^2.3.0",
     "mocha-generators": "^1.2.0",
     "multer": "1.1.0",


### PR DESCRIPTION
Contributors wanting to commit something will be met by this message:

```
'make' is not recognized as an internal or external command,
operable program or batch file.
```

if they did not install `make` on their own, which is not mentioned in the README.