### PR TITLE
Make Nightmare.action() return match doc header

### DIFF
--- a/lib/nightmare.js
+++ b/lib/nightmare.js
@@ -633,6 +633,8 @@ Nightmare.action = function() {
       }
     }
   }
+  
+  return Nightmare;
 }
 
 /**


### PR DESCRIPTION
Working on updating the DefinitelyTyped definitions for this and ran into trouble with the return not matching the documented signature