### PR TITLE
Fixes error this issue: Cannot assign to read only property 'onbefore…

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -52,7 +52,7 @@ Object.defineProperties(window, {
   },
   onbeforeunload: {
     enumerable: true,
-    writable: false,
+    writable: true,
     value: null
   }
 })


### PR DESCRIPTION
Fixes 
Cannot assign to read only property 'onbeforeunload' of object '#<Window>'

#1082

There was another pull request that I don't believe was pulled in.  This issue is still present in 3.0.1.  Thanks!