### PR TITLE
 Electron 2.0.18 - Chromium FileReader Vulnerability Fix (CVE-2019-5786)

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -127,6 +127,14 @@ app.on('ready', function() {
     win.webContents.setAudioMuted(true)
 
     /**
+     * Sets user agent.
+     */
+
+    if (options.userAgent) {
+      win.webContents.setUserAgent(options.userAgent)
+    }
+
+    /**
      * Pass along web content events
      */
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -474,7 +474,7 @@ app.on('ready', function() {
     // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
     var args = [
       function handleCapture(img) {
-        done(null, img.toPng())
+        done(null, img.toPNG())
       }
     ]
     if (clip) args.unshift(clip)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron": "^1.8.4",
+    "electron": "^2.0.2",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.2.0",
     "deep-defaults": "^1.0.3",
     "defaults": "^1.0.2",
-    "electron": "^2.0.2",
+    "electron": "^2.0.18",
     "enqueue": "^1.0.2",
     "function-source": "^0.1.0",
     "jsesc": "^0.5.0",


### PR DESCRIPTION
Chromium before 2.0.18 is affected by this "Use-after-free in FileReader"
vulnerability, Google is aware of reports that an exploit for CVE-2019-5786
exists in the wild: https://electronjs.org/blog/filereader-fix

This vulnerability has high impact (CVSS3 Base Score 8.8).

Solution: Bump Nightmare's Electron dependency to version 2.0.18.
This pull request includes #1466
"Bumps the version of electron to 2.0.2" from ZackNeyland.