### PR TITLE
Electron 8

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -347,7 +347,7 @@ app.on('ready', function() {
         if (!protocol || KNOWN_PROTOCOLS.includes(protocol)) {
           return callback(true)
         }
-        electron.protocol.isProtocolHandled(protocol, callback)
+        callback(electron.protocol.isProtocolRegistered(protocol))
       }
 
       function startLoading() {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -508,15 +508,10 @@ app.on('ready', function() {
    */
 
   parent.respondTo('screenshot', function(path, clip, done) {
-    // https://gist.github.com/twolfson/0d374d9d7f26eefe7d38
-    var args = [
-      function handleCapture(img) {
-        done(null, img.toPNG())
-      }
-    ]
-    if (clip) args.unshift(clip)
     frameManager.requestFrame(function() {
-      win.capturePage.apply(win, args)
+      win.capturePage(clip)
+        .then(img => done(null, img.toPNG()))
+        .catch(done)
     })
   })
 
@@ -527,9 +522,9 @@ app.on('ready', function() {
   parent.respondTo('html', function(path, saveType, done) {
     // https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentssavepagefullpath-savetype-callback
     saveType = saveType || 'HTMLComplete'
-    win.webContents.savePage(path, saveType, function(err) {
-      done(err)
-    })
+    win.webContents.savePage(path, saveType)
+      .then(done)
+      .catch(done)
   })
 
   /**
@@ -545,10 +540,9 @@ app.on('ready', function() {
       landscape: false
     })
 
-    win.webContents.printToPDF(options, function(err, data) {
-      if (err) return done(err)
-      done(null, data)
-    })
+    win.webContents.printToPDF(options)
+      .then(data => done(null, data))
+      .catch(done)
   })
 
   /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,11 +12,14 @@ var renderer = require('electron').ipcMain
 var app = require('electron').app
 var urlFormat = require('url')
 var FrameManager = require('./frame-manager')
-
+var EventEmitter = require('events');
 // URL protocols that don't need to be checked for validity
 const KNOWN_PROTOCOLS = ['http', 'https', 'file', 'about', 'javascript']
 // Property for tracking whether a window is ready for interaction
 const IS_READY = Symbol('isReady')
+// Used to register multiple listeners on WebRequest targets that only
+// support one listener
+const WebRequestEventTarget = new EventEmitter();
 
 /**
  * Handle uncaught exceptions in the main electron process
@@ -135,6 +138,40 @@ app.on('ready', function() {
     }
 
     /**
+     * Set up the WebRequest listeners. 
+     * Electron only serves one at a time, so we need to create 
+     * "master" listeners if we'd like to subscribe multiple listeners.
+     */
+
+    win.webContents.session.webRequest.onBeforeRedirect(function(details) {
+      WebRequestEventTarget.emit("BeforeRedirect", details)
+    })
+    win.webContents.session.webRequest.onBeforeRequest(function(details, cb) {
+      WebRequestEventTarget.emit("BeforeRequest", details)
+      cb({})
+    })
+    win.webContents.session.webRequest.onBeforeSendHeaders(function(details, cb) {
+      WebRequestEventTarget.emit("BeforeSendHeaders", details)
+      cb({})
+    })
+    win.webContents.session.webRequest.onCompleted(function(details) {
+      WebRequestEventTarget.emit("Completed", details)
+    })
+    win.webContents.session.webRequest.onErrorOccurred(function(details) {
+      WebRequestEventTarget.emit("ErrorOccurred", details)
+    })
+    win.webContents.session.webRequest.onHeadersReceived(function(details, cb) {
+      WebRequestEventTarget.emit("HeadersReceived", details)
+      cb({})
+    })
+    win.webContents.session.webRequest.onResponseStarted(function(details) {
+      WebRequestEventTarget.emit("ResponseStarted", details)
+    })
+    win.webContents.session.webRequest.onSendHeaders(function(details) {
+      WebRequestEventTarget.emit("SendHeaders", details)
+    })
+
+    /**
      * Pass along web content events
      */
 
@@ -158,14 +195,8 @@ app.on('ready', function() {
     )
     win.webContents.on('did-start-loading', forward('did-start-loading'))
     win.webContents.on('did-stop-loading', forward('did-stop-loading'))
-    win.webContents.on(
-      'did-get-response-details',
-      forward('did-get-response-details')
-    )
-    win.webContents.on(
-      'did-get-redirect-request',
-      forward('did-get-redirect-request')
-    )
+    WebRequestEventTarget.on('ResponseStarted', forward('did-get-response-details'))
+    WebRequestEventTarget.on('BeforeRedirect', forward('did-get-redirect-request'))
     win.webContents.on('dom-ready', forward('dom-ready'))
     win.webContents.on('page-favicon-updated', forward('page-favicon-updated'))
     win.webContents.on('new-window', forward('new-window'))
@@ -262,24 +293,22 @@ app.on('ready', function() {
         }
       }
 
-      function handleDetails(
-        event,
-        status,
-        newUrl,
-        oldUrl,
+      function handleDetails({
+        url,
         statusCode,
         method,
         referrer,
-        headers,
+        responseHeaders,
         resourceType
-      ) {
+      }) {
+        parent.emit('log', new Error().stack.match(/runner.js:[0-9]+:[0-9]+/)[0])
         if (resourceType === 'mainFrame') {
           responseData = {
-            url: newUrl,
+            url,
             code: statusCode,
-            method: method,
-            referrer: referrer,
-            headers: headers
+            method,
+            referrer,
+            headers: responseHeaders
           }
         }
       }
@@ -300,8 +329,8 @@ app.on('ready', function() {
           'did-fail-provisional-load',
           handleFailure
         )
-        win.webContents.removeListener(
-          'did-get-response-details',
+        WebRequestEventTarget.removeListener(
+          'ResponseStarted',
           handleDetails
         )
         win.webContents.removeListener('dom-ready', handleDomReady)
@@ -333,7 +362,7 @@ app.on('ready', function() {
 
         win.webContents.on('did-fail-load', handleFailure)
         win.webContents.on('did-fail-provisional-load', handleFailure)
-        win.webContents.on('did-get-response-details', handleDetails)
+        WebRequestEventTarget.addListener('ResponseStarted', handleDetails)
         win.webContents.on('dom-ready', handleDomReady)
         win.webContents.on('did-finish-load', handleFinish)
         win.webContents.loadURL(url, loadUrlOptions)

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -564,10 +564,11 @@ app.on('ready', function() {
     )
 
     parent.emit('log', 'getting cookie: ' + JSON.stringify(details))
-    win.webContents.session.cookies.get(details, function(err, cookies) {
-      if (err) return done(err)
-      done(null, details.name ? cookies[0] : cookies)
-    })
+    win.webContents.session.cookies.get(details)
+      .then(function(cookies) {
+        done(null, details.name ? cookies[0] : cookies)
+      })
+      .catch(done)
   })
 
   /**
@@ -586,10 +587,11 @@ app.on('ready', function() {
       )
 
       parent.emit('log', 'setting cookie: ' + JSON.stringify(details))
-      win.webContents.session.cookies.set(details, function(err) {
-        if (err) done(err)
-        else if (!--pending) done()
-      })
+      win.webContents.session.cookies.set(details)
+        .then(function() { 
+          done()
+        })
+        .catch(done)
     }
   })
 
@@ -603,9 +605,9 @@ app.on('ready', function() {
 
     if (cookies.length == 0) {
       getCookies = cb =>
-        win.webContents.session.cookies.get({ url: url }, (error, cookies) => {
-          cb(error, cookies.map(cookie => cookie.name))
-        })
+        win.webContents.session.cookies.get({ url: url })
+          .then( cookies => cb(null, cookies.map(cookie => cookie.name)))
+          .catch(cb)
     }
 
     getCookies((error, cookies) => {
@@ -619,10 +621,9 @@ app.on('ready', function() {
       //for each cookie name in cookies,
       for (var i = 0, cookie; (cookie = cookies[i]); i++) {
         //remove the cookie from the url
-        win.webContents.session.cookies.remove(url, cookie, function(err) {
-          if (err) done(err)
-          else if (!--pending) done()
-        })
+        win.webContents.session.cookies.remove(url, cookie)
+          .then(done)
+          .catch(done)
       }
     })
   })
@@ -635,12 +636,9 @@ app.on('ready', function() {
     win.webContents.session.clearStorageData(
       {
         storages: ['cookies']
-      },
-      function(err) {
-        if (err) return done(err)
-        return done()
-      }
-    )
+      })
+      .then(done)
+      .catch(done)
   })
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -1392,7 +1392,7 @@ describe('Nightmare', function() {
         })
         assert.fail("shouldn't have got here")
       } catch (e) {
-        assert.equal(e.message, 'Setting cookie failed')
+        assert.equal(e.message, 'Failed to parse cookie')
       }
     })
   })


### PR DESCRIPTION
This is a work in progress. Opening PR for more visibility. 

# Current state 
Currently 10 tests are still failing. They are:

From `navigation`:

1) should succeed properly if request handler is present
2) should support javascript URLs that load pages
3) should fail immediately/not time out for 304 statuses

From `navigation/timeouts`:

4) should allow actions on a hanging page
5) should allow loading a new page after timing out

From `referer`:

6) should return referer from headers

From `options`:

7) should set a single header
8) should set all headers
9) should set headers for that request
10) should allow webPreferences settings


# Looking for help 

To help updating to Electron 8, submit PRs against the [branch here](https://github.com/codebling/nightmare/tree/electron-8). If there are issues, open them against that repo, as well.

# plan 

First step is to fix these tests. This is kind of a first "naive" pass at migrating. Since test coverage is quite good for this project, this might actually be all that is needed, but I'd still want to go over the [list of breaking changes](https://github.com/electron/electron/blob/b1f4ac00f09c75b39c775f20a8d07e308444c166/docs/breaking-changes.md) one by one to make sure each change has been accounted for. 
