### PR TITLE
Fix #1387 - refactor win.webContents.executeJavaScript(src) to use promises

### DIFF
--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -12,37 +12,27 @@ var minstache = require('minstache')
 
 var execute = `
 (function javascript () {
-  var nightmare = window.__nightmare || window[''].nightmare;
-  try {
-    var fn = ({{!src}}), 
-      response, 
-      args = [];
+  return new Promise((resolve, reject) => {
+    try {
+      var fn = ({{!src}}),
+        response,
+        args = [];
 
-    {{#args}}args.push({{!argument}});{{/args}}
+      {{#args}}args.push({{!argument}});{{/args}}
 
-    if(fn.length - 1 == args.length) {
-      args.push(((err, v) => {
-          if(err) return nightmare.reject(err);
-          nightmare.resolve(v);
-        }));
-      fn.apply(null, args);
-    } 
-    else {
-      response = fn.apply(null, args);
-      if(response && response.then) {
-        response.then((v) => {
-          nightmare.resolve(v);
-        })
-        .catch((err) => {
-          nightmare.reject(err)
-        });
+      if(fn.length - 1 == args.length) {
+        args.push(((err, v) => {
+            if(err) reject(err);
+            resolve(v);
+          }));
+        fn.apply(null, args);
       } else {
-        nightmare.resolve(response);
+        resolve(fn.apply(null, args));
       }
+    } catch(err) {
+      reject(err);
     }
-  } catch (err) {
-    nightmare.reject(err);
-  }
+  });
 })()
 `
 
@@ -51,16 +41,15 @@ var execute = `
  * the response and logs, and send back via
  * ipc to electron's main process
  */
-
 var inject = `
 (function javascript () {
-  var nightmare = window.__nightmare || window[''].nightmare;
-  try {
-    var response = (function () { {{!src}} \n})()
-    nightmare.resolve(response);
-  } catch (e) {
-    nightmare.reject(e);
-  }
+  return new Promise((resolve, reject) => {
+    try {
+      resolve( (function () { {{!src}} \n})() );
+    } catch(err) {
+      reject(err);
+    }
+  });
 })()
 `
 

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -5,18 +5,16 @@
 var minstache = require('minstache')
 
 /**
- * Run the `src` function on the client-side, capture
- * the response and logs, and send back via
- * ipc to electron's main process
+ * Run the `src` function on the client-side, resolve
+ * with result, or reject with error
  */
 
 var execute = `
 (function javascript () {
   return new Promise((resolve, reject) => {
     try {
-      var fn = ({{!src}}),
-        response,
-        args = [];
+      var fn = ({{!src}});
+      var args = [];
 
       {{#args}}args.push({{!argument}});{{/args}}
 
@@ -37,15 +35,14 @@ var execute = `
 `
 
 /**
- * Inject the `src` on the client-side, capture
- * the response and logs, and send back via
- * ipc to electron's main process
+ * Inject the `src` on the client-side, resolve
+ * with result, or reject with error
  */
 var inject = `
 (function javascript () {
   return new Promise((resolve, reject) => {
     try {
-      resolve( (function () { {{!src}} \n})() );
+      resolve((function () { {{!src}} \n})());
     } catch(err) {
       reject(err);
     }

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -7,24 +7,6 @@ function send(_event) {
   ipc.send.apply(ipc, arguments)
 }
 
-// offer limited access to allow
-// .evaluate() and .inject()
-// to continue to work as expected.
-//
-// TODO: this could be avoided by
-// rewriting the evaluate to
-// use promises instead. But
-// for now this fixes the security
-// issue in: segmentio/nightmare/#1358
-window.__nightmare = {
-  resolve: function(value) {
-    send('response', value)
-  },
-  reject: function(err) {
-    send('error', error(err))
-  }
-}
-
 // Listen for error events
 window.addEventListener(
   'error',

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -373,8 +373,7 @@ app.on('ready', function() {
    */
 
   parent.respondTo('javascript', function(src, done) {
-    win.webContents
-      .executeJavaScript(src)
+    win.webContents.executeJavaScript(src)
       .then(response => {
         done(null, response)
       })

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -373,26 +373,14 @@ app.on('ready', function() {
    */
 
   parent.respondTo('javascript', function(src, done) {
-    var onresponse = (event, response) => {
-      renderer.removeListener('error', onerror)
-      renderer.removeListener('log', onlog)
-      done(null, response)
-    }
-
-    var onerror = (event, err) => {
-      renderer.removeListener('log', onlog)
-      renderer.removeListener('response', onresponse)
-      done(err)
-    }
-
-    var onlog = (event, args) => parent.emit.apply(parent, ['log'].concat(args))
-
-    renderer.once('response', onresponse)
-    renderer.once('error', onerror)
-    renderer.on('log', onlog)
-
-    //parent.emit('log', 'about to execute javascript: ' + src);
-    win.webContents.executeJavaScript(src)
+    win.webContents
+      .executeJavaScript(src)
+      .then(response => {
+        done(null, response)
+      })
+      .catch(err => {
+        done(err)
+      })
   })
 
   /**


### PR DESCRIPTION
Fixes #1387 

I followed the suggestions in the issue, and refactored `win.webContents.executeJavaScript(src)` to use promises instead of ipc to return the result of the executed Javascript. The issue mentions removing javascript.js, however it looks like it is still necessary to do the string templating there, so it may need to be refactored further.