### PR TITLE
Fix spelling mistakes in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -489,7 +489,7 @@ Nightmare disables `window.confirm` from popping up by default, but you can stil
 
 ###### .on('console', function(type [, arguments, ...]))
 
-`type` will be either `log`, `warn` or `error` and `arguments` are what gets passed from the console. This event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
+`type` will be either `log`, `warn` or `error` and `arguments` are what get passed from the console. This event is not triggered if the injected javascript code (e.g. via `.evaluate()`) is using `console.log`.
 
 #### .once(event, callback)
 
@@ -811,7 +811,7 @@ By default nightmare will create an in-memory partition for each instance. This 
 ```js
 import Nightmare from 'nightmare';
 
-nightmare = Nightmare(); // non persistent paritition by default
+nightmare = Nightmare(); // non persistent partition by default
 yield nightmare
   .evaluate(() => {
     window.localStorage.setItem('testing', 'This will not be persisted');
@@ -830,7 +830,7 @@ yield nightmare
   .end();
 ```
 
-If you specify a `null` paritition then it will use the electron default behavior (persistent) or any string that starts with `'persist:'` will persist under that partition name, any other string will result in in-memory only storage.
+If you specify a `null` partition then it will use the electron default behavior (persistent) or any string that starts with `'persist:'` will persist under that partition name, any other string will result in in-memory only storage.
 
 ## Usage
 


### PR DESCRIPTION
- "Complementary" -> "complimentary"
- "argument gets" -> "argument get"
- "paritition" -> "partition"