### PR TITLE
Use either toPng or toPNG when screenshot

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -474,7 +474,12 @@ app.on('ready', function() {
     // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
     var args = [
       function handleCapture(img) {
-        done(null, img.toPng())
+        const toPng = img.toPng || img.toPNG;
+        if (toPng) {
+          done(null, toPng());
+        } else {
+          done(new ReferenceError('No toPng or toPNG method found on electron img'));
+        }
       }
     ]
     if (clip) args.unshift(clip)


### PR DESCRIPTION
If the `img` objects being resolved in electron don't have a `toPng` method, they may have a `toPNG` method depending on the version of electron being used.

This change will use the correct one or resolve with a `ReferenceError`